### PR TITLE
chore: Add dependabot grouping (minor-and-patch + major)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,16 @@ updates:
     labels:
       - "dependencies"
       - "automated pr"
-    
+
   # Enable version updates for GitHub Actions
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+      major:
+        update-types:
+          - major
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -23,3 +31,11 @@ updates:
     labels:
       - "dependencies"
       - "automated pr"
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+      major:
+        update-types:
+          - major


### PR DESCRIPTION
Adds `groups:` config to each `package-ecosystem` entry, splitting updates into:
- **minor-and-patch** — auto-bundleable, low-risk
- **major** — separate PR, gets review attention

This dramatically reduces dependabot PR volume per repo.

Generated rollout — config-only change, no runtime impact.