### PR TITLE
Add divine grounding Reality engine and canon oracle tests

### DIFF
--- a/AnointedAutomation.Objects.Demo/Program.cs
+++ b/AnointedAutomation.Objects.Demo/Program.cs
@@ -21,29 +21,32 @@ namespace AnointedAutomation.Objects.Demo
 
             // A neighbor in need whom you have the means to help (the Good Samaritan principle).
             RunAllLoves(new Situation("A stranger lies beaten by the road; I have the means to help.")
-                .Set("inNeed")
-                .Set("iCanHelp"));
+                .With(new Need())
+                .With(new Means()));
 
             // A situation never named in Scripture: an online teammate betrays the group.
             RunAllLoves(new Situation("A teammate betrayed the group and ninja-looted the boss drop.")
-                .Set("wronged"));
+                .With(new Grievance()));
 
             // A work of mercy (Matthew 25:35): someone hungry before you.
             RunAllLoves(new Situation("A hungry person is at your door.")
-                .Set("hungry"));
+                .With(new Hunger()));
 
             // A composed condition (Romans 12:20): enemy AND (hungry OR thirsty).
             RunAllLoves(new Situation("An enemy who hates you is now hungry at your door.")
-                .Set("enemy")
-                .Set("hungry"));
+                .With(new Enmity())
+                .With(new Hunger()));
 
-            // A friend's life on the line — where sacrificial love goes further than the rest.
+            // A friend's life on the line, where sacrificial love goes further than the rest.
             RunAllLoves(new Situation("A friend's life is at stake; saving them would cost my own.")
-                .Set("friendsLifeAtStake"));
+                .With(new MortalPeril()));
 
             // A situation the engine has no specific branch for at all.
             RunAllLoves(new Situation("Something the Bible never described.")
-                .Set("quantumComputerMalfunctioned"));
+                .With(new Circumstance("quantumComputerMalfunctioned")));
+
+            Console.WriteLine();
+            RealityDemo.Run();
         }
 
         private static void RunAllLoves(Situation situation)

--- a/AnointedAutomation.Objects.Demo/RealityDemo.cs
+++ b/AnointedAutomation.Objects.Demo/RealityDemo.cs
@@ -1,0 +1,77 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using System;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Demo
+{
+    /// <summary>
+    /// Demonstrates the divine grounding / reality engine: reality is grounded in God's whole
+    /// character at once (Love, Justice, Mercy, Order), every deed is composed of first-class moral
+    /// concepts (not strings), is witnessed and written onto the heavenly tablets, and the standing
+    /// order of the world rises or drifts with what is done in it. Scripture is the oracle: the acts
+    /// of God read fully coherent and destabilize nothing, sin reads incoherent and disorders
+    /// reality, and deeds never named in Scripture are still judged by principle.
+    /// </summary>
+    public static class RealityDemo
+    {
+        public static void Run()
+        {
+            Console.WriteLine("=== Reality grounded in God: present a deed, reality resolves it ===");
+            Console.WriteLine();
+
+            Reality reality = Reality.Revealed();
+
+            // The acts of God: the standard. Never incoherent, never disorder.
+            Witness(reality, "The cross (Christ crucified)", new Act("the cross",
+                new SelfSacrifice(), new Atonement(), new Pardon(), new CovenantFaithfulness()));
+
+            Witness(reality, "God so loved the world (John 3:16)",
+                new Act("the Father gives the Son", new SelfSacrifice(), new Compassion()));
+
+            // Righteous human deeds.
+            Witness(reality, "The Good Samaritan (Luke 10:37)",
+                new Act("binding a stranger's wounds", new Compassion(), new Protection()));
+
+            // Sin: incoherent, and it disorders the world.
+            Witness(reality, "Cain murders Abel (Genesis 4)", new Act("the first murder", new Murder()));
+
+            Witness(reality, "The unforgiving servant (Matthew 18)",
+                new Act("mercy refused", new Unforgiveness(), new Condemnation()));
+
+            // A deed never named in Scripture, judged by principle, not by lookup.
+            Witness(reality, "Novel: talking a stranger off the ledge",
+                new Act("a rescue online", new Compassion(), new Protection()));
+
+            Console.WriteLine();
+            Console.WriteLine("--- Grounding: the same act of worship, on God vs on an idol (1 Meqabyan) ---");
+            Act worship = new Act("a sacrifice offered", new CovenantFaithfulness());
+            Reality onGod = Reality.Revealed();
+            Reality onIdol = Reality.Revealed();
+            Resolution faithful = onGod.Witness(worship, Grounding.InGod());
+            Resolution idolatrous = onIdol.Witness(worship, Grounding.InIdol("the golden calf"));
+            Console.WriteLine("  on God        -> coherence " + Format(faithful.Coherence)
+                + ", disorder " + Format(faithful.Disorder));
+            Console.WriteLine("  on the calf   -> coherence " + Format(idolatrous.Coherence)
+                + ", disorder " + Format(idolatrous.Disorder) + "  (drifts toward non-being)");
+            Console.WriteLine();
+        }
+
+        private static void Witness(Reality reality, string title, Act act)
+        {
+            Resolution r = reality.Witness(act);
+            Console.WriteLine(title);
+            Console.WriteLine("  coherence " + Format(r.Coherence) + ", disorder " + Format(r.Disorder)
+                + "  | Love " + Format(r.Reading("Love")) + ", Justice " + Format(r.Reading("Justice"))
+                + ", Mercy " + Format(r.Reading("Mercy")) + ", Order " + Format(r.Reading("Order")));
+            Console.WriteLine("  standing order of reality now: " + Format(reality.Tablets.Coherence()));
+            Console.WriteLine();
+        }
+
+        private static string Format(double value)
+        {
+            return value.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/AgapeTests.cs
+++ b/AnointedAutomation.Objects.Tests/AgapeTests.cs
@@ -1,6 +1,5 @@
-// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-05-28 10:42:10
-// Edited by Alexander Fields https://www.alexanderfields.me 2026-05-28 12:05:18
-//Stewarded by Alexander Fields
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
 
 using Xunit;
 using AnointedAutomation.Objects.Concepts;
@@ -15,8 +14,8 @@ namespace AnointedAutomation.Objects.Tests
             // Arrange (the Good Samaritan principle, Luke 10:33-35)
             Love agape = Love.Agape();
             Situation situation = new Situation("A stranger lies beaten by the road.")
-                .Set("inNeed")
-                .Set("iCanHelp");
+                .With(new Need())
+                .With(new Means());
 
             // Act
             LoveAction action = agape.Decide(situation);
@@ -34,7 +33,7 @@ namespace AnointedAutomation.Objects.Tests
             // Arrange — a situation never named in Scripture: an online teammate betrays the group.
             Love agape = Love.Agape();
             Situation betrayal = new Situation("A teammate betrayed the group and ninja-looted the boss.")
-                .Set("wronged");
+                .With(new Grievance());
 
             // Act
             LoveAction action = agape.Decide(betrayal);
@@ -50,7 +49,7 @@ namespace AnointedAutomation.Objects.Tests
         {
             // Arrange (Romans 12:15)
             Love agape = Love.Agape();
-            Situation situation = new Situation("A friend has lost someone dear.").Set("grieving");
+            Situation situation = new Situation("A friend has lost someone dear.").With(new Grief());
 
             // Act
             LoveAction action = agape.Decide(situation);
@@ -66,7 +65,7 @@ namespace AnointedAutomation.Objects.Tests
         {
             // Arrange (Romans 12:15; 1 Corinthians 13:6)
             Love agape = Love.Agape();
-            Situation situation = new Situation("A friend just got the job they prayed for.").Set("rejoicing");
+            Situation situation = new Situation("A friend just got the job they prayed for.").With(new Gladness());
 
             // Act
             LoveAction action = agape.Decide(situation);
@@ -81,7 +80,7 @@ namespace AnointedAutomation.Objects.Tests
         {
             // Arrange (Matthew 5:44)
             Love agape = Love.Agape();
-            Situation situation = new Situation("Someone who hates me is before me.").Set("enemy");
+            Situation situation = new Situation("Someone who hates me is before me.").With(new Enmity());
 
             // Act
             LoveAction action = agape.Decide(situation);
@@ -97,8 +96,8 @@ namespace AnointedAutomation.Objects.Tests
             // Arrange (Romans 12:20 — a composed branch: enemy AND (hungry OR thirsty))
             Love agape = Love.Agape();
             Situation situation = new Situation("An enemy who hates you is now hungry.")
-                .Set("enemy")
-                .Set("hungry");
+                .With(new Enmity())
+                .With(new Hunger());
 
             // Act
             LoveAction action = agape.Decide(situation);
@@ -115,8 +114,8 @@ namespace AnointedAutomation.Objects.Tests
             // Arrange (Romans 12:20 — the OR half of the composed condition)
             Love agape = Love.Agape();
             Situation situation = new Situation("An enemy is thirsty.")
-                .Set("enemy")
-                .Set("thirsty");
+                .With(new Enmity())
+                .With(new Thirst());
 
             // Act
             LoveAction action = agape.Decide(situation);
@@ -131,7 +130,7 @@ namespace AnointedAutomation.Objects.Tests
         {
             // Arrange — the composed branch only fires for an enemy; a hungry friend gets Matthew 25.
             Love agape = Love.Agape();
-            Situation situation = new Situation("A hungry person who is not my enemy.").Set("hungry");
+            Situation situation = new Situation("A hungry person who is not my enemy.").With(new Hunger());
 
             // Act
             LoveAction action = agape.Decide(situation);
@@ -146,7 +145,7 @@ namespace AnointedAutomation.Objects.Tests
         {
             // Arrange — an enemy who is neither hungry nor thirsty falls to the plain enemy branch.
             Love agape = Love.Agape();
-            Situation situation = new Situation("An enemy who is not in any physical need.").Set("enemy");
+            Situation situation = new Situation("An enemy who is not in any physical need.").With(new Enmity());
 
             // Act
             LoveAction action = agape.Decide(situation);
@@ -162,11 +161,12 @@ namespace AnointedAutomation.Objects.Tests
         [InlineData("naked", "Clothe")]
         [InlineData("sick", "tend")]
         [InlineData("imprisoned", "visit")]
-        public void Decide_WorksOfMercy_RespondToTheNeed(string fact, string deedKeyword)
+        public void Decide_WorksOfMercy_RespondToTheNeed(string circumstance, string deedKeyword)
         {
-            // Arrange (Matthew 25:35-36 — the Sheep and the Goats)
+            // Arrange (Matthew 25:35-36 — the Sheep and the Goats). A directly-named circumstance
+            // matches the named one in the tree, so any of the works of mercy can be exercised.
             Love agape = Love.Agape();
-            Situation situation = new Situation().Set(fact);
+            Situation situation = new Situation().With(new Circumstance(circumstance));
 
             // Act
             LoveAction action = agape.Decide(situation);
@@ -179,12 +179,12 @@ namespace AnointedAutomation.Objects.Tests
         }
 
         [Fact]
-        public void Decide_NovelSituationWithNoKnownFacts_IsPatientAndKind()
+        public void Decide_NovelSituationWithNoKnownCircumstance_IsPatientAndKind()
         {
             // Arrange — a situation the repertoire has no branch for; love must still respond.
             Love agape = Love.Agape();
             Situation novel = new Situation("Something the Bible never described.")
-                .Set("quantumComputerMalfunctioned");
+                .With(new Circumstance("quantumComputerMalfunctioned"));
 
             // Act
             LoveAction action = agape.Decide(novel);
@@ -201,7 +201,7 @@ namespace AnointedAutomation.Objects.Tests
             // Arrange — the need is real but the means are absent, so the "meet the need" branch fails.
             Love agape = Love.Agape();
             Situation situation = new Situation("Someone is in need, but I have no means to help.")
-                .Set("inNeed");
+                .With(new Need());
 
             // Act
             LoveAction action = agape.Decide(situation);
@@ -214,9 +214,9 @@ namespace AnointedAutomation.Objects.Tests
         [Fact]
         public void Decide_PriorityOrder_ForgivenessBeforeMeetingNeed()
         {
-            // Arrange — both facts hold; the higher-priority branch (wronged) wins.
+            // Arrange — both circumstances hold; the higher-priority branch (wronged) wins.
             Love agape = Love.Agape();
-            Situation situation = new Situation().Set("wronged").Set("inNeed").Set("iCanHelp");
+            Situation situation = new Situation().With(new Grievance()).With(new Need()).With(new Means());
 
             // Act
             LoveAction action = agape.Decide(situation);
@@ -229,7 +229,7 @@ namespace AnointedAutomation.Objects.Tests
         public void Decide_SameSituation_DifferentLove_DifferentDeed()
         {
             // Arrange — the heart of the abstraction: one situation, two loves, two deeds.
-            Situation situation = new Situation().Set("inNeed").Set("iCanHelp");
+            Situation situation = new Situation().With(new Need()).With(new Means());
             Love samaritan = new Agape();
             Love passerby = new SelfSeekingLove();
 
@@ -248,7 +248,7 @@ namespace AnointedAutomation.Objects.Tests
         {
             // Arrange (Luke 10:31-32)
             Love passerby = new SelfSeekingLove();
-            Situation situation = new Situation().Set("inNeed").Set("iCanHelp");
+            Situation situation = new Situation().With(new Need()).With(new Means());
 
             // Act
             LoveAction action = passerby.Decide(situation);
@@ -262,10 +262,8 @@ namespace AnointedAutomation.Objects.Tests
         [Fact]
         public void Agape_IsPerfect_AndSacrificial()
         {
-            // Act
             Agape agape = new Agape();
 
-            // Assert
             Assert.True(agape.IsPerfect());
             Assert.True(agape.sacrificial);
             Assert.Equal(Love.MaxCompleteness, agape.Completeness());
@@ -274,10 +272,8 @@ namespace AnointedAutomation.Objects.Tests
         [Fact]
         public void SelfSeekingLove_IsSelfSeeking_AndNotPerfect()
         {
-            // Act
             SelfSeekingLove love = new SelfSeekingLove();
 
-            // Assert
             Assert.True(love.selfSeeking);
             Assert.False(love.IsPerfect());
         }
@@ -287,24 +283,20 @@ namespace AnointedAutomation.Objects.Tests
         [Fact]
         public void Decide_WithNullSituation_ThrowsArgumentNullException()
         {
-            // Arrange
             Love agape = Love.Agape();
 
-            // Assert
             Assert.Throws<System.ArgumentNullException>(() => agape.Decide(null));
         }
 
         [Fact]
         public void Decide_IsRepeatable_ForReusedLove()
         {
-            // Arrange — the lazily-built tree is reusable across situations.
+            // The lazily-built tree is reusable across situations.
             Love agape = Love.Agape();
 
-            // Act
-            LoveAction first = agape.Decide(new Situation().Set("wronged"));
-            LoveAction second = agape.Decide(new Situation().Set("grieving"));
+            LoveAction first = agape.Decide(new Situation().With(new Grievance()));
+            LoveAction second = agape.Decide(new Situation().With(new Grief()));
 
-            // Assert
             Assert.Contains("Forgive", first.Deed);
             Assert.Contains("Mourn with", second.Deed);
         }

--- a/AnointedAutomation.Objects.Tests/BehaviorTreeTests.cs
+++ b/AnointedAutomation.Objects.Tests/BehaviorTreeTests.cs
@@ -1,6 +1,5 @@
-// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-05-28 12:05:18
-// Edited by Alexander Fields https://www.alexanderfields.me 2026-05-28 12:05:18
-//Stewarded by Alexander Fields
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
 
 using Xunit;
 using AnointedAutomation.Objects.Concepts;
@@ -17,14 +16,11 @@ namespace AnointedAutomation.Objects.Tests
         [Fact]
         public void Deed_AlwaysSucceeds_CarryingItsAction()
         {
-            // Arrange
             LoveAction action = Action("A");
             Deed deed = new Deed(action);
 
-            // Act
             BehaviorResult result = deed.Tick(new Situation());
 
-            // Assert
             Assert.True(result.succeeded);
             Assert.Same(action, result.Action);
         }
@@ -32,13 +28,10 @@ namespace AnointedAutomation.Objects.Tests
         [Fact]
         public void Condition_PredicateTrue_Succeeds_WithNoAction()
         {
-            // Arrange
             Condition condition = new Condition(situation => true);
 
-            // Act
             BehaviorResult result = condition.Tick(new Situation());
 
-            // Assert
             Assert.True(result.succeeded);
             Assert.Null(result.Action);
         }
@@ -46,116 +39,104 @@ namespace AnointedAutomation.Objects.Tests
         [Fact]
         public void Condition_PredicateFalse_Fails()
         {
-            // Arrange
             Condition condition = new Condition(situation => false);
 
-            // Assert
             Assert.False(condition.Tick(new Situation()).succeeded);
         }
 
         [Fact]
-        public void Condition_Fact_ReadsTheSituation()
+        public void Condition_For_ReadsTheSituation()
         {
-            // Arrange
-            Condition condition = Condition.Fact("inNeed");
+            Condition condition = Condition.For(new Need());
 
-            // Assert
-            Assert.True(condition.Tick(new Situation().Set("inNeed")).succeeded);
+            Assert.True(condition.Tick(new Situation().With(new Need())).succeeded);
             Assert.False(condition.Tick(new Situation()).succeeded);
         }
 
         [Fact]
         public void Condition_And_HoldsOnlyWhenBothHold()
         {
-            // Arrange (sick AND imprisoned)
-            Condition condition = Condition.Fact("sick").And("imprisoned");
+            // sick AND imprisoned
+            Condition condition = Condition.For(new Sickness()).And(new Imprisonment());
 
-            // Assert
-            Assert.True(condition.Tick(new Situation().Set("sick").Set("imprisoned")).succeeded);
-            Assert.False(condition.Tick(new Situation().Set("sick")).succeeded);
-            Assert.False(condition.Tick(new Situation().Set("imprisoned")).succeeded);
+            Assert.True(condition.Tick(new Situation().With(new Sickness()).With(new Imprisonment())).succeeded);
+            Assert.False(condition.Tick(new Situation().With(new Sickness())).succeeded);
+            Assert.False(condition.Tick(new Situation().With(new Imprisonment())).succeeded);
             Assert.False(condition.Tick(new Situation()).succeeded);
         }
 
         [Fact]
         public void Condition_And_AcceptsConditionOverload()
         {
-            // Arrange
-            Condition condition = Condition.Fact("a").And(Condition.Fact("b"));
+            Condition condition = Condition.For(new Circumstance("a")).And(Condition.For(new Circumstance("b")));
 
-            // Assert
-            Assert.True(condition.Tick(new Situation().Set("a").Set("b")).succeeded);
-            Assert.False(condition.Tick(new Situation().Set("a")).succeeded);
+            Assert.True(condition.Tick(new Situation().With(new Circumstance("a")).With(new Circumstance("b"))).succeeded);
+            Assert.False(condition.Tick(new Situation().With(new Circumstance("a"))).succeeded);
         }
 
         [Fact]
         public void Condition_Or_HoldsWhenEitherHolds()
         {
-            // Arrange (hungry OR thirsty)
-            Condition condition = Condition.Fact("hungry").Or("thirsty");
+            // hungry OR thirsty
+            Condition condition = Condition.For(new Hunger()).Or(new Thirst());
 
-            // Assert
-            Assert.True(condition.Tick(new Situation().Set("hungry")).succeeded);
-            Assert.True(condition.Tick(new Situation().Set("thirsty")).succeeded);
-            Assert.True(condition.Tick(new Situation().Set("hungry").Set("thirsty")).succeeded);
+            Assert.True(condition.Tick(new Situation().With(new Hunger())).succeeded);
+            Assert.True(condition.Tick(new Situation().With(new Thirst())).succeeded);
+            Assert.True(condition.Tick(new Situation().With(new Hunger()).With(new Thirst())).succeeded);
             Assert.False(condition.Tick(new Situation()).succeeded);
         }
 
         [Fact]
         public void Condition_Not_NegatesTheCondition()
         {
-            // Arrange (NOT an enemy)
-            Condition condition = Condition.Fact("enemy").Not();
+            // NOT an enemy
+            Condition condition = Condition.For(new Enmity()).Not();
 
-            // Assert
             Assert.True(condition.Tick(new Situation()).succeeded);
-            Assert.False(condition.Tick(new Situation().Set("enemy")).succeeded);
+            Assert.False(condition.Tick(new Situation().With(new Enmity())).succeeded);
         }
 
         [Fact]
         public void Condition_StaticNot_NegatesTheGivenCondition()
         {
-            // Arrange
-            Condition condition = Condition.Not(Condition.Fact("enemy"));
+            Condition condition = Condition.Not(Condition.For(new Enmity()));
 
-            // Assert
             Assert.True(condition.Tick(new Situation()).succeeded);
-            Assert.False(condition.Tick(new Situation().Set("enemy")).succeeded);
+            Assert.False(condition.Tick(new Situation().With(new Enmity())).succeeded);
         }
 
         [Fact]
         public void Condition_Composition_ChainsLeftToRight()
         {
-            // Arrange — (a AND b) OR c
-            Condition condition = Condition.Fact("a").And("b").Or("c");
+            // (a AND b) OR c
+            Condition condition = Condition.For(new Circumstance("a"))
+                .And(new Circumstance("b")).Or(new Circumstance("c"));
 
-            // Assert
-            Assert.True(condition.Tick(new Situation().Set("a").Set("b")).succeeded);
-            Assert.True(condition.Tick(new Situation().Set("c")).succeeded);
-            Assert.False(condition.Tick(new Situation().Set("a")).succeeded);
+            Assert.True(condition.Tick(new Situation().With(new Circumstance("a")).With(new Circumstance("b"))).succeeded);
+            Assert.True(condition.Tick(new Situation().With(new Circumstance("c"))).succeeded);
+            Assert.False(condition.Tick(new Situation().With(new Circumstance("a"))).succeeded);
         }
 
         [Fact]
         public void Condition_AndNot_Combine()
         {
-            // Arrange — sick AND NOT contagious
-            Condition condition = Condition.Fact("sick").And(Condition.Fact("contagious").Not());
+            // sick AND NOT contagious
+            Condition condition = Condition.For(new Sickness()).And(Condition.For(new Circumstance("contagious")).Not());
 
-            // Assert
-            Assert.True(condition.Tick(new Situation().Set("sick")).succeeded);
-            Assert.False(condition.Tick(new Situation().Set("sick").Set("contagious")).succeeded);
+            Assert.True(condition.Tick(new Situation().With(new Sickness())).succeeded);
+            Assert.False(condition.Tick(new Situation().With(new Sickness()).With(new Circumstance("contagious"))).succeeded);
         }
 
         [Fact]
         public void Condition_And_WithNullCondition_ThrowsArgumentNullException()
         {
-            Assert.Throws<System.ArgumentNullException>(() => Condition.Fact("a").And((Condition)null));
+            Assert.Throws<System.ArgumentNullException>(() => Condition.For(new Circumstance("a")).And((Condition)null));
         }
 
         [Fact]
         public void Condition_Or_WithNullCondition_ThrowsArgumentNullException()
         {
-            Assert.Throws<System.ArgumentNullException>(() => Condition.Fact("a").Or((Condition)null));
+            Assert.Throws<System.ArgumentNullException>(() => Condition.For(new Circumstance("a")).Or((Condition)null));
         }
 
         [Fact]
@@ -167,14 +148,11 @@ namespace AnointedAutomation.Objects.Tests
         [Fact]
         public void Sequence_AllChildrenSucceed_CarriesLastDeed()
         {
-            // Arrange
             LoveAction action = Action("A");
             Sequence sequence = new Sequence(new Condition(situation => true), new Deed(action));
 
-            // Act
             BehaviorResult result = sequence.Tick(new Situation());
 
-            // Assert
             Assert.True(result.succeeded);
             Assert.Same(action, result.Action);
         }
@@ -182,27 +160,22 @@ namespace AnointedAutomation.Objects.Tests
         [Fact]
         public void Sequence_AnyChildFails_Fails()
         {
-            // Arrange
             Sequence sequence = new Sequence(new Condition(situation => false), new Deed(Action("A")));
 
-            // Assert
             Assert.False(sequence.Tick(new Situation()).succeeded);
         }
 
         [Fact]
         public void Selector_ReturnsFirstChildThatSucceeds()
         {
-            // Arrange
             LoveAction first = Action("first");
             LoveAction fallback = Action("fallback");
             Selector selector = new Selector(
                 new Sequence(new Condition(situation => false), new Deed(first)),
                 new Deed(fallback));
 
-            // Act
             BehaviorResult result = selector.Tick(new Situation());
 
-            // Assert
             Assert.True(result.succeeded);
             Assert.Same(fallback, result.Action);
         }
@@ -210,27 +183,23 @@ namespace AnointedAutomation.Objects.Tests
         [Fact]
         public void Selector_AllChildrenFail_Fails()
         {
-            // Arrange
             Selector selector = new Selector(
                 new Condition(situation => false),
                 new Condition(situation => false));
 
-            // Assert
             Assert.False(selector.Tick(new Situation()).succeeded);
         }
 
         [Fact]
         public void Composition_PicksMatchingBranch_ElseFallback()
         {
-            // Arrange
             LoveAction help = Action("help");
             LoveAction fallback = Action("fallback");
             Selector tree = new Selector(
-                new Sequence(Condition.Fact("inNeed"), new Deed(help)),
+                new Sequence(Condition.For(new Need()), new Deed(help)),
                 new Deed(fallback));
 
-            // Assert
-            Assert.Same(help, tree.Tick(new Situation().Set("inNeed")).Action);
+            Assert.Same(help, tree.Tick(new Situation().With(new Need())).Action);
             Assert.Same(fallback, tree.Tick(new Situation()).Action);
         }
 
@@ -249,21 +218,18 @@ namespace AnointedAutomation.Objects.Tests
         }
 
         [Fact]
-        public void Condition_Fact_WithNullName_ThrowsArgumentNullException()
+        public void Condition_For_WithNullCircumstance_ThrowsArgumentNullException()
         {
-            Assert.Throws<System.ArgumentNullException>(() => Condition.Fact(null));
+            Assert.Throws<System.ArgumentNullException>(() => Condition.For(null));
         }
 
         [Fact]
         public void Sequence_WithNoChildren_Succeeds_WithNoAction()
         {
-            // Arrange — a vacuous sequence (no children) succeeds, carrying no deed.
             Sequence sequence = new Sequence();
 
-            // Act
             BehaviorResult result = sequence.Tick(new Situation());
 
-            // Assert
             Assert.True(result.succeeded);
             Assert.Null(result.Action);
         }
@@ -271,10 +237,8 @@ namespace AnointedAutomation.Objects.Tests
         [Fact]
         public void Selector_WithNoChildren_Fails()
         {
-            // Arrange — a selector with nothing to try fails.
             Selector selector = new Selector();
 
-            // Assert
             Assert.False(selector.Tick(new Situation()).succeeded);
         }
     }

--- a/AnointedAutomation.Objects.Tests/BiblicalOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/BiblicalOracleTests.cs
@@ -1,0 +1,198 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests
+{
+    /// <summary>
+    /// Scripture is the regression oracle. The acts of God, Jesus, and the Holy Spirit are the
+    /// standard of reality, so the engine must ALWAYS agree with the Biblical record: a divine act
+    /// can never read incoherent and can never introduce disorder, sin must always read incoherent
+    /// and destabilize reality, and righteous deeds must cohere. If the engine ever returns a
+    /// different verdict than Scripture, the code is wrong, not the Bible.
+    /// </summary>
+    public class BiblicalOracleTests
+    {
+        // ----- The acts of God / Jesus / the Spirit: the standard. Never disorder, never incoherent.
+
+        [Fact]
+        public void TheCross_IsTheFullnessOfGodsCharacter_PerfectlyCoherent()
+        {
+            // The supreme act: full Love (lays down His life, John 15:13), full Justice (the debt is
+            // paid, Romans 3:25), full Mercy (the guilty go free), and faithful to the promise
+            // (Genesis 3:15; Luke 24:44). Every facet of God is satisfied at once.
+            Reality reality = Reality.Revealed();
+            Act theCross = new Act("Christ crucified",
+                new SelfSacrifice(), new Atonement(), new Pardon(), new CovenantFaithfulness());
+
+            Resolution r = reality.Witness(theCross);
+
+            Assert.Equal(1.0, r.Coherence);
+            Assert.Equal(0.0, r.Disorder);
+        }
+
+        [Fact]
+        public void GodSoLovedTheWorld_IsLove_AndDestabilizesNothing()
+        {
+            // "For God so loved the world that he gave his one and only Son." (John 3:16)
+            Reality reality = Reality.Revealed();
+            Act gift = new Act("the Father gives the Son", new SelfSacrifice(), new Compassion());
+
+            Resolution r = reality.Witness(gift);
+
+            AssertDivineAct(r);
+            Assert.Equal(1.0, r.Reading("Love"));
+        }
+
+        [Fact]
+        public void GodKeepsCreationsOrder_IsFaithful_AndDestabilizesNothing()
+        {
+            // God ordains and sustains the courses of creation (Genesis 1; 1 Enoch 72-82;
+            // Colossians 1:17). His faithfulness never fails (Lamentations 3:22-23).
+            Reality reality = Reality.Revealed();
+            Act sustaining = new Act("the courses of the heavens kept",
+                new CreationOrder(), new CovenantFaithfulness());
+
+            Resolution r = reality.Witness(sustaining);
+
+            AssertDivineAct(r);
+            Assert.Equal(1.0, r.Reading("Faithfulness"));
+        }
+
+        // ----- Sin: always incoherent, always introduces disorder (1 Enoch 80).
+
+        [Fact]
+        public void CainMurdersAbel_IsIncoherent_AndDisordersReality()
+        {
+            // "Your brother's blood cries out to me from the ground." (Genesis 4:10) The first murder
+            // wrongs the neighbour and curses the very ground: disorder enters creation.
+            Reality reality = Reality.Revealed();
+            Act murder = new Act("Cain kills Abel", new Murder());
+
+            Resolution r = reality.Witness(murder);
+
+            AssertSin(r);
+        }
+
+        [Fact]
+        public void TheUnforgivingServant_IsIncoherent_AndDisordersReality()
+        {
+            // Forgiven much, he would not forgive (Matthew 18:23-35). Mercy refused is grievous.
+            Reality reality = Reality.Revealed();
+            Act cruelty = new Act("the unforgiving servant", new Unforgiveness(), new Condemnation());
+
+            Resolution r = reality.Witness(cruelty);
+
+            AssertSin(r);
+        }
+
+        [Fact]
+        public void CovenantBetrayal_IsIncoherent_AndDisordersReality()
+        {
+            // Breaking faith transgresses the order God decreed (1 Enoch 80; Malachi 2:10).
+            Reality reality = Reality.Revealed();
+            Act betrayal = new Act("a covenant broken", new Treachery());
+
+            Resolution r = reality.Witness(betrayal);
+
+            AssertSin(r);
+        }
+
+        // ----- Righteous human deeds: coherent, no disorder. The priest who passes by is not.
+
+        [Fact]
+        public void TheGoodSamaritan_IsCoherent_AndDestabilizesNothing()
+        {
+            // "Go and do likewise." (Luke 10:37) The mercy shown is the coherent act.
+            Reality reality = Reality.Revealed();
+            Act mercy = new Act("the Samaritan binds the wounds", new Compassion(), new Protection());
+
+            Resolution r = reality.Witness(mercy);
+
+            Assert.True(r.Coherence > 0.5, "Mercy shown must read coherent.");
+            Assert.Equal(0.0, r.Disorder);
+        }
+
+        [Fact]
+        public void ThePriestPassesByOnTheOtherSide_IsIncoherent_AndDisordersReality()
+        {
+            // The priest and Levite "passed by on the other side." (Luke 10:31-32) Compassion withheld
+            // for self is not neutral; it offends love and mercy.
+            Reality reality = Reality.Revealed();
+            Act passingBy = new Act("passing by the half-dead man", new SelfSeeking(), new Indifference());
+
+            Resolution r = reality.Witness(passingBy);
+
+            AssertSin(r);
+        }
+
+        // ----- Grounding: an idolatrous act drifts toward non-being (1 Meqabyan; Exodus 32).
+
+        [Fact]
+        public void TheGoldenCalf_EvenAsWorship_DriftsTowardNonBeing()
+        {
+            // Worship offered to an idol cannot give life (1 Meqabyan 1; Exodus 32). The same outward
+            // act of devotion, grounded in an idol, cannot hold.
+            Act worship = new Act("a sacrifice offered", new CovenantFaithfulness());
+
+            Reality toGod = Reality.Revealed();
+            Resolution faithful = toGod.Witness(worship, Grounding.InGod());
+
+            Reality toCalf = Reality.Revealed();
+            Resolution idolatrous = toCalf.Witness(worship, Grounding.InIdol("the golden calf"));
+
+            Assert.Equal(0.0, faithful.Disorder);
+            Assert.True(idolatrous.Disorder > 0.0, "Idolatry drifts reality toward non-being.");
+            Assert.True(idolatrous.Coherence < faithful.Coherence);
+        }
+
+        // ----- The engine, not a lookup: scenarios never named in Scripture must resolve rightly.
+
+        [Fact]
+        public void NovelMercy_NeverNamedInScripture_StillReadsCoherent()
+        {
+            // A stranger online talks someone off the ledge. Never in the Bible by name, yet love is
+            // love: the engine must judge it by principle, not by a catalogue of stories.
+            Reality reality = Reality.Revealed();
+            Act rescue = new Act("a stranger talks someone out of suicide",
+                new Compassion(), new Protection());
+
+            Resolution r = reality.Witness(rescue);
+
+            Assert.True(r.Coherence > 0.5);
+            Assert.Equal(0.0, r.Disorder);
+        }
+
+        [Fact]
+        public void NovelCruelty_NeverNamedInScripture_StillReadsAsSin()
+        {
+            // Doxxing someone for revenge. Not in Scripture by name, but it wrongs the neighbour,
+            // keeps a record of wrongs, and condemns the broken: the engine must still read it as sin.
+            Reality reality = Reality.Revealed();
+            Act revenge = new Act("doxxing someone for revenge",
+                new Wrongdoing(), new Grudge(), new Condemnation());
+
+            Resolution r = reality.Witness(revenge);
+
+            AssertSin(r);
+        }
+
+        // ----- Oracle helpers: the verdicts Scripture requires.
+
+        private static void AssertDivineAct(Resolution r)
+        {
+            // God is the standard of reality: His acts never read incoherent and never destabilize it.
+            Assert.True(r.Coherence >= 0.5, "An act of God can never read incoherent.");
+            Assert.Equal(0.0, r.Disorder);
+        }
+
+        private static void AssertSin(Resolution r)
+        {
+            // Sin offends God's character and warps the order of reality (1 Enoch 80).
+            Assert.True(r.Coherence < 0.5, "Sin must read incoherent.");
+            Assert.True(r.Disorder > 0.0, "Sin must introduce disorder into reality.");
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/AbtilisNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/AbtilisNarrativeTests.cs
@@ -1,0 +1,124 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Abtilis narrative oracle: the engine must return the verdict the Apostolic Canons give at each step.
+    // Canon: ETH (Ethiopic-only; best-effort). Abtilis is the fourth book of the Ethiopic Sinodos,
+    // the Apostolic Canons (81/83 canons), paralleling Book VIII of the Apostolic Constitutions and the
+    // Clementine Octateuch. It is church order: ordination, right worship, fasting, the discipline and
+    // qualifications of clergy, care for the poor, and the rejection of simony, idolatry, and immorality.
+    public class AbtilisNarrativeTests
+    {
+        [Fact]
+        public void TheChurchCaresForWidowsOrphansAndTheNeedy_IsRighteous()
+        {
+            // The Apostolic Canons charge the bishop to distribute the offerings of the faithful to the
+            // widows, the orphans, and the poor, and not to convert them to his own use. (Abtilis / Ap. Can. 4, 41)
+            OracleHarness.Righteous(OracleHarness.Witness("the church cares for the widows, orphans, and the needy from its offerings",
+                new HonoringTheVulnerable(), new Generosity(), new Compassion(), new Trustworthiness()));
+        }
+
+        [Fact]
+        public void TheBishopIsOrdainedByLayingOnOfHandsInRightWorship_IsRighteous()
+        {
+            // A bishop is to be ordained by two or three bishops with prayer and the laying on of hands,
+            // ordering the worship of the Church. (Abtilis / Ap. Can. 1)
+            OracleHarness.Righteous(OracleHarness.Witness("a bishop is ordained by the laying on of hands in right worship",
+                new Worship(), new ObedienceToGod(), new CreationOrder()));
+        }
+
+        [Fact]
+        public void TheBishopTeachesSoundDoctrineToTheFlock_IsRighteous()
+        {
+            // The bishop is bound to teach the words of godliness rightly and to feed the people with
+            // sound doctrine. (Abtilis / Ap. Can. 58)
+            OracleHarness.Righteous(OracleHarness.Witness("the bishop teaches sound doctrine and feeds the flock",
+                new TeachingTruth(), new Fidelity(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void TheChurchKeepsTheLordsDayAndAppointedFastsFaithfully_IsRighteous()
+        {
+            // The canons command the faithful keeping of the Lord's Day, of Pentecost, and of the
+            // appointed fasts of Wednesday and Friday. (Abtilis / Ap. Can. 66, 69)
+            OracleHarness.Righteous(OracleHarness.Witness("the church keeps the Lord's Day and the appointed fasts faithfully",
+                new Worship(), new Fidelity(), new SelfControl(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void ThePenitentBrotherIsReceivedBackInMercy_IsRighteous()
+        {
+            // One cut off for sin who repents is to be received again, lest he be swallowed up by
+            // overmuch sorrow; the canons forbid crushing the contrite. (Abtilis / Ap. Can. 52)
+            OracleHarness.Righteous(OracleHarness.Witness("the penitent brother who turns from sin is received back in mercy",
+                new Forgiveness(), new Repentance(), new Compassion(), new Pardon()));
+        }
+
+        [Fact]
+        public void TravelingBrethrenAreReceivedWithHospitality_IsRighteous()
+        {
+            // Clergy and faithful traveling abroad are to be received with letters of peace and shown
+            // hospitality, not turned away. (Abtilis / Ap. Can. 12-13)
+            OracleHarness.Righteous(OracleHarness.Witness("traveling brethren are received with letters of peace and hospitality",
+                new Hospitality(), new Kindness(), new Peacemaking()));
+        }
+
+        [Fact]
+        public void OrdainingOrBuyingHolyOfficeForMoney_IsSin()
+        {
+            // Whoever obtains the office of bishop, priest, or deacon by money, he and the one who
+            // ordained him are to be cut off: the sin of simony. (Abtilis / Ap. Can. 29)
+            OracleHarness.Sin(OracleHarness.Witness("a man buys the holy office for money and the ordainer sells it",
+                new Greed(), new Theft(), new Deceit()));
+        }
+
+        [Fact]
+        public void AClericWhoStrikesTheFaithfulInRage_IsSin()
+        {
+            // A bishop or presbyter who strikes the faithful who sin, or the unbelievers who wrong them,
+            // seeking to terrify them by violence, is to be deposed. (Abtilis / Ap. Can. 27)
+            OracleHarness.Sin(OracleHarness.Witness("a cleric strikes the faithful in a fit of rage to terrify them",
+                new FitsOfRage(), new Oppression(), new Rudeness()));
+        }
+
+        [Fact]
+        public void OfferingToIdolsAndPartakingWithIdolaters_IsSin()
+        {
+            // The canons forbid the faithful to bring strange offerings to the altar or to share in the
+            // worship and feasts of idols. (Abtilis / Ap. Can. 3, 7, 70-71)
+            OracleHarness.Sin(OracleHarness.Witness("clergy offer to idols and partake of the table of idolaters",
+                new Idolatry(), new Defilement(), new CovenantBreaking()));
+        }
+
+        [Fact]
+        public void ClergyGivenToDrunkennessAndGambling_IsSin()
+        {
+            // A bishop, presbyter, or deacon given to drunkenness or to dicing and revelry is to either
+            // cease or be deposed. (Abtilis / Ap. Can. 42-43)
+            OracleHarness.Sin(OracleHarness.Witness("clergy give themselves to drunkenness, dicing, and revelry",
+                new Drunkenness(), new Carousing(), new Gluttony()));
+        }
+
+        [Fact]
+        public void TheBishopWhoWithholdsTheChurchGoodsFromThePoor_IsSin()
+        {
+            // A bishop who squanders the goods of the Church to his own ends and withholds them from the
+            // poor and needy is to give account and be deposed. (Abtilis / Ap. Can. 4, 38, 41)
+            OracleHarness.Sin(OracleHarness.Witness("a bishop withholds the church goods from the poor and spends them on himself",
+                new WithholdingWhatIsDue(), new Greed(), new Indifference(), new Heartlessness()));
+        }
+
+        [Fact]
+        public void BearingFalseWitnessOrTakingBribesToPervertJudgment_IsSin()
+        {
+            // The canons condemn the cleric who bears false witness or accepts a bribe to pervert
+            // righteous judgment against a brother. (Abtilis / Ap. Can. 74-75)
+            OracleHarness.Sin(OracleHarness.Witness("a cleric bears false witness and takes a bribe to pervert judgment",
+                new FalseWitness(), new Deceit(), new Wrongdoing()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/ActsAndPaulineOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/ActsAndPaulineOracleTests.cs
@@ -1,0 +1,124 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 51-64: Acts and the Pauline epistles (Romans through Philemon).
+    public class ActsAndPaulineOracleTests
+    {
+        [Fact]
+        public void Acts_TheChurchSharesWithTheNeedy_IsRighteous()
+        {
+            // "They gave to anyone who had need." (Acts 2:44-45)
+            OracleHarness.Righteous(OracleHarness.Witness("the church shares with the needy", new Generosity(), new Compassion()));
+        }
+
+        [Fact]
+        public void Acts_AnaniasAndSapphirasDeceit_IsSin()
+        {
+            // Lying to the Holy Spirit about the gift (Acts 5:1-11).
+            OracleHarness.Sin(OracleHarness.Witness("Ananias lies to the Spirit", new Deceit(), new Greed()));
+        }
+
+        [Fact]
+        public void Romans_TheAtonementJustAndJustifying_IsADivineAct()
+        {
+            // "So as to be just and the one who justifies." (Romans 3:25-26) Justice and mercy meet.
+            OracleHarness.DivineAct(OracleHarness.Witness("the atonement", new Atonement(), new Pardon()));
+        }
+
+        [Fact]
+        public void Romans_LoveDoesNoHarmToANeighbor_IsRighteous()
+        {
+            // "Love does no harm to a neighbor. Therefore love is the fulfillment of the law." (Rom 13:10)
+            OracleHarness.Righteous(OracleHarness.Witness("love fulfills the law", new Compassion()));
+        }
+
+        [Fact]
+        public void FirstCorinthians_LoveIsPatientAndKind_IsRighteous()
+        {
+            // "Love is patient, love is kind." (1 Corinthians 13:4)
+            OracleHarness.Righteous(OracleHarness.Witness("love is patient and kind", new Patience(), new Kindness()));
+        }
+
+        [Fact]
+        public void SecondCorinthians_TheMinistryOfReconciliation_IsADivineAct()
+        {
+            // "God made him who had no sin to be sin for us." (2 Corinthians 5:21)
+            OracleHarness.DivineAct(OracleHarness.Witness("the ministry of reconciliation", new Atonement(), new Peacemaking()));
+        }
+
+        [Fact]
+        public void Galatians_BearOneAnothersBurdens_IsRighteous()
+        {
+            // "Carry each other's burdens, and so fulfill the law of Christ." (Galatians 6:2)
+            OracleHarness.Righteous(OracleHarness.Witness("bear one another's burdens", new Compassion(), new Patience()));
+        }
+
+        [Fact]
+        public void Ephesians_SavedByGraceThroughFaith_IsADivineAct()
+        {
+            // "It is by grace you have been saved, through faith." (Ephesians 2:8)
+            OracleHarness.DivineAct(OracleHarness.Witness("saved by grace", new Pardon(), new Compassion()));
+        }
+
+        [Fact]
+        public void Philippians_ChristEmptiesHimself_IsADivineAct()
+        {
+            // "He humbled himself ... to death on a cross." (Philippians 2:6-8)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ empties Himself", new SelfSacrifice(), new Humility()));
+        }
+
+        [Fact]
+        public void Colossians_InHimAllThingsHoldTogether_IsADivineAct()
+        {
+            // "In him all things hold together." (Colossians 1:17) The grounding of reality.
+            OracleHarness.DivineAct(OracleHarness.Witness("in Him all things hold together", new CreationOrder()));
+        }
+
+        [Fact]
+        public void Thessalonians_TheLawlessOne_IsSin()
+        {
+            // "The man of lawlessness." (2 Thessalonians 2:3)
+            OracleHarness.Sin(OracleHarness.Witness("the man of lawlessness", new Lawlessness(), new Pride()));
+        }
+
+        [Fact]
+        public void FirstTimothy_ChristCameToSaveSinners_IsADivineAct()
+        {
+            // "Christ Jesus came into the world to save sinners." (1 Timothy 1:15)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ came to save sinners", new Pardon(), new Compassion()));
+        }
+
+        [Fact]
+        public void FirstTimothy_TheLoveOfMoney_IsSin()
+        {
+            // "The love of money is a root of all kinds of evil." (1 Timothy 6:10)
+            OracleHarness.Sin(OracleHarness.Witness("the love of money", new Greed()));
+        }
+
+        [Fact]
+        public void SecondTimothy_HeRemainsFaithful_IsADivineAct()
+        {
+            // "If we are faithless, he remains faithful." (2 Timothy 2:13)
+            OracleHarness.DivineAct(OracleHarness.Witness("He remains faithful", new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void Titus_SavedByHisMercyNotByWorks_IsADivineAct()
+        {
+            // "He saved us ... because of his mercy." (Titus 3:5)
+            OracleHarness.DivineAct(OracleHarness.Witness("saved by His mercy", new Pardon(), new Compassion()));
+        }
+
+        [Fact]
+        public void Philemon_ReceiveHimBackAsABrother_IsRighteous()
+        {
+            // Paul pleads for Onesimus to be received back, no longer as a slave but a brother (Philemon 15-17).
+            OracleHarness.Righteous(OracleHarness.Witness("receive him back as a brother", new Forgiveness(), new Peacemaking()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/ActsNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/ActsNarrativeTests.cs
@@ -1,0 +1,159 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Acts narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class ActsNarrativeTests
+    {
+        [Fact]
+        public void HolySpiritPouredOutAtPentecost_IsADivineAct()
+        {
+            // "And they were all filled with the Holy Ghost, and began to speak with other tongues." (Acts 2:1-4)
+            // God pours out the promised Spirit on the gathered disciples, fulfilling the word of the prophet.
+            OracleHarness.DivineAct(OracleHarness.Witness("God pours out the Holy Spirit upon the disciples at Pentecost",
+                new PromiseFulfilled(), new CovenantFaithfulness(), new Deliverance(),
+                new Goodness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void PeterPreachesAndThreeThousandRepent_IsRighteous()
+        {
+            // "Repent, and be baptized every one of you ... and the same day there were added unto them about three thousand souls." (Acts 2:38-41)
+            // Peter proclaims the risen Christ and the crowd turns to God in repentance.
+            OracleHarness.Righteous(OracleHarness.Witness("Peter preaches the risen Christ and three thousand repent and are baptized",
+                new TeachingTruth(), new Repentance(), new CourageousFaith(),
+                new ObedienceToGod(), new Trust()));
+        }
+
+        [Fact]
+        public void PeterHealsTheLameManAtTheGate_IsADivineAct()
+        {
+            // "In the name of Jesus Christ of Nazareth rise up and walk ... and immediately his feet and ankle bones received strength." (Acts 3:6-8)
+            // Through the apostle, God restores the man lame from birth.
+            OracleHarness.DivineAct(OracleHarness.Witness("God heals the man lame from birth through Peter at the Beautiful Gate",
+                new Healing(), new Compassion(), new HonoringTheVulnerable(),
+                new Goodness(), new Kindness()));
+        }
+
+        [Fact]
+        public void BelieversShareAllThingsInCommon_IsRighteous()
+        {
+            // "And all that believed ... had all things common; and sold their possessions ... and parted them to all men, as every man had need." (Acts 2:44-45; 4:32-35)
+            // The early church holds nothing back, supplying every need among them.
+            OracleHarness.Righteous(OracleHarness.Witness("The believers share all things in common and give to all as any had need",
+                new Generosity(), new FeedingTheHungry(), new Kindness(),
+                new SelfSacrifice(), new Hospitality()));
+        }
+
+        [Fact]
+        public void AnaniasAndSapphiraLieToTheHolySpirit_IsSin()
+        {
+            // "Why hath Satan filled thine heart to lie to the Holy Ghost, and to keep back part of the price?" (Acts 5:1-10)
+            // They conspire to deceive the apostles, withholding while pretending full surrender.
+            OracleHarness.Sin(OracleHarness.Grounded("Ananias and Sapphira lie to the Holy Spirit and withhold part of the price",
+                Grounding.InIdol("Mammon"),
+                new Deceit(), new WithholdingWhatIsDue(), new Greed(),
+                new FalseWitness(), new Treachery()));
+        }
+
+        [Fact]
+        public void StephenForgivesHisMurderersAsHeIsStoned_IsRighteous()
+        {
+            // "Lord, lay not this sin to their charge. And when he had said this, he fell asleep." (Acts 7:54-60)
+            // Stephen, full of the Spirit, prays pardon for those killing him.
+            OracleHarness.Righteous(OracleHarness.Witness("Stephen forgives those stoning him and commits his spirit to the Lord",
+                new Forgiveness(), new Pardon(), new CourageousFaith(),
+                new Endurance(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void StephenIsStonedToDeathByTheCouncil_IsSin()
+        {
+            // "Then they cried out with a loud voice ... and cast him out of the city, and stoned him." (Acts 7:57-58)
+            // The council murders the righteous witness in their rage.
+            Resolution r = OracleHarness.Witness("The council murders Stephen by stoning in their rage",
+                new Murder(), new Bloodshed(), new FitsOfRage(),
+                new Hatred(), new WickedScheming());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void SimonTheSorcererTriesToBuyTheSpirit_IsSin()
+        {
+            // "Thy money perish with thee, because thou hast thought that the gift of God may be purchased with money." (Acts 8:18-23)
+            // Simon, who had practiced sorcery, seeks the Spirit's power for selfish gain.
+            OracleHarness.Sin(OracleHarness.Grounded("Simon the sorcerer offers money to buy the gift of the Holy Spirit",
+                Grounding.InIdol("Mammon"),
+                new Sorcery(), new Greed(), new SelfSeeking(),
+                new SelfishAmbition(), new Pride()));
+        }
+
+        [Fact]
+        public void GodCallsSaulAndTurnsThePersecutorToChrist_IsADivineAct()
+        {
+            // "Saul, Saul, why persecutest thou me? ... it is hard for thee to kick against the pricks." (Acts 9:3-18)
+            // The risen Lord arrests the persecutor on the Damascus road and makes him His chosen vessel.
+            OracleHarness.DivineAct(OracleHarness.Witness("The risen Christ confronts Saul on the road to Damascus and calls him",
+                new Deliverance(), new Pardon(), new Compassion(),
+                new RestoringLife(), new Goodness()));
+        }
+
+        [Fact]
+        public void PeterPreachesAndGodGivesTheSpiritToTheGentiles_IsADivineAct()
+        {
+            // "While Peter yet spake these words, the Holy Ghost fell on all them which heard the word." (Acts 10:34-44)
+            // God shows no partiality and pours out His Spirit on Cornelius and the Gentiles.
+            OracleHarness.DivineAct(OracleHarness.Witness("God pours out the Holy Spirit on the Gentiles in the house of Cornelius",
+                new PromiseFulfilled(), new CovenantFaithfulness(), new JustRecompense(),
+                new Goodness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void HerodMurdersJamesAndExaltsHimself_IsSin()
+        {
+            // "And he killed James the brother of John with the sword ... and the people gave a shout, saying, It is the voice of a god." (Acts 12:1-3, 21-23)
+            // Herod slays the apostle and accepts worship, refusing to give God the glory.
+            Resolution r = OracleHarness.Grounded("Herod murders James with the sword and exalts himself as a god",
+                Grounding.InIdol("Herod"),
+                new Murder(), new Bloodshed(), new Pride(),
+                new Blasphemy(), new Oppression());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void AnAngelDeliversPeterFromPrison_IsADivineAct()
+        {
+            // "And his chains fell off from his hands ... and they went out, and passed on through one street." (Acts 12:7-11)
+            // God sends His angel and frees Peter from Herod's prison the night before his trial.
+            OracleHarness.DivineAct(OracleHarness.Witness("God sends an angel to deliver Peter from prison",
+                new Deliverance(), new Protection(), new Fidelity(),
+                new Goodness(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void PaulAndSilasWorshipInPrisonAndKeepTheJailorFromHarm_IsRighteous()
+        {
+            // "Do thyself no harm: for we are all here ... and he ... washed their stripes; and was baptized." (Acts 16:25-34)
+            // Paul and Silas sing hymns to God, then stay to spare the jailor's life and lead him to faith.
+            OracleHarness.Righteous(OracleHarness.Witness("Paul and Silas sing praises in prison and stay to save the jailor's life",
+                new Worship(), new Joy(), new Protection(),
+                new TeachingTruth(), new Kindness()));
+        }
+
+        [Fact]
+        public void PaulEncouragesAllAboardTheStorm_TossedShip_IsRighteous()
+        {
+            // "I exhort you to be of good cheer: for there shall be no loss of any man's life among you ... and so it came to pass, that they escaped all safe to land." (Acts 27:21-44)
+            // Paul, trusting God's promise, strengthens the despairing crew and they are all brought safely to shore.
+            OracleHarness.Righteous(OracleHarness.Witness("Paul encourages the despairing crew in the storm and all reach land safely",
+                new CourageousFaith(), new Trust(), new Protection(),
+                new HonoringTheVulnerable(), new Endurance()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/AdversarialOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/AdversarialOracleTests.cs
@@ -1,0 +1,115 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-12
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    /// <summary>
+    /// The adversarial sweep: the hard cases where a naive reading fights the text. The finding is
+    /// twofold. (1) Most "hard cases" resolve once you assign the RIGHT concept rather than the
+    /// shocking surface label: Abraham's act is obedience and trust, not child sacrifice; Jael's is
+    /// deliverance, not murder; the imprecatory cry is an appeal to God's justice, not enacted
+    /// murder. The engine judges the concepts you give it; it does not adjudicate the theology for
+    /// you. (2) ONE case genuinely needs context, Rahab's deception, where the very same act-feature
+    /// is present yet Scripture refuses to condemn it. That is why the engine now carries a Context
+    /// dimension.
+    /// </summary>
+    public class AdversarialOracleTests
+    {
+        private static Circumstance[] ProtectingTheInnocent()
+        {
+            return new[] { new Circumstance("protectingInnocentLife") };
+        }
+
+        // ----- The case that genuinely needs context: the same deceit, read two ways. -----
+
+        [Fact]
+        public void RahabsDeception_ReadNaively_LooksLikeSin()
+        {
+            // Stripped of context, a deception offends the God of truth.
+            OracleHarness.Sin(OracleHarness.Witness("a bare deception", new Deceit()));
+        }
+
+        [Fact]
+        public void RahabsDeception_ToSaveTheSpies_IsRighteous()
+        {
+            // But Rahab hid the spies from those who would kill them, and Scripture commends her
+            // faith (Joshua 2; Hebrews 11:31; James 2:25). In that context the deceit is not the lie
+            // God condemns. The verdict FLIPS, which is exactly why context had to be modeled.
+            OracleHarness.Righteous(OracleHarness.WitnessInContext(
+                "Rahab hides the spies from those who would kill them",
+                ProtectingTheInnocent(), new Deceit(), new Protection()));
+        }
+
+        [Fact]
+        public void TheHebrewMidwives_DeceivingPharaohToSaveTheBabies_IsRighteous()
+        {
+            // "The midwives feared God ... so God was kind to them." (Exodus 1:17-21)
+            OracleHarness.Righteous(OracleHarness.WitnessInContext(
+                "the midwives deceive Pharaoh to spare the newborns",
+                ProtectingTheInnocent(), new Deceit(), new CourageousFaith()));
+        }
+
+        // ----- Cases that resolve by assigning the right concept, not the surface label. -----
+
+        [Fact]
+        public void AbrahamOffersIsaac_IsObedientFaith_NotChildSacrifice()
+        {
+            // The act Scripture records is faith: Abraham trusted that God could raise the dead, and
+            // God provided the ram (Genesis 22:13; Hebrews 11:17-19). The sacrifice was never carried
+            // out. The right concepts are obedience and trust, and the verdict is righteous.
+            OracleHarness.Righteous(OracleHarness.Witness("Abraham offers Isaac in faith",
+                new ObedienceToGod(), new Trust()));
+        }
+
+        [Fact]
+        public void JaelKillsSisera_IsDeliverance_NotMurder()
+        {
+            // "Most blessed of women be Jael." (Judges 5:24) The text frames the killing of the enemy
+            // commander as the deliverance of an oppressed people, not as murder.
+            OracleHarness.Righteous(OracleHarness.Witness("Jael delivers Israel from Sisera",
+                new Deliverance(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void TheImprecatoryCry_IsAnAppealToGodsJustice_NotEnactedMurder()
+        {
+            // "Repay her for what she has done." (Psalm 137:8) The psalmist hands vengeance to God
+            // (Deuteronomy 32:35; Romans 12:19); he does not lift the sword himself. The shocking
+            // words are lament committed to the Judge, an appeal to justice.
+            OracleHarness.Righteous(OracleHarness.Witness("the cry for God to repay the oppressor",
+                new JustRecompense()));
+        }
+
+        // ----- The genuine judgment call, stated as such. -----
+
+        [Fact]
+        public void TheConquest_FramedAsDivineJudgment_ReadsAsJustWhenSoAssigned()
+        {
+            // JUDGMENT CALL, flagged honestly: the herem can be framed as God's just judgment on
+            // persistent wickedness (including the Canaanites' own child sacrifice, Deuteronomy 9:4-5;
+            // 12:31), executed in obedience. Assigned those concepts, the engine reads it as just.
+            // The engine does NOT settle the theology; it reports the verdict of whatever moral
+            // concepts you assign, and this is the traditional framing.
+            OracleHarness.DivineAct(OracleHarness.WitnessInContext(
+                "the judgment on the Canaanites under divine command",
+                new[] { new Circumstance("divineCommand") }, new JustRecompense(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TheModelsLimit_IsHonest_NaiveLabelingCanMisjudge()
+        {
+            // The lesson of the sweep: the same outward facts can be labeled "child sacrifice" or
+            // "obedient faith," "murder" or "deliverance." The engine is only as faithful as the
+            // concepts assigned to a deed. Labeled crudely, it can misjudge; labeled as Scripture
+            // frames the act, it agrees with Scripture. That dependency is the model's real boundary.
+            Resolution crude = OracleHarness.Witness("Abraham raises the knife, labeled crudely", new ChildSacrifice());
+            Resolution faithful = OracleHarness.Witness("Abraham offers Isaac in faith", new ObedienceToGod(), new Trust());
+
+            OracleHarness.Sin(crude);
+            OracleHarness.Righteous(faithful);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/AmosNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/AmosNarrativeTests.cs
@@ -1,0 +1,173 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Amos narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class AmosNarrativeTests
+    {
+        [Fact]
+        public void TheLordRoarsFromZionAndJudgesTheNations_IsADivineAct()
+        {
+            // "The LORD will roar from Zion ... For three transgressions of Damascus, and for four." (Amos 1:2-3)
+            // God, the righteous Judge of all peoples, declares just recompense on the surrounding nations.
+            OracleHarness.DivineAct(OracleHarness.Witness("The LORD roars from Zion and judges the transgressions of the nations",
+                new Righteousness(), new JustRecompense(), new TeachingTruth(),
+                new RejoicingInTruth(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void AmmonRipsOpenPregnantWomenToEnlargeItsBorder_IsSin()
+        {
+            // "because they have ripped up the women with child of Gilead, that they might enlarge their border." (Amos 1:13)
+            // Ammon sheds innocent blood in greed for territory, an atrocity God will not let pass.
+            Resolution r = OracleHarness.Grounded("Ammon rips open the pregnant women of Gilead to enlarge its border",
+                Grounding.InIdol("Molech"),
+                new Bloodshed(), new Murder(), new Greed(),
+                new Oppression(), new Lawlessness());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void MoabBurnsTheBonesOfTheKingOfEdomToLime_IsSin()
+        {
+            // "because he burned the bones of the king of Edom into lime." (Amos 2:1)
+            // Moab desecrates the dead in vengeful hatred, defiling what God says is His to judge.
+            OracleHarness.Sin(OracleHarness.Grounded("Moab burns the bones of the king of Edom into lime",
+                Grounding.InIdol("Chemosh"),
+                new Defilement(), new Hatred(), new Treachery(),
+                new Rebellion(), new Insolence()));
+        }
+
+        [Fact]
+        public void IsraelSellsTheRighteousForSilverAndTheNeedyForShoes_IsSin()
+        {
+            // "they sold the righteous for silver, and the poor for a pair of shoes." (Amos 2:6-7)
+            // Israel monetizes justice, crushing the head of the poor into the dust of the earth.
+            Resolution r = OracleHarness.Grounded("Israel sells the righteous for silver and the needy for a pair of shoes",
+                Grounding.InIdol("greed for gain"),
+                new Oppression(), new Greed(), new WithholdingWhatIsDue(),
+                new Heartlessness(), new Lawlessness());
+            OracleHarness.Sin(r);
+        }
+
+        [Fact]
+        public void FatherAndSonGoInToTheSameGirlAndProfaneGodsName_IsSin()
+        {
+            // "a man and his father will go in unto the same maid, to profane my holy name." (Amos 2:7-8)
+            // Sexual defilement and idolatrous feasting on pledged garments profane the holy name of God.
+            OracleHarness.Sin(OracleHarness.Grounded("Father and son defile the same girl and feast on pledged garments by every altar",
+                Grounding.InIdol("the altars of the high places"),
+                new SexualImmorality(), new Defilement(), new Blasphemy(),
+                new Idolatry(), new Impurity()));
+        }
+
+        [Fact]
+        public void GodRemindsIsraelHeBroughtThemUpFromEgypt_IsADivineAct()
+        {
+            // "I brought you up from the land of Egypt, and led you forty years through the wilderness." (Amos 2:10)
+            // God recalls His saving deliverance and faithful provision, the ground of His covenant claim.
+            OracleHarness.DivineAct(OracleHarness.Witness("God reminds Israel He delivered them from Egypt and led them through the wilderness",
+                new Deliverance(), new CovenantFaithfulness(), new Protection(),
+                new PromiseFulfilled(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheLordRevealsHisSecretToHisServantsTheProphets_IsADivineAct()
+        {
+            // "Surely the Lord GOD will do nothing, but he revealeth his secret unto his servants the prophets." (Amos 3:7)
+            // God graciously discloses His purposes through the prophets, teaching truth before judgment falls.
+            OracleHarness.DivineAct(OracleHarness.Witness("The Lord reveals His secret counsel to His servants the prophets",
+                new TeachingTruth(), new RejoicingInTruth(), new Fidelity(),
+                new CovenantFaithfulness(), new Goodness()));
+        }
+
+        [Fact]
+        public void TheCowsOfBashanOppressThePoorAndCrushTheNeedy_IsSin()
+        {
+            // "ye kine of Bashan ... which oppress the poor, which crush the needy." (Amos 4:1)
+            // The pampered women of Samaria demand drink while grinding down the poor in luxury and excess.
+            OracleHarness.Sin(OracleHarness.Grounded("The cows of Bashan oppress the poor and crush the needy to fund their feasting",
+                Grounding.InIdol("Samaria's luxury"),
+                new Oppression(), new Greed(), new Drunkenness(),
+                new Heartlessness(), new Indifference()));
+        }
+
+        [Fact]
+        public void AmosCallsIsraelToSeekTheLordAndLive_IsRighteous()
+        {
+            // "Seek ye me, and ye shall live ... Seek good, and not evil, that ye may live." (Amos 5:4,14)
+            // The prophet pleads with Israel to turn from death to life by seeking the LORD and good.
+            OracleHarness.Righteous(OracleHarness.Witness("Amos calls Israel to seek the LORD and seek good that they may live",
+                new Repentance(), new TeachingTruth(), new HungerForRighteousness(),
+                new Worship(), new Goodness()));
+        }
+
+        [Fact]
+        public void GodCommandsJusticeToRollDownLikeWaters_IsADivineAct()
+        {
+            // "let judgment run down as waters, and righteousness as a mighty stream." (Amos 5:24)
+            // God rejects empty festivals and demands a flood of justice and unending righteousness instead.
+            OracleHarness.DivineAct(OracleHarness.Witness("God commands that justice roll down like waters and righteousness like a mighty stream",
+                new Righteousness(), new JustRecompense(), new DefendingTheWeak(),
+                new TeachingTruth(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void TheComplacentAtEaseInZionLieOnIvoryBedsAndIgnoreTheRuin_IsSin()
+        {
+            // "that lie upon beds of ivory ... but they are not grieved for the affliction of Joseph." (Amos 6:1-6)
+            // The idle rich indulge in luxury, drink, and music, heedless of the coming ruin of the nation.
+            OracleHarness.Sin(OracleHarness.Grounded("Those at ease in Zion lie on ivory beds and drink wine, unmoved by the ruin of Joseph",
+                Grounding.InIdol("self-indulgent ease"),
+                new Pride(), new Indifference(), new Drunkenness(),
+                new Gluttony(), new Sloth()));
+        }
+
+        [Fact]
+        public void AmosIntercedesAndAsksGodToForgiveJacobWhoIsSmall_IsRighteous()
+        {
+            // "O Lord GOD, forgive, I beseech thee: by whom shall Jacob arise? for he is small." (Amos 7:2,5)
+            // Seeing the locust and fire, the prophet pleads for mercy, and the LORD relents from the judgment.
+            OracleHarness.Righteous(OracleHarness.Witness("Amos intercedes for small Jacob and pleads with God to forgive",
+                new Compassion(), new HonoringTheVulnerable(), new Humility(),
+                new Trust(), new DefendingTheWeak()));
+        }
+
+        [Fact]
+        public void AmaziahThePriestOpposesTheProphetAndTellsHimToFlee_IsSin()
+        {
+            // "O thou seer, go, flee thee away ... but prophesy not again any more at Bethel." (Amos 7:10-13)
+            // The priest of Bethel slanders Amos to the king and silences God's word for the sake of the shrine.
+            OracleHarness.Sin(OracleHarness.Grounded("Amaziah the priest opposes Amos, slanders him to the king, and forbids him to prophesy at Bethel",
+                Grounding.InIdol("the king's sanctuary at Bethel"),
+                new Slander(), new Rebellion(), new Idolatry(),
+                new Pride(), new Disobedience()));
+        }
+
+        [Fact]
+        public void MerchantsWaitToCheatWithFalseScalesAndSellTheRefuseOfWheat_IsSin()
+        {
+            // "Making the ephah small, and the shekel great, and falsifying the balances by deceit." (Amos 8:4-6)
+            // Greedy traders rig the scales, sell chaff for grain, and buy the poor for silver and sandals.
+            OracleHarness.Sin(OracleHarness.Grounded("Merchants falsify the balances by deceit and sell the refuse of wheat to buy the poor",
+                Grounding.InIdol("dishonest gain"),
+                new Deceit(), new Greed(), new Oppression(),
+                new WithholdingWhatIsDue(), new Lawlessness()));
+        }
+
+        [Fact]
+        public void GodPromisesToRaiseUpTheFallenTabernacleOfDavidAndRestoreHisPeople_IsADivineAct()
+        {
+            // "In that day will I raise up the tabernacle of David that is fallen ... I will bring again the captivity." (Amos 9:11-15)
+            // After judgment, God pledges to rebuild David's fallen house and plant His people never to be uprooted.
+            OracleHarness.DivineAct(OracleHarness.Witness("God promises to raise up the fallen tabernacle of David and restore the fortunes of His people",
+                new RestoringLife(), new PromiseFulfilled(), new CovenantFaithfulness(),
+                new Healing(), new Compassion()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/BaruchNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/BaruchNarrativeTests.cs
@@ -1,0 +1,129 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Baruch narrative oracle: the engine must return the verdict Scripture gives at each step.
+    // Canon: EO (Eastern-Orthodox-accepted). Chapter 6 is the Letter of Jeremiah, counted within Baruch.
+    public class BaruchNarrativeTests
+    {
+        [Fact]
+        public void ExilesHearTheBookAndWeepFastAndPray_IsRighteous()
+        {
+            // When they heard Baruch's words, "they wept, and fasted, and prayed before the Lord."
+            // (Baruch 1:1-5)
+            // A humbled, mourning people turning to the Lord in repentance.
+            OracleHarness.Righteous(OracleHarness.Witness("the exiles hear Baruch's book and weep, fast, and pray before the Lord",
+                new Mourning(), new Humility(), new Repentance(), new Worship(), new Trust()));
+        }
+
+        [Fact]
+        public void ExilesSendMoneyToJerusalemForSacrificesAndIntercession_IsRighteous()
+        {
+            // They gather money and send it to Jerusalem to buy burnt offerings and to pray for
+            // the life of Nebuchadnezzar and for themselves. (Baruch 1:6-14)
+            // Generous, worshipful provision and intercession for the welfare of others.
+            OracleHarness.Righteous(OracleHarness.Witness("the exiles send money to Jerusalem for sacrifices and pray for the people",
+                new Generosity(), new Worship(), new ObedienceToGod(), new Peacemaking()));
+        }
+
+        [Fact]
+        public void IsraelConfessesCovenantBreakingAndDisobedience_IsSin()
+        {
+            // "To the Lord our God belongeth righteousness, but unto us confusion of faces ... we have
+            // sinned, we have done wickedly ... and have not been obedient unto the Lord our God."
+            // (Baruch 1:15-2:10)
+            // Israel names the very sin that brought the exile: rebellion against the covenant.
+            OracleHarness.Sin(OracleHarness.Witness("Israel confesses its covenant-breaking and disobedience to the Lord",
+                new CovenantBreaking(), new Disobedience(), new Rebellion(), new Idolatry()));
+        }
+
+        [Fact]
+        public void IsraelPraysForMercyAppealingToGodsCovenant_IsRighteous()
+        {
+            // "Hear our prayers, O Lord ... according to all thy righteousness ... remember not the
+            // iniquities of our forefathers." (Baruch 2:11-3:8)
+            // A penitent appeal resting wholly on God's covenant faithfulness and mercy.
+            OracleHarness.Righteous(OracleHarness.Grounded("Israel prays for mercy, appealing to God's covenant",
+                Grounding.InGod(),
+                new Repentance(), new Humility(), new Trust(), new CovenantFaithfulness(), new Worship()));
+        }
+
+        [Fact]
+        public void IsraelForsakesTheFountainOfWisdom_IsSin()
+        {
+            // "Thou hast forsaken the fountain of wisdom. For if thou hadst walked in the way of God,
+            // thou shouldest have dwelled in peace for ever." (Baruch 3:9-13)
+            // The rebuke: Israel abandoned the wisdom and commandments of God.
+            OracleHarness.Sin(OracleHarness.Witness("Israel forsakes the fountain of wisdom and walks not in God's way",
+                new Disobedience(), new Rebellion(), new CovenantBreaking()));
+        }
+
+        [Fact]
+        public void GodAloneFindsOutWisdomAndGivesHerToJacob_IsADivineAct()
+        {
+            // "He hath found out all the way of knowledge, and hath given it unto Jacob his servant ...
+            // afterward did he shew himself upon earth." (Baruch 3:36-4:1)
+            // God Himself reveals wisdom, the book of the commandments, to His people.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God finds out all wisdom and gives her to Jacob His servant",
+                Grounding.InGod(),
+                new TeachingTruth(), new CreationOrder(), new CovenantFaithfulness(), new Goodness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void BaruchExhortsIsraelToHoldFastWisdomAndLive_IsRighteous()
+        {
+            // "Turn thee, O Jacob, and take hold of it: walk in the presence of the light thereof,
+            // that thou mayest be illuminated." (Baruch 4:2-4)
+            // A call to obedient return to God's commandments, the way of life.
+            OracleHarness.Righteous(OracleHarness.Witness("Baruch exhorts Israel to take hold of wisdom and walk in God's light",
+                new TeachingTruth(), new ObedienceToGod(), new Repentance(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void ZionMournsButCallsHerChildrenToHopeInGod_IsRighteous()
+        {
+            // Jerusalem laments her exiled children yet comforts them: "Be of good cheer, O my children,
+            // and cry unto God." (Baruch 4:9-29)
+            // Maternal mourning joined to a steadfast call to repentance and trust.
+            OracleHarness.Righteous(OracleHarness.Witness("Zion mourns her exiled children and calls them to cry unto God",
+                new Mourning(), new Compassion(), new Repentance(), new Trust(), new TeachingTruth()));
+        }
+
+        [Fact]
+        public void GodPromisesToBringTheExilesHomeInGloryAndJoy_IsADivineAct()
+        {
+            // "Arise, O Jerusalem ... God will bring them unto thee with glory ... for God will lead
+            // Israel with joy in the light of his glory with the mercy and righteousness that cometh
+            // from him." (Baruch 4:30-5:9)
+            // God's saving promise: He gathers His scattered people in mercy and righteousness.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God promises to gather the exiles home in glory, mercy, and joy",
+                Grounding.InGod(),
+                new Deliverance(), new PromiseFulfilled(), new CovenantFaithfulness(),
+                new Compassion(), new Righteousness(), new Joy()));
+        }
+
+        [Fact]
+        public void ThePeopleAreWarnedThatBabylonianIdolsAreNoGods_IsRighteous()
+        {
+            // The Letter of Jeremiah warns the exiles: "be not ye afraid of them ... how should a man
+            // think or say that they are gods?" (Baruch 6:4-23)
+            // True teaching that exposes idols as powerless, guarding the people from false worship.
+            OracleHarness.Righteous(OracleHarness.Witness("the exiles are warned that the idols of Babylon are no gods",
+                new TeachingTruth(), new RejoicingInTruth(), new Protection(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void BabylonWorshipsLifelessIdolsAndPracticesDefilement_IsSin()
+        {
+            // The idols are decked with gold and silver, cannot save, and "the women ... sit in the ways"
+            // and burn bran for incense to them while the priests rob their temples. (Baruch 6:8-33)
+            // Idolatry, deceit, theft, and sexual defilement bound up in Babylon's false worship.
+            OracleHarness.Sin(OracleHarness.Witness("Babylon worships lifeless idols with deceit, theft, and immorality",
+                new Idolatry(), new Deceit(), new Theft(), new SexualImmorality(), new Defilement()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/ChroniclesNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/ChroniclesNarrativeTests.cs
@@ -1,0 +1,161 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 1 & 2 Chronicles narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class ChroniclesNarrativeTests
+    {
+        [Fact]
+        public void SaulDiesForHisUnfaithfulnessAndConsultingAMedium_IsSin()
+        {
+            // "Saul died for his breach of faith ... and also because he consulted a medium ... and did not
+            // keep the command of the LORD." (1 Chronicles 10:13-14)
+            // Covenant treachery joined to sorcery and disobedience.
+            OracleHarness.Sin(OracleHarness.Witness("Saul breaks faith with God and consults a medium",
+                new CovenantBreaking(), new Sorcery(), new Disobedience(), new Treachery()));
+        }
+
+        [Fact]
+        public void DavidBringsUpTheArkWithWorshipAndRejoicing_IsRighteous()
+        {
+            // David brings the ark to Jerusalem with sacrifices, singing, and praise before God. (1 Chronicles 15-16)
+            // "Oh give thanks to the LORD ... sing to him, sing praises to him." (1 Chronicles 16:8-9)
+            OracleHarness.Righteous(OracleHarness.Witness("David brings up the ark with worship and rejoicing",
+                new Worship(), new Joy(), new ObedienceToGod(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void GodMakesAnEverlastingCovenantWithDavid_IsADivineAct()
+        {
+            // "I will raise up your offspring after you ... and I will establish his kingdom ... forever."
+            // (1 Chronicles 17:11-14) God's covenant promise to build David a house.
+            OracleHarness.DivineAct(OracleHarness.Witness("The LORD covenants to establish David's throne forever",
+                new CovenantFaithfulness(), new PromiseFulfilled(), new Fidelity(), new Goodness()));
+        }
+
+        [Fact]
+        public void DavidNumbersIsraelInProvocationFromSatan_IsSin()
+        {
+            // "Satan stood against Israel and incited David to number Israel." (1 Chronicles 21:1)
+            // A proud, faithless census provoking God; "this thing ... was evil in the sight of God." (21:7-8)
+            OracleHarness.Sin(OracleHarness.Witness("David proudly numbers Israel against God's will",
+                new Pride(), new Disobedience(), new Wrongdoing()));
+        }
+
+        [Fact]
+        public void DavidRepentsAndBuildsAnAltarToHaltThePlague_IsRighteous()
+        {
+            // "I have sinned greatly ... please take away the iniquity of your servant." (1 Chronicles 21:8)
+            // David buys the threshing floor, refuses to offer what costs nothing, and the plague is stayed. (21:24-27)
+            OracleHarness.Righteous(OracleHarness.Witness("David repents, builds the altar, and offers sacrifice",
+                new Repentance(), new Worship(), new Humility(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void SolomonAsksForWisdomToGovernGodsPeople_IsRighteous()
+        {
+            // "Give me now wisdom and knowledge to go out and come in before this people." (2 Chronicles 1:10)
+            // Solomon seeks not riches but discernment to serve; God commends the request. (1:11-12)
+            OracleHarness.Righteous(OracleHarness.Witness("Solomon asks God for wisdom to lead the people",
+                new Humility(), new Trust(), new ObedienceToGod(), new Worship()));
+        }
+
+        [Fact]
+        public void TheGloryOfTheLordFillsTheDedicatedTemple_IsADivineAct()
+        {
+            // "The glory of the LORD filled the house of God." (2 Chronicles 5:14; 7:1-3)
+            // God answers with fire and glory at the temple dedication.
+            OracleHarness.DivineAct(OracleHarness.Witness("The glory of the LORD fills Solomon's temple",
+                new CreationOrder(), new Goodness(), new PromiseFulfilled(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodPromisesToHealTheLandIfThePeopleHumbleThemselves_IsADivineAct()
+        {
+            // "If my people ... humble themselves, and pray ... then I will hear ... and heal their land."
+            // (2 Chronicles 7:14) God's gracious promise of pardon and healing for the repentant.
+            OracleHarness.DivineAct(OracleHarness.Witness("The LORD promises to forgive and heal a repentant people",
+                new Pardon(), new Healing(), new CovenantFaithfulness(), new Compassion()));
+        }
+
+        [Fact]
+        public void AsaRemovesTheIdolsAndSeeksTheLord_IsRighteous()
+        {
+            // Asa "took away the foreign altars ... and commanded Judah to seek the LORD." (2 Chronicles 14:2-4)
+            // Reform that tears down idolatry and turns the nation back to God.
+            OracleHarness.Righteous(OracleHarness.Witness("Asa removes the idols and leads Judah to seek God",
+                new Worship(), new ObedienceToGod(), new CourageousFaith(), new Righteousness()));
+        }
+
+        [Fact]
+        public void JehoshaphatTrustsGodAndIsDeliveredFromTheInvadingArmies_IsRighteous()
+        {
+            // "We do not know what to do, but our eyes are on you." (2 Chronicles 20:12) Judah fasts, worships,
+            // and stands still; the LORD sets ambushes and delivers them without a sword. (20:17-22)
+            OracleHarness.Righteous(OracleHarness.Witness("Jehoshaphat trusts the LORD and worships before battle",
+                new Trust(), new Worship(), new CourageousFaith(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void JoashMurdersZechariahThePriestWhoRebukedHim_IsSin()
+        {
+            // King Joash forgets the kindness of Jehoiada and has his son Zechariah stoned in the temple court.
+            // "May the LORD see and avenge!" (2 Chronicles 24:20-22) Ingratitude crowned with bloodshed.
+            Resolution r = OracleHarness.Witness("Joash has the priest Zechariah stoned to death",
+                new Murder(), new Bloodshed(), new Ingratitude(), new Treachery());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void AhazSacrificesHisSonsAndBurnsIncenseToOtherGods_IsSin()
+        {
+            // Ahaz "made metal images for the Baals ... and burned his sons as an offering." (2 Chronicles 28:2-4)
+            // Idolatry compounded by child sacrifice in the valley of Hinnom.
+            Resolution r = OracleHarness.Grounded("Ahaz burns his sons as offerings to idols", Grounding.InIdol("Baal"),
+                new ChildSacrifice(), new Idolatry(), new Bloodshed(), new Blasphemy());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void HezekiahCleansesTheTempleAndKeepsThePassover_IsRighteous()
+        {
+            // Hezekiah reopens and cleanses the house of the LORD and restores the Passover for all Israel.
+            // (2 Chronicles 29-30) "He did what was good and right and faithful before the LORD his God." (31:20)
+            OracleHarness.Righteous(OracleHarness.Witness("Hezekiah cleanses the temple and restores the Passover",
+                new Worship(), new ObedienceToGod(), new Righteousness(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void ManassehHumblesHimselfInPrisonAndIsRestored_IsRighteous()
+        {
+            // The captive Manasseh "humbled himself greatly ... and prayed to him ... and God ... brought him again."
+            // (2 Chronicles 33:12-13) Even the worst king's repentance is received.
+            OracleHarness.Righteous(OracleHarness.Witness("Manasseh humbles himself, repents, and turns back to God",
+                new Repentance(), new Humility(), new Worship(), new Trust()));
+        }
+
+        [Fact]
+        public void JosiahRenewsTheCovenantAtTheBookOfTheLaw_IsRighteous()
+        {
+            // Josiah hears the rediscovered Law, tears his clothes, and leads the people to keep the covenant.
+            // (2 Chronicles 34:29-33) He turned to the LORD with all his heart.
+            OracleHarness.Righteous(OracleHarness.Witness("Josiah renews the covenant and keeps the Law",
+                new Repentance(), new CovenantFaithfulness(), new ObedienceToGod(), new Humility()));
+        }
+
+        [Fact]
+        public void CyrusIsStirredToReleaseGodsPeopleToRebuildTheTemple_IsADivineAct()
+        {
+            // "The LORD stirred up the spirit of Cyrus ... 'let him go up.'" (2 Chronicles 36:22-23)
+            // God keeps his word through Jeremiah and delivers the exiles home.
+            OracleHarness.DivineAct(OracleHarness.Witness("The LORD stirs Cyrus to free the exiles to rebuild Jerusalem",
+                new Deliverance(), new PromiseFulfilled(), new CovenantFaithfulness(), new Fidelity()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/ChroniclesOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/ChroniclesOracleTests.cs
@@ -1,0 +1,40 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 11 & 12: 1 and 2 Chronicles.
+    public class ChroniclesOracleTests
+    {
+        [Fact]
+        public void DavidOrdersWholeheartedWorship_IsRighteous()
+        {
+            // David sets the worship of the LORD in order and gives wholeheartedly (1 Chronicles 16; 29).
+            OracleHarness.Righteous(OracleHarness.Witness("David orders the worship", new Worship(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void DavidsPridefulCensus_IsSin()
+        {
+            // Numbering the fighting men in pride, trusting strength over God (1 Chronicles 21).
+            OracleHarness.Sin(OracleHarness.Witness("David's prideful census", new Pride()));
+        }
+
+        [Fact]
+        public void IfMyPeopleHumbleThemselves_IsRighteous()
+        {
+            // "If my people ... will humble themselves and pray ... I will forgive." (2 Chronicles 7:14)
+            OracleHarness.Righteous(OracleHarness.Witness("the people humble themselves", new Repentance(), new Humility()));
+        }
+
+        [Fact]
+        public void ApostasyUnderWickedKings_IsSin()
+        {
+            // Manasseh and others lead Judah into idolatry and bloodshed (2 Chronicles 33).
+            OracleHarness.Sin(OracleHarness.Witness("Judah's apostasy", new Idolatry(), new Rebellion()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/ClementBookNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/ClementBookNarrativeTests.cs
@@ -1,0 +1,134 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Book of Clement (Ethiopic Mäshafä Qälemenṭos / Qalementos) narrative oracle:
+    // the engine must return the verdict Scripture gives at each step.
+    // Canon: ETH (Ethiopic-only; best-effort). The work is framed as the secret teaching the
+    // Lord gave to Peter, who delivers it to Clement; it retells creation, the watchers, the flood,
+    // the patriarchs and the priestly line, and closes with exhortation and warning.
+    public class ClementBookNarrativeTests
+    {
+        [Fact]
+        public void GodCreatesTheHeavensAndTheEarthInOrder_IsADivineAct()
+        {
+            // The book opens by retelling how God in His wisdom established the heavens, the earth,
+            // and every ordered creature (Qalementos, Book 1, the creation account).
+            // God's ordering of reality is the very pattern of coherence.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God creates the heavens and the earth and orders all things",
+                Grounding.InGod(),
+                new CreationOrder(), new Goodness(), new Fidelity(), new TeachingTruth()));
+        }
+
+        [Fact]
+        public void ChristEntrustsTheSecretTeachingToPeterForClement_IsADivineAct()
+        {
+            // The frame: the Lord delivers His hidden teaching to Peter, charging him to hand it to
+            // Clement so the truth is preserved for the church (Qalementos, Book 1, the commission).
+            // Christ teaching truth and entrusting His covenant word is a divine act.
+            OracleHarness.DivineAct(OracleHarness.Grounded("Christ entrusts His secret teaching to Peter to deliver to Clement",
+                Grounding.InGod(),
+                new TeachingTruth(), new CovenantFaithfulness(), new Trustworthiness(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void PeterFaithfullyHandsTheTeachingToClement_IsRighteous()
+        {
+            // Peter, obedient to the charge, writes and delivers the teaching to Clement
+            // (Qalementos, Book 1). A faithful steward passing on the deposit of truth.
+            OracleHarness.Righteous(OracleHarness.Witness("Peter faithfully writes and delivers the Lord's teaching to Clement",
+                new ObedienceToGod(), new Fidelity(), new TeachingTruth(), new Trustworthiness()));
+        }
+
+        [Fact]
+        public void TheWatchersDescendAndDefileTheDaughtersOfMen_IsSin()
+        {
+            // Retelling the fall of the watchers: the sons of heaven abandon their station, descend,
+            // and defile the daughters of men, teaching forbidden arts (Qalementos, the antediluvian
+            // history echoing 1 Enoch). Rebellion, immorality, defilement, and sorcery together.
+            Resolution r = OracleHarness.Witness("the watchers abandon heaven and defile the daughters of men, teaching forbidden arts",
+                new Rebellion(), new SexualImmorality(), new Defilement(), new Sorcery(), new Disobedience());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void TheEarthIsFilledWithBloodshedBeforeTheFlood_IsSin()
+        {
+            // The offspring of the watchers and the wickedness of men fill the earth with violence and
+            // blood, so that the ground itself cries out (Qalementos, the corruption before the flood).
+            // Capital bloodshed drives reality to full disorder.
+            Resolution r = OracleHarness.Witness("the earth is filled with violence and bloodshed before the flood",
+                new Bloodshed(), new Murder(), new Lawlessness(), new Chaos(), new Oppression());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void NoahWalksWithGodAndIsFoundRighteous_IsRighteous()
+        {
+            // Amid the corruption, Noah alone is found upright and obedient, walking with God
+            // (Qalementos, the Noah narrative). A righteous remnant clinging to obedience and trust.
+            OracleHarness.Righteous(OracleHarness.Witness("Noah walks with God and is found righteous in his generation",
+                new Righteousness(), new ObedienceToGod(), new Fidelity(), new Trust(), new Purity()));
+        }
+
+        [Fact]
+        public void GodPreservesNoahThroughTheFloodAndRenewsTheCovenant_IsADivineAct()
+        {
+            // God shuts Noah in the ark, delivers him and his house through the waters, and afterward
+            // renews His covenant with the earth (Qalementos, the flood and the covenant of Noah).
+            // Deliverance and a kept promise are a divine act.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God delivers Noah through the flood and renews His covenant",
+                Grounding.InGod(),
+                new Deliverance(), new Protection(), new CovenantFaithfulness(), new PromiseFulfilled(), new Compassion()));
+        }
+
+        [Fact]
+        public void GodAppointsThePriestlyLineToGuardWorshipAndTruth_IsADivineAct()
+        {
+            // The book traces how God sets apart the priestly order to guard true worship and to teach
+            // His commandments to the people (Qalementos, the priesthood material drawn into the Sinodos).
+            // God establishing right worship and ordered teaching is a divine act.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God appoints the priestly line to guard worship and teach His commandments",
+                Grounding.InGod(),
+                new Worship(), new CreationOrder(), new TeachingTruth(), new CovenantFaithfulness(), new Righteousness()));
+        }
+
+        [Fact]
+        public void TheNationsTurnToIdolsAndForbiddenWorship_IsSin()
+        {
+            // After the flood the book laments how the nations forsake the living God and bow to idols,
+            // mingling worship with sorcery and deceit (Qalementos, the apostasy of the nations).
+            // Idolatry and its attendant lies disorder reality.
+            OracleHarness.Sin(OracleHarness.Grounded("the nations forsake God and turn to idols and forbidden worship",
+                Grounding.InIdol("the idols of the nations"),
+                new Idolatry(), new Sorcery(), new Deceit(), new Rebellion(), new CovenantBreaking()));
+        }
+
+        [Fact]
+        public void PeterExhortsTheChurchToRepentanceAndHolyLiving_IsRighteous()
+        {
+            // The teaching turns to exhortation: Peter calls the faithful to repent, keep purity, and
+            // endure in obedience until the Lord's appearing (Qalementos, the closing exhortation).
+            // A pastoral summons to repentance, purity, and steadfastness.
+            OracleHarness.Righteous(OracleHarness.Witness("Peter exhorts the church to repentance, purity, and patient endurance",
+                new Repentance(), new Purity(), new Endurance(), new ObedienceToGod(), new TeachingTruth()));
+        }
+
+        [Fact]
+        public void TheLordPromisesToJudgeTheWickedAndRewardTheRighteous_IsADivineAct()
+        {
+            // The book closes with apocalyptic promise: the Lord will come to render just recompense,
+            // delivering the righteous and judging the wicked (Qalementos, the eschatological warning).
+            // Just judgment and the deliverance of His own is a divine act.
+            OracleHarness.DivineAct(OracleHarness.Grounded("the Lord promises just judgment of the wicked and deliverance of the righteous",
+                Grounding.InGod(),
+                new JustRecompense(), new Righteousness(), new Deliverance(), new PromiseFulfilled(), new Fidelity()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/ColossiansNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/ColossiansNarrativeTests.cs
@@ -1,0 +1,103 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Colossians narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class ColossiansNarrativeTests
+    {
+        [Fact]
+        public void ChristIsTheImageAndAllThingsCreatedInHim_IsADivineAct()
+        {
+            // "He is the image of the invisible God ... by him all things were created." (Colossians 1:15-17)
+            OracleHarness.DivineAct(OracleHarness.Witness("in Christ all things are created and hold together", new CreationOrder()));
+        }
+
+        [Fact]
+        public void ChristReconcilesAllThingsByTheBloodOfHisCross_IsADivineAct()
+        {
+            // "making peace through his blood, shed on the cross." (Colossians 1:19-22)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ reconciles all things by the blood of the cross", new Atonement(), new Peacemaking(), new Deliverance()));
+        }
+
+        [Fact]
+        public void ChristCancelsTheRecordOfDebtNailingItToTheCross_IsADivineAct()
+        {
+            // "He forgave us all our sins, having canceled the charge of our legal indebtedness ... nailing it to the cross." (Colossians 2:13-15)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ forgives all sins and cancels the record of debt", new Forgiveness(), new Pardon()));
+        }
+
+        [Fact]
+        public void PaulRejoicesInHisSufferingsForTheChurch_IsRighteous()
+        {
+            // "Now I rejoice in what I am suffering for you, and I fill up ... Christ's afflictions, for the sake of his body." (Colossians 1:24)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul rejoices in his sufferings for the church", new SelfSacrifice(), new Joy()));
+        }
+
+        [Fact]
+        public void HollowAndDeceptivePhilosophyOfHumanTradition_IsSin()
+        {
+            // "See to it that no one takes you captive through hollow and deceptive philosophy." (Colossians 2:8)
+            OracleHarness.Sin(OracleHarness.Witness("captive minds seduced by hollow and deceptive philosophy", new Deceit()));
+        }
+
+        [Fact]
+        public void WorshipOfAngelsAndFalseHumility_IsSin()
+        {
+            // "Do not let anyone ... delights in false humility and the worship of angels." (Colossians 2:18)
+            OracleHarness.Sin(OracleHarness.Witness("the worship of angels with false humility and unspiritual pride", new Idolatry(), new Pride()));
+        }
+
+        [Fact]
+        public void SexualImmoralityImpurityAndLustOfTheEarthlyNature_IsSin()
+        {
+            // "Put to death ... sexual immorality, impurity, lust, evil desires and greed, which is idolatry." (Colossians 3:5)
+            OracleHarness.Sin(OracleHarness.Witness("the earthly nature of immorality, impurity, lust, and greed", new SexualImmorality(), new Impurity(), new Lust(), new Greed()));
+        }
+
+        [Fact]
+        public void AngerRageMaliceAndSlander_IsSin()
+        {
+            // "But now you must also rid yourselves of all such things as these: anger, rage, malice, slander, and filthy language." (Colossians 3:8)
+            OracleHarness.Sin(OracleHarness.Witness("anger, rage, malice, slander, and filthy language from the lips", new FitsOfRage(), new Malice(), new Slander(), new FilthyLanguage()));
+        }
+
+        [Fact]
+        public void PuttingOnCompassionKindnessHumilityAndGentleness_IsRighteous()
+        {
+            // "Clothe yourselves with compassion, kindness, humility, gentleness and patience." (Colossians 3:12)
+            OracleHarness.Righteous(OracleHarness.Witness("the chosen clothe themselves in compassion, kindness, humility, gentleness, and patience", new Compassion(), new Kindness(), new Humility(), new Gentleness(), new Patience()));
+        }
+
+        [Fact]
+        public void BearingWithAndForgivingOneAnotherAsTheLordForgave_IsRighteous()
+        {
+            // "Bear with each other and forgive one another ... Forgive as the Lord forgave you." (Colossians 3:13)
+            OracleHarness.Righteous(OracleHarness.Witness("the church bears with and forgives one another as the Lord forgave", new Forgiveness(), new Patience()));
+        }
+
+        [Fact]
+        public void LettingThePeaceOfChristRuleWithThankfulness_IsRighteous()
+        {
+            // "Let the peace of Christ rule in your hearts ... And be thankful." (Colossians 3:15)
+            OracleHarness.Righteous(OracleHarness.Witness("the peace of Christ rules the heart in unity and thankfulness", new Peace(), new Peacemaking()));
+        }
+
+        [Fact]
+        public void DoingAllInTheNameOfTheLordWithThanksgiving_IsRighteous()
+        {
+            // "Whatever you do, whether in word or deed, do it all in the name of the Lord Jesus, giving thanks." (Colossians 3:17)
+            OracleHarness.Righteous(OracleHarness.Witness("believers do all in the name of the Lord, giving thanks to God", new Worship(), new Fidelity()));
+        }
+
+        [Fact]
+        public void DevotingToPrayerWatchfulAndThankful_IsRighteous()
+        {
+            // "Devote yourselves to prayer, being watchful and thankful." (Colossians 4:2)
+            OracleHarness.Righteous(OracleHarness.Witness("the church devotes itself to prayer, watchful and thankful", new Worship(), new Endurance()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/ConceptCoverageTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/ConceptCoverageTests.cs
@@ -1,0 +1,109 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-12
+// Stewarded by Alexander Fields
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    /// <summary>
+    /// The completeness guard: reflects over EVERY moral concept in the engine and proves none is a
+    /// dead stub. Each must be instantiable, name itself, cite Scripture, and actually be wired to
+    /// God's character (uphold or violate at least one facet). Vices must violate; virtues and
+    /// mysteries must uphold. This is the automated answer to "is anything missing or half-built": if
+    /// a concept exists but bears on nothing, this test fails.
+    /// </summary>
+    public class ConceptCoverageTests
+    {
+        private static IEnumerable<MoralConcept> AllConcepts()
+        {
+            Type baseType = typeof(MoralConcept);
+            return baseType.Assembly.GetTypes()
+                .Where(t => !t.IsAbstract && baseType.IsAssignableFrom(t))
+                .Select(t => (MoralConcept)Activator.CreateInstance(t));
+        }
+
+        private static DivineAttribute[] Facets()
+        {
+            return new DivineAttribute[] { new LoveFacet(), new Justice(), new Mercy(), new Faithfulness() };
+        }
+
+        [Fact]
+        public void TheEngineHasASubstantialBodyOfConcepts()
+        {
+            // Sanity floor: the canon census + per-book agents produced a large vocabulary.
+            Assert.True(AllConcepts().Count() >= 100, "Expected at least 100 moral concepts.");
+        }
+
+        [Fact]
+        public void EveryConcept_NamesItselfAndCitesScripture()
+        {
+            foreach (MoralConcept concept in AllConcepts())
+            {
+                Assert.False(string.IsNullOrWhiteSpace(concept.Name),
+                    concept.GetType().Name + " has no Name.");
+                Assert.False(string.IsNullOrWhiteSpace(concept.Scripture),
+                    concept.GetType().Name + " cites no Scripture.");
+            }
+        }
+
+        [Fact]
+        public void EveryConcept_BearsOnGodsCharacter()
+        {
+            DivineAttribute[] facets = Facets();
+            foreach (MoralConcept concept in AllConcepts())
+            {
+                bool wired = facets.Any(f => concept.Upholds(f) || concept.Violates(f));
+                Assert.True(wired, concept.GetType().Name + " touches no facet of God's character.");
+            }
+        }
+
+        [Fact]
+        public void EveryVice_Violates_AndEveryVirtueOrMystery_Upholds()
+        {
+            DivineAttribute[] facets = Facets();
+            foreach (MoralConcept concept in AllConcepts())
+            {
+                bool upholds = facets.Any(f => concept.Upholds(f));
+                bool violates = facets.Any(f => concept.Violates(f));
+
+                if (concept.Gravity == Gravity.None)
+                {
+                    // A virtue or a sacred mystery: it embodies God's character, it does not offend it.
+                    Assert.True(upholds, concept.GetType().Name + " has no gravity but upholds nothing.");
+                    Assert.False(violates, concept.GetType().Name + " has no gravity yet violates a facet.");
+                }
+                else
+                {
+                    // A sin: its gravity must answer to a real offence against God's character.
+                    Assert.True(violates, concept.GetType().Name + " has gravity but violates nothing.");
+                }
+            }
+        }
+
+        [Fact]
+        public void EveryConcept_ResolvesToTheRightSideOfTheVerdict()
+        {
+            // The deepest check: run each concept through the engine alone and confirm a virtue/mystery
+            // never disorders reality, and a sin always does.
+            foreach (MoralConcept concept in AllConcepts())
+            {
+                Resolution r = Reality.Revealed().Witness(new Act(concept.Name, concept));
+
+                if (concept.Gravity == Gravity.None)
+                {
+                    Assert.Equal(0.0, r.Disorder);
+                    Assert.True(r.Coherence >= 0.5, concept.GetType().Name + " is a virtue but reads incoherent.");
+                }
+                else
+                {
+                    Assert.True(r.Disorder > 0.0, concept.GetType().Name + " is a sin but disorders nothing.");
+                    Assert.True(r.Coherence < 0.5, concept.GetType().Name + " is a sin but reads coherent.");
+                }
+            }
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/DanielNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/DanielNarrativeTests.cs
@@ -1,0 +1,134 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Daniel narrative oracle (Eastern-Orthodox, including the canonical Greek additions: Song of the Three,
+    // Susanna, and Bel and the Dragon): the engine must return the verdict Scripture gives at each step.
+    public class DanielNarrativeTests
+    {
+        [Fact]
+        public void DanielResolvesNotToDefileHimselfWithTheKingsFood_IsRighteous()
+        {
+            // Daniel purposes in his heart not to defile himself with the king's meat and wine (Daniel 1:8-16).
+            OracleHarness.Righteous(OracleHarness.Witness("Daniel refuses the king's defiling food to keep faithful",
+                new SelfControl(), new Fidelity(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void GodRevealsNebuchadnezzarsDreamToDaniel_IsADivineAct()
+        {
+            // The mystery is revealed to Daniel in a night vision; God alone reveals deep and secret things (Daniel 2:19-23, 27-28).
+            OracleHarness.DivineAct(OracleHarness.Grounded("God reveals the king's dream and its meaning to Daniel",
+                Grounding.InGod(), new TeachingTruth(), new RejoicingInTruth(), new Goodness()));
+        }
+
+        [Fact]
+        public void DanielGivesThanksAndAscribesWisdomToGod_IsRighteous()
+        {
+            // Daniel blesses the God of heaven, ascribing the wisdom and the revelation to Him, not himself (Daniel 2:20-23).
+            OracleHarness.Righteous(OracleHarness.Witness("Daniel blesses God and gives Him the glory for the revelation",
+                new Worship(), new Humility(), new Trust()));
+        }
+
+        [Fact]
+        public void TheThreeHebrewsRefuseToWorshipTheGoldenImage_IsRighteous()
+        {
+            // Shadrach, Meshach, and Abednego will not bow to the golden image, choosing the furnace over idolatry (Daniel 3:13-18).
+            OracleHarness.Righteous(OracleHarness.Witness("the three refuse to worship the golden image, ready to die",
+                new CourageousFaith(), new ObedienceToGod(), new SelfSacrifice(), new Fidelity()));
+        }
+
+        [Fact]
+        public void NebuchadnezzarErectsTheGoldenImageAndCommandsAllToWorshipIt_IsSin()
+        {
+            // The king sets up a golden image and decrees that all peoples must fall down and worship it (Daniel 3:1-7).
+            OracleHarness.Sin(OracleHarness.Witness("Nebuchadnezzar commands all to worship his golden image",
+                new Idolatry(), new Pride(), new Oppression()));
+        }
+
+        [Fact]
+        public void GodDeliversTheThreeFromTheFieryFurnace_IsADivineAct()
+        {
+            // A fourth like a son of the gods walks in the fire with them, and they come out unharmed (Daniel 3:24-27).
+            OracleHarness.DivineAct(OracleHarness.Grounded("God walks in the furnace and delivers the three unharmed",
+                Grounding.InGod(), new Deliverance(), new Protection(), new Fidelity()));
+        }
+
+        [Fact]
+        public void DanielCounselsNebuchadnezzarToBreakOffSinByRighteousness_IsRighteous()
+        {
+            // Daniel urges the king to break off his sins by righteousness and his iniquities by mercy to the poor (Daniel 4:27).
+            OracleHarness.Righteous(OracleHarness.Witness("Daniel counsels the king to turn from sin by righteousness and mercy to the poor",
+                new TeachingTruth(), new Righteousness(), new Generosity(), new Compassion()));
+        }
+
+        [Fact]
+        public void BelshazzarDesecratesTheTempleVesselsAndPraisesIdols_IsSin()
+        {
+            // Belshazzar drinks from the holy vessels of the temple while praising gods of gold and silver (Daniel 5:1-4, 22-23).
+            OracleHarness.Sin(OracleHarness.Witness("Belshazzar profanes the temple vessels and praises idols",
+                new Defilement(), new Idolatry(), new Pride(), new Blasphemy()));
+            // Defilement is a capital vice and drives disorder to its maximum.
+        }
+
+        [Fact]
+        public void TheSatrapsConspireFalselyToCondemnDaniel_IsSin()
+        {
+            // The officials, finding no fault in Daniel, scheme to trap him through a law about his prayer (Daniel 6:4-9).
+            OracleHarness.Sin(OracleHarness.Witness("the satraps conspire with a false decree to destroy Daniel",
+                new WickedScheming(), new FalseWitness(), new Envy(), new Treachery()));
+        }
+
+        [Fact]
+        public void DanielPraysToGodThreeTimesDailyDespiteTheDecree_IsRighteous()
+        {
+            // Knowing the decree is signed, Daniel still kneels and prays toward Jerusalem as he always had (Daniel 6:10-11).
+            OracleHarness.Righteous(OracleHarness.Witness("Daniel prays to God three times daily despite the death decree",
+                new Worship(), new CourageousFaith(), new Fidelity(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void GodShutsTheLionsMouthsAndDeliversDaniel_IsADivineAct()
+        {
+            // God sends His angel to shut the lions' mouths, and Daniel is taken up unhurt because he trusted God (Daniel 6:19-23).
+            OracleHarness.DivineAct(OracleHarness.Grounded("God shuts the lions' mouths and delivers Daniel from the den",
+                Grounding.InGod(), new Deliverance(), new Protection(), new Fidelity()));
+        }
+
+        [Fact]
+        public void DanielExposesTheFraudOfBelsPriests_IsRighteous()
+        {
+            // Daniel reveals by the ashes on the floor that the priests of Bel, not the idol, ate the offerings (Daniel 14:10-22, Bel and the Dragon).
+            OracleHarness.Righteous(OracleHarness.Witness("Daniel exposes the deceit of Bel's priests by the secret footprints",
+                new TeachingTruth(), new RejoicingInTruth(), new Righteousness()));
+        }
+
+        [Fact]
+        public void SusannaRefusesTheEldersAndKeepsHerPurity_IsRighteous()
+        {
+            // Susanna refuses the two elders' demand, choosing to fall into their hands rather than sin against God (Daniel 13:22-23, Susanna).
+            OracleHarness.Righteous(OracleHarness.Witness("Susanna refuses the elders and keeps her purity though it may cost her life",
+                new Purity(), new CourageousFaith(), new SelfControl(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TheTwoEldersBearFalseWitnessAgainstSusanna_IsSin()
+        {
+            // The elders, rebuffed in their lust, lie in court to condemn the innocent Susanna to death (Daniel 13:36-41, Susanna).
+            OracleHarness.Sin(OracleHarness.Witness("the elders lust after and bear false witness against Susanna",
+                new Lust(), new FalseWitness(), new WickedScheming(), new Condemnation()));
+        }
+
+        [Fact]
+        public void DanielVindicatesSusannaByCrossExaminingTheElders_IsRighteous()
+        {
+            // The young Daniel separates the elders and convicts them by their contradiction, saving innocent blood (Daniel 13:45-62, Susanna).
+            OracleHarness.Righteous(OracleHarness.Witness("Daniel cross-examines the elders and vindicates the innocent Susanna",
+                new DefendingTheWeak(), new Righteousness(), new JustRecompense(), new Protection()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/DeuteronomyNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/DeuteronomyNarrativeTests.cs
@@ -1,0 +1,112 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Deuteronomy narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class DeuteronomyNarrativeTests
+    {
+        [Fact]
+        public void GodCommandsIsraelToPossessTheLandHePromised_IsDivineAct()
+        {
+            // "Behold, I have set the land before you: go in and possess the land which the LORD sware unto your fathers." (Deuteronomy 1:8)
+            OracleHarness.DivineAct(OracleHarness.Witness("God gives Israel the promised land sworn to the fathers", new PromiseFulfilled(), new CovenantFaithfulness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void IsraelRebelsAndRefusesToEnterAtKadesh_IsSin()
+        {
+            // "Ye rebelled against the commandment of the LORD your God: and ye believed him not." (Deuteronomy 1:26, 32)
+            OracleHarness.Sin(OracleHarness.Witness("Israel refuses to enter the land and distrusts the LORD", new Rebellion(), new Disobedience()));
+        }
+
+        [Fact]
+        public void GodCaresForIsraelFortyYearsInTheWilderness_IsDivineAct()
+        {
+            // "These forty years the LORD thy God hath been with thee; thou hast lacked nothing." (Deuteronomy 2:7; 8:4)
+            OracleHarness.DivineAct(OracleHarness.Witness("God provides for Israel forty years so they lack nothing", new Fidelity(), new Compassion(), new Protection()));
+        }
+
+        [Fact]
+        public void GodGivesTheTenCommandmentsAtHoreb_IsDivineAct()
+        {
+            // "The LORD made a covenant with us in Horeb... and he wrote them in two tables of stone." (Deuteronomy 5:2-22)
+            OracleHarness.DivineAct(OracleHarness.Witness("God speaks the Ten Commandments and his covenant at Horeb", new CovenantFaithfulness(), new TeachingTruth(), new Righteousness()));
+        }
+
+        [Fact]
+        public void TheShemaCommandsWholeHeartedLoveAndWorshipOfGod_IsRighteous()
+        {
+            // "Hear, O Israel: The LORD our God is one LORD: and thou shalt love the LORD thy God with all thine heart." (Deuteronomy 6:4-5)
+            OracleHarness.Righteous(OracleHarness.Witness("Israel is called to love and worship the one LORD with all the heart", new Worship(), new ObedienceToGod(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void GodChoosesIsraelInLoveNotForTheirGreatness_IsDivineAct()
+        {
+            // "The LORD did not set his love upon you... because ye were more in number... but because the LORD loved you." (Deuteronomy 7:7-9)
+            OracleHarness.DivineAct(OracleHarness.Witness("God sets his love on Israel and keeps his oath to the fathers", new CovenantFaithfulness(), new Compassion(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void IsraelIsCommandedToOpenTheirHandToThePoor_IsRighteous()
+        {
+            // "Thou shalt open thine hand wide unto thy brother, to thy poor, and to thy needy." (Deuteronomy 15:7-11)
+            OracleHarness.Righteous(OracleHarness.Witness("Israel opens its hand wide to the poor and the needy", new Generosity(), new Compassion(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void IsraelMustDefendTheFatherlessWidowAndStranger_IsRighteous()
+        {
+            // "He doth execute the judgment of the fatherless and widow, and loveth the stranger... Love ye therefore the stranger." (Deuteronomy 10:18-19; 24:17)
+            OracleHarness.Righteous(OracleHarness.Witness("Israel does justice for the fatherless, the widow, and the stranger", new DefendingTheWeak(), new HonoringTheVulnerable(), new Kindness()));
+        }
+
+        [Fact]
+        public void PassingChildrenThroughTheFireToIdols_IsSin()
+        {
+            // "There shall not be found among you any one that maketh his son or his daughter to pass through the fire." (Deuteronomy 18:10; 12:31)
+            Resolution r = OracleHarness.Grounded("the nations burn their sons and daughters to false gods", Grounding.InIdol("Molech"), new ChildSacrifice(), new Idolatry(), new Bloodshed());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void ProvidingCitiesOfRefugeToSpareInnocentBlood_IsRighteous()
+        {
+            // "Thou shalt separate three cities... that innocent blood be not shed in thy land." (Deuteronomy 19:2-10)
+            OracleHarness.Righteous(OracleHarness.Witness("Israel sets apart cities of refuge to protect the innocent", new Protection(), new Righteousness(), new JustRecompense()));
+        }
+
+        [Fact]
+        public void RemovingLandmarksAndFalseWitnessAreForbidden_IsSin()
+        {
+            // "Thou shalt not remove thy neighbour's landmark... One witness shall not rise up... a false witness." (Deuteronomy 19:14-19)
+            OracleHarness.Sin(OracleHarness.Witness("a man bears false witness and steals his neighbor's boundary", new FalseWitness(), new Theft(), new Deceit()));
+        }
+
+        [Fact]
+        public void BlessingsAndCursesSetBeforeIsraelOnEbalAndGerizim_IsDivineAct()
+        {
+            // "I have set before you life and death, blessing and cursing: therefore choose life." (Deuteronomy 30:19; 11:26-29)
+            OracleHarness.DivineAct(OracleHarness.Witness("God sets life and blessing before Israel and calls them to choose life", new TeachingTruth(), new CovenantFaithfulness(), new Goodness()));
+        }
+
+        [Fact]
+        public void GodPromisesToCircumciseTheirHeartsToLoveHim_IsDivineAct()
+        {
+            // "The LORD thy God will circumcise thine heart... to love the LORD thy God with all thine heart." (Deuteronomy 30:6)
+            OracleHarness.DivineAct(OracleHarness.Witness("God promises to circumcise Israel's heart so they may love him", new Healing(), new CovenantFaithfulness(), new Purity()));
+        }
+
+        [Fact]
+        public void GodCommissionsJoshuaAndPromisesToGoBeforeIsrael_IsDivineAct()
+        {
+            // "Be strong and of a good courage... the LORD, he it is that doth go before thee; he will not fail thee." (Deuteronomy 31:6-8)
+            OracleHarness.DivineAct(OracleHarness.Witness("God commissions Joshua and promises never to fail or forsake Israel", new Fidelity(), new Protection(), new PromiseFulfilled()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/DeuteronomyOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/DeuteronomyOracleTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 05: Deuteronomy.
+    public class DeuteronomyOracleTests
+    {
+        [Fact]
+        public void TheShema_LoveTheLord_IsRighteous()
+        {
+            // "Love the LORD your God with all your heart." (Deuteronomy 6:5)
+            OracleHarness.Righteous(OracleHarness.Witness("the Shema", new Worship(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void LovingTheForeignerAndTheFatherless_IsRighteous()
+        {
+            // "He ... loves the foreigner ... and you are to love those who are foreigners." (Deut 10:18-19)
+            OracleHarness.Righteous(OracleHarness.Witness("loving the foreigner",
+                new Hospitality(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void ObedienceBringsBlessing_IsRighteous()
+        {
+            // "If you fully obey the LORD your God ... you will be blessed." (Deuteronomy 28:1-2)
+            OracleHarness.Righteous(OracleHarness.Witness("Israel keeps the covenant", new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TurningToOtherGods_IsSin()
+        {
+            // The covenant curse falls on apostasy (Deuteronomy 28:15; 30:17-18).
+            OracleHarness.Sin(OracleHarness.Witness("turning to other gods", new Idolatry(), new Rebellion()));
+        }
+
+        [Fact]
+        public void ViolationOfAPerson_IsEquatedWithMurder()
+        {
+            // "This case is like that of someone who attacks and murders a neighbor." (Deuteronomy 22:25-27)
+            Resolution r = OracleHarness.Witness("the violation of a person", new Defilement());
+
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/DidascaliaNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/DidascaliaNarrativeTests.cs
@@ -1,0 +1,127 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Didascalia narrative oracle (ETH): the Didascalia Apostolorum, the apostolic teaching of
+    // church order. It commands bishops and the faithful toward mercy to the penitent, care for the
+    // poor, orphan and widow, just judgment, honoring the church, and away from harshness, division,
+    // and the snares of the world. The engine must return the verdict Scripture gives at each step.
+    public class DidascaliaNarrativeTests
+    {
+        [Fact]
+        public void Didascalia_ReceivingThePenitentSinnerWithMercy_IsRighteous()
+        {
+            // Did. ch. 6-7: the bishop is to receive the one who repents, heal and restore him, not crush him.
+            OracleHarness.Righteous(OracleHarness.Witness("the bishop receives the penitent and restores him",
+                new Forgiveness(), new Compassion(), new Repentance()));
+        }
+
+        [Fact]
+        public void Didascalia_TheBishopJudgingJustlyWithoutPartiality_IsRighteous()
+        {
+            // Did. ch. 11: the bishop is to judge righteously, hearing both sides, without respect of persons.
+            OracleHarness.Righteous(OracleHarness.Witness("the bishop judges justly, without partiality",
+                new Righteousness(), new JustRecompense()));
+        }
+
+        [Fact]
+        public void Didascalia_CaringForOrphansAndWidows_IsRighteous()
+        {
+            // Did. ch. 14-15: the church is to nourish the orphan and the widow as a sacred charge.
+            OracleHarness.Righteous(OracleHarness.Witness("the church nourishes orphans and widows",
+                new HonoringTheVulnerable(), new Compassion(), new Generosity()));
+        }
+
+        [Fact]
+        public void Didascalia_FeedingTheHungryAndClothingTheNaked_IsRighteous()
+        {
+            // Did. ch. 17-18: out of the offerings the poor are fed and clothed and the stranger received.
+            OracleHarness.Righteous(OracleHarness.Witness("feeding the poor and clothing the naked from the offerings",
+                new FeedingTheHungry(), new ClothingTheNaked(), new Hospitality()));
+        }
+
+        [Fact]
+        public void Didascalia_VisitingTheImprisonedAndTheSick_IsRighteous()
+        {
+            // Did. ch. 18-19: the faithful are to visit the sick and minister to those in prison and chains.
+            OracleHarness.Righteous(OracleHarness.Witness("visiting the sick and the imprisoned confessors",
+                new CaringForTheSick(), new VisitingThePrisoner(), new Kindness()));
+        }
+
+        [Fact]
+        public void Didascalia_HonoringTheBishopAndKeepingChurchOrder_IsRighteous()
+        {
+            // Did. ch. 9: honor the bishop as the steward of God, keeping the order of the church.
+            OracleHarness.Righteous(OracleHarness.Witness("honoring the bishop and keeping church order",
+                new Worship(), new ObedienceToGod(), new CreationOrder()));
+        }
+
+        [Fact]
+        public void Didascalia_ForgivingTheBrotherWhoTrespasses_IsRighteous()
+        {
+            // Did. ch. 6: be not unforgiving toward the brother who turns; pardon him as God pardons.
+            OracleHarness.Righteous(OracleHarness.Witness("pardoning the brother who turns from his trespass",
+                new Pardon(), new Forgiveness(), new Peacemaking()));
+        }
+
+        [Fact]
+        public void Didascalia_TheRichManFavoredOverThePoorInTheAssembly_IsSin()
+        {
+            // Did. ch. 12: rebukes the bishop who honors the rich man and dishonors the poor man who enters.
+            OracleHarness.Sin(OracleHarness.Witness("favoring the rich and despising the poor in the assembly",
+                new Oppression(), new Indifference()));
+        }
+
+        [Fact]
+        public void Didascalia_TheHarshBishopWhoRefusesThePenitent_IsSin()
+        {
+            // Did. ch. 6: the shepherd who will not heal the wounded sheep but condemns him sins gravely.
+            OracleHarness.Sin(OracleHarness.Witness("the bishop who refuses and condemns the penitent",
+                new Condemnation(), new Unforgiveness(), new Heartlessness()));
+        }
+
+        [Fact]
+        public void Didascalia_KeepingTheBrotherInAGrudgeAndStrife_IsSin()
+        {
+            // Did. ch. 10-11: warns against the man who holds a grudge and sows strife among the brethren.
+            OracleHarness.Sin(OracleHarness.Witness("holding a grudge and stirring strife among brethren",
+                new Grudge(), new Discord(), new SowingDiscord()));
+        }
+
+        [Fact]
+        public void Didascalia_FollowingTheRepetitionsAndBondsOfTheLaw_IsSin()
+        {
+            // Did. ch. 26: those who return to the "second legislation," the heavy bonds, after Christ's freedom.
+            OracleHarness.Sin(OracleHarness.Witness("turning back to the bondage of the second legislation",
+                new Rebellion(), new Disobedience()));
+        }
+
+        [Fact]
+        public void Didascalia_AcceptingAlmsFromOppressorsAndExtortioners_IsSin()
+        {
+            // Did. ch. 18: forbids the church to take the gifts of the extortioner and the oppressor for the poor.
+            OracleHarness.Sin(OracleHarness.Witness("taking the gifts of the extortioner and oppressor",
+                new Greed(), new Oppression(), new Theft()));
+        }
+
+        [Fact]
+        public void Didascalia_FleshlyImmoralityAndDrunkennessOfTheWorld_IsSin()
+        {
+            // Did. ch. 3 & 22: warns the faithful away from the immorality and drunkenness of the heathen.
+            OracleHarness.Sin(OracleHarness.Witness("the immorality and drunkenness of the world",
+                new SexualImmorality(), new Drunkenness(), new Debauchery()));
+        }
+
+        [Fact]
+        public void Didascalia_SchismRendingTheUnityOfTheChurch_IsSin()
+        {
+            // Did. ch. 23: the heretic and schismatic who tear the one church are likened to wolves.
+            OracleHarness.Sin(OracleHarness.Witness("rending the unity of the church by schism",
+                new Faction(), new Rebellion(), new Treachery()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/EcclesiastesNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/EcclesiastesNarrativeTests.cs
@@ -1,0 +1,97 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Ecclesiastes narrative oracle: the engine must return the verdict Scripture gives at each step.
+    // Qoheleth (the Preacher) weighs life "under the sun" and lands on the fear of God as the whole of man.
+    public class EcclesiastesNarrativeTests
+    {
+        [Fact]
+        public void GodMadeEverythingBeautifulInItsTime_IsADivineAct()
+        {
+            // "He has made everything beautiful in its time... a time for every matter under heaven." (Ecclesiastes 3:1-11)
+            OracleHarness.DivineAct(OracleHarness.Witness("God appoints a season for everything", new CreationOrder(), new Goodness()));
+        }
+
+        [Fact]
+        public void GodSettingEternityInTheHumanHeart_IsADivineAct()
+        {
+            // "He has put eternity into man's heart." (Ecclesiastes 3:11)
+            OracleHarness.DivineAct(OracleHarness.Witness("God places eternity in the heart", new CreationOrder(), new Goodness()));
+        }
+
+        [Fact]
+        public void QohelethChasingPleasureAndPossessionsAsHisPortion_IsSin()
+        {
+            // "I made great works... whatever my eyes desired I did not keep from them... all was vanity and a striving after wind." (Ecclesiastes 2:1-11)
+            OracleHarness.Sin(OracleHarness.Witness("the Preacher heaps up pleasure, houses, and treasure for himself", new SelfSeeking(), new Greed(), new Gluttony()));
+        }
+
+        [Fact]
+        public void TheOppressionsDoneUnderTheSun_AreSin()
+        {
+            // "I saw all the oppressions that are done under the sun... and they had no comforter." (Ecclesiastes 4:1)
+            OracleHarness.Sin(OracleHarness.Witness("the tears of the oppressed who have no comforter", new Oppression(), new Heartlessness()));
+        }
+
+        [Fact]
+        public void TwoAreBetterThanOneBearingOneAnotherUp_IsRighteous()
+        {
+            // "Two are better than one... if they fall, one will lift up his fellow." (Ecclesiastes 4:9-12)
+            OracleHarness.Righteous(OracleHarness.Witness("companions lift up the one who falls", new Kindness(), new Protection()));
+        }
+
+        [Fact]
+        public void DrawingNearToListenInTheHouseOfGod_IsRighteous()
+        {
+            // "Guard your steps when you go to the house of God... let your words be few, for God is in heaven." (Ecclesiastes 5:1-2)
+            OracleHarness.Righteous(OracleHarness.Witness("guarding one's steps and words before God", new Worship(), new Humility()));
+        }
+
+        [Fact]
+        public void TheLoverOfMoneyNeverSatisfied_IsSin()
+        {
+            // "He who loves money will not be satisfied with money." (Ecclesiastes 5:10)
+            OracleHarness.Sin(OracleHarness.Witness("the insatiable love of money and wealth", new Greed(), new Covetousness()));
+        }
+
+        [Fact]
+        public void ReceivingFoodToilAndJoyAsTheGiftOfGod_IsRighteous()
+        {
+            // "Behold, what I have seen to be good and fitting is to eat and drink and find enjoyment in his toil... this is the gift of God." (Ecclesiastes 5:18-19)
+            OracleHarness.Righteous(OracleHarness.Witness("eating, drinking, and rejoicing in one's toil as God's gift", new Joy(), new Goodness(), new Trust()));
+        }
+
+        [Fact]
+        public void TheFoolGivenToFollyAndCarousing_IsSin()
+        {
+            // "The heart of fools is in the house of mirth... laughter of the fools." (Ecclesiastes 7:4-6)
+            OracleHarness.Sin(OracleHarness.Witness("the fool feasting in mindless mirth", new Carousing(), new Sloth()));
+        }
+
+        [Fact]
+        public void RememberingYourCreatorInTheDaysOfYouth_IsRighteous()
+        {
+            // "Remember also your Creator in the days of your youth." (Ecclesiastes 12:1)
+            OracleHarness.Righteous(OracleHarness.Witness("remembering the Creator in youth", new Worship(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TheWholeDutyOfManToFearGodAndKeepHisCommandments_IsRighteous()
+        {
+            // "Fear God and keep his commandments, for this is the whole duty of man." (Ecclesiastes 12:13)
+            OracleHarness.Righteous(OracleHarness.Witness("fear God and keep his commandments", new ObedienceToGod(), new Humility(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodBringingEveryDeedIntoJudgment_IsADivineAct()
+        {
+            // "God will bring every deed into judgment, with every secret thing, whether good or evil." (Ecclesiastes 12:14)
+            OracleHarness.DivineAct(OracleHarness.Witness("God brings every deed and secret into judgment", new JustRecompense(), new Righteousness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/EnochOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/EnochOracleTests.cs
@@ -1,0 +1,46 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 14: Enoch / 1 Enoch (Ethiopic-unique). The decreed cosmic order, its disordering by sin
+    // (ch 80), and the judgment of the wicked.
+    public class EnochOracleTests
+    {
+        [Fact]
+        public void TheCoursesOfTheLuminariesKeepTheirLaw_IsADivineAct()
+        {
+            // The sun, moon, and stars keep the law of their courses (1 Enoch 72-82).
+            OracleHarness.DivineAct(OracleHarness.Witness("the courses of the heavens", new CreationOrder()));
+        }
+
+        [Fact]
+        public void TheWatchersCorruptTheEarth_IsSin()
+        {
+            // The Watchers teach violence and bloodshed and corrupt the earth (1 Enoch 6-9).
+            OracleHarness.Sin(OracleHarness.Witness("the Watchers corrupt the earth", new Bloodshed(), new Rebellion()));
+        }
+
+        [Fact]
+        public void InTheDaysOfSinners_TheOrderIsDisordered()
+        {
+            // "The moon shall alter her order ... the stars shall transgress." (1 Enoch 80) Sin warps
+            // the very order of reality.
+            Resolution r = OracleHarness.Witness("the days of sinners", new Rebellion(), new Idolatry());
+
+            OracleHarness.Sin(r);
+            Assert.True(r.Disorder > 0.0);
+        }
+
+        [Fact]
+        public void TheJudgmentOfTheWicked_IsJust()
+        {
+            // The Holy One comes to judge the wicked and vindicate the righteous (1 Enoch 1; 91-105).
+            OracleHarness.DivineAct(OracleHarness.Witness("the judgment of the wicked",
+                new Righteousness(), new JustRecompense()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/EphesiansNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/EphesiansNarrativeTests.cs
@@ -1,0 +1,138 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Ephesians narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class EphesiansNarrativeTests
+    {
+        [Fact]
+        public void GodChoosesAndAdoptsUsBeforeTheCreationOfTheWorld_IsADivineAct()
+        {
+            // "He chose us in him before the creation of the world ... he predestined us for adoption to sonship." (Ephesians 1:4-5)
+            OracleHarness.DivineAct(OracleHarness.Witness("God chooses and adopts us in Christ before creation", new CovenantFaithfulness(), new CreationOrder(), new Kindness()));
+        }
+
+        [Fact]
+        public void RedemptionThroughHisBloodTheForgivenessOfSins_IsADivineAct()
+        {
+            // "In him we have redemption through his blood, the forgiveness of sins." (Ephesians 1:7)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ redeems us by his blood for the forgiveness of sins", new SelfSacrifice(), new Atonement(), new Forgiveness(), new Deliverance()));
+        }
+
+        [Fact]
+        public void GodRaisesChristFromTheDeadAndSeatsHimAboveAllPower_IsADivineAct()
+        {
+            // "He raised Christ from the dead and seated him at his right hand ... far above all rule and authority." (Ephesians 1:20-21)
+            OracleHarness.DivineAct(OracleHarness.Witness("God raises Christ from the dead and exalts him over all", new RestoringLife(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void GodMakesUsAliveWithChristWhileWeWereDeadInSins_IsADivineAct()
+        {
+            // "Because of his great love ... God, who is rich in mercy, made us alive with Christ even when we were dead in transgressions." (Ephesians 2:4-5)
+            OracleHarness.DivineAct(OracleHarness.Witness("God who is rich in mercy makes us alive together with Christ", new Compassion(), new RestoringLife(), new Deliverance()));
+        }
+
+        [Fact]
+        public void SalvationByGraceAsTheGiftOfGod_IsADivineAct()
+        {
+            // "For it is by grace you have been saved, through faith ... it is the gift of God." (Ephesians 2:8-9)
+            OracleHarness.DivineAct(OracleHarness.Witness("God saves us by grace as his free gift", new Generosity(), new Deliverance(), new Kindness()));
+        }
+
+        [Fact]
+        public void ChristMakesPeaceAndReconcilesJewAndGentileIntoOneBody_IsADivineAct()
+        {
+            // "He himself is our peace, who has made the two groups one ... to create in himself one new humanity ... making peace." (Ephesians 2:14-16)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ destroys the dividing wall and reconciles the two into one", new Peacemaking(), new Atonement(), new Peace()));
+        }
+
+        [Fact]
+        public void WalkingInTheGoodWorksGodPreparedForUs_IsRighteous()
+        {
+            // "We are God's handiwork, created in Christ Jesus to do good works, which God prepared in advance for us to do." (Ephesians 2:10)
+            OracleHarness.Righteous(OracleHarness.Witness("the believers walk in the good works God prepared for them", new Goodness(), new ObedienceToGod(), new Righteousness()));
+        }
+
+        [Fact]
+        public void TheFormerGentileLifeWithoutHopeAndWithoutGod_IsSin()
+        {
+            // "Remember that ... you were separate from Christ ... without hope and without God in the world." (Ephesians 2:11-12)
+            OracleHarness.Sin(OracleHarness.Grounded("the Gentiles once lived without God, following the cravings of the flesh", Grounding.InIdol("the gods of the uncircumcised nations"), new Idolatry(), new Impurity()));
+        }
+
+        [Fact]
+        public void LivingWorthyOfTheCallingInHumilityGentlenessAndPatience_IsRighteous()
+        {
+            // "Be completely humble and gentle; be patient, bearing with one another in love." (Ephesians 4:2-3)
+            OracleHarness.Righteous(OracleHarness.Witness("the church keeps the unity of the Spirit in humility, gentleness, and patience", new Humility(), new Gentleness(), new Patience(), new Peacemaking()));
+        }
+
+        [Fact]
+        public void SpeakingTheTruthInLoveToBuildUpTheBody_IsRighteous()
+        {
+            // "Speaking the truth in love, we will grow to become in every respect the mature body." (Ephesians 4:15)
+            OracleHarness.Righteous(OracleHarness.Witness("the body grows up as it speaks the truth in love", new TeachingTruth(), new RejoicingInTruth(), new Kindness()));
+        }
+
+        [Fact]
+        public void TheGentileLifeGivenOverToSensualityAndImpurity_IsSin()
+        {
+            // "Having lost all sensitivity, they have given themselves over to sensuality so as to indulge in every kind of impurity, with a continual lust for more." (Ephesians 4:19)
+            OracleHarness.Sin(OracleHarness.Witness("the Gentiles give themselves over to sensuality, impurity, and greed", new Debauchery(), new Impurity(), new Greed(), new Lust()));
+        }
+
+        [Fact]
+        public void FallingBackIntoFalsehoodTheftRageAndSlander_IsSin()
+        {
+            // "Get rid of all bitterness, rage and anger ... brawling and slander, along with every form of malice." (Ephesians 4:25, 28, 31)
+            OracleHarness.Sin(OracleHarness.Witness("the old self lives in falsehood, theft, fits of rage, slander, and malice", new Deceit(), new Theft(), new FitsOfRage(), new Slander(), new Malice()));
+        }
+
+        [Fact]
+        public void BeingKindForgivingOneAnotherAsGodForgaveYou_IsRighteous()
+        {
+            // "Be kind and compassionate to one another, forgiving each other, just as in Christ God forgave you." (Ephesians 4:32)
+            OracleHarness.Righteous(OracleHarness.Witness("the believers are kind, compassionate, and forgiving as God forgave them", new Kindness(), new Compassion(), new Forgiveness()));
+        }
+
+        [Fact]
+        public void SexualImmoralityImpurityAndGreedHaveNoPlaceAmongTheSaints_IsSin()
+        {
+            // "But among you there must not be even a hint of sexual immorality, or of any kind of impurity, or of greed." (Ephesians 5:3-5)
+            OracleHarness.Sin(OracleHarness.Witness("the impure indulge in immorality, impurity, greed, and obscene talk", new SexualImmorality(), new Impurity(), new Greed(), new FilthyLanguage(), new Idolatry()));
+        }
+
+        [Fact]
+        public void DrunkennessWithWineLeadingToDebauchery_IsSin()
+        {
+            // "Do not get drunk on wine, which leads to debauchery." (Ephesians 5:18)
+            OracleHarness.Sin(OracleHarness.Witness("the foolish get drunk on wine, which leads to debauchery", new Drunkenness(), new Debauchery()));
+        }
+
+        [Fact]
+        public void ChristLovesTheChurchAndGivesHimselfUpForHer_IsADivineAct()
+        {
+            // "Christ loved the church and gave himself up for her to make her holy, cleansing her ... without stain or wrinkle." (Ephesians 5:25-27)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ loves the church and gives himself up to sanctify her", new SelfSacrifice(), new Atonement(), new Purity(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void ChildrenObeyingParentsAndFathersNotProvoking_IsRighteous()
+        {
+            // "Children, obey your parents in the Lord ... Fathers, do not exasperate your children; instead, bring them up in the ... instruction of the Lord." (Ephesians 6:1-4)
+            OracleHarness.Righteous(OracleHarness.Witness("children obey their parents and fathers raise them gently in the Lord", new ObedienceToGod(), new Gentleness(), new Kindness()));
+        }
+
+        [Fact]
+        public void StandingFirmInTheArmorOfGodAgainstTheDevilsSchemes_IsRighteous()
+        {
+            // "Put on the full armor of God, so that you can take your stand against the devil's schemes." (Ephesians 6:11-17)
+            OracleHarness.Righteous(OracleHarness.Witness("the believer stands firm in the armor of God, girded with truth and righteousness", new CourageousFaith(), new Righteousness(), new RejoicingInTruth(), new Endurance()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/EstherNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/EstherNarrativeTests.cs
@@ -1,0 +1,113 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Esther narrative oracle (Eastern-Orthodox / Greek Esther, including the canonical Additions):
+    // the engine must return the verdict Scripture gives at each step.
+    public class EstherNarrativeTests
+    {
+        [Fact]
+        public void MordecaiExposesTheAssassinationPlotAgainstTheKing_IsRighteous()
+        {
+            // Mordecai learns of Bigthan and Teresh's plot and discloses it through Esther, saving the king (Esther 2:21-23).
+            OracleHarness.Righteous(OracleHarness.Witness("Mordecai exposes the plot and protects the king's life",
+                new Protection(), new Trustworthiness()));
+        }
+
+        [Fact]
+        public void MordecaiRefusesToBowToHaman_IsRighteous()
+        {
+            // Mordecai will not bow or do reverence to Haman, keeping faith though it costs him (Esther 3:2-4).
+            OracleHarness.Righteous(OracleHarness.Witness("Mordecai refuses to bow to Haman",
+                new CourageousFaith(), new Fidelity()));
+        }
+
+        [Fact]
+        public void HamansGenocidalEdictToDestroyTheJews_IsSin()
+        {
+            // Haman, enraged, plots to destroy, slay, and annihilate all the Jews in one day (Esther 3:6-13).
+            Resolution r = OracleHarness.Witness("Haman's edict to destroy all the Jews",
+                new Murder(), new Bloodshed(), new WickedScheming(), new Hatred());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void HamansPrideAndContemptForMordecai_IsSin()
+        {
+            // Full of his own honor, Haman despises Mordecai and seeks his ruin out of wounded pride (Esther 3:5; 5:9-13).
+            OracleHarness.Sin(OracleHarness.Witness("Haman's pride and contempt for Mordecai",
+                new Pride(), new Boasting(), new Hatred()));
+        }
+
+        [Fact]
+        public void HamanBuildsTheGallowsToHangMordecai_IsSin()
+        {
+            // At his wife's counsel Haman builds a fifty-cubit gallows to hang the innocent Mordecai (Esther 5:14).
+            Resolution r = OracleHarness.Witness("Haman builds the gallows to hang Mordecai",
+                new Murder(), new WickedScheming(), new Malice());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void TheJewsFastAndMournUnderTheDecree_IsRighteous()
+        {
+            // Mordecai and all the Jews fast, weep, and mourn, turning to God in their distress (Esther 4:1-3).
+            OracleHarness.Righteous(OracleHarness.Witness("the Jews fast and mourn before God",
+                new Mourning(), new Repentance(), new Worship()));
+        }
+
+        [Fact]
+        public void EstherResolvesToGoToTheKingThoughSheMayPerish_IsRighteous()
+        {
+            // "If I perish, I perish" — Esther risks her life to intercede for her people (Esther 4:15-16).
+            OracleHarness.Righteous(OracleHarness.Witness("Esther risks her life to plead for her people",
+                new CourageousFaith(), new SelfSacrifice(), new DefendingTheWeak()));
+        }
+
+        [Fact]
+        public void EstherPraysAndPleadsGroundedInGod_IsADivineAct()
+        {
+            // In the Greek Addition, Esther prays to the Lord and her plea is answered as His deliverance (Esther [Greek] C/D).
+            OracleHarness.DivineAct(OracleHarness.Grounded("Esther prays to the LORD and is delivered",
+                Grounding.InGod(), new Worship(), new Deliverance(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void MordecaiIsHonoredForSavingTheKing_IsRighteous()
+        {
+            // The unrewarded good deed is remembered, and Mordecai is paraded in royal honor (Esther 6:1-11).
+            OracleHarness.Righteous(OracleHarness.Witness("Mordecai is justly honored for his faithfulness",
+                new JustRecompense(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void HamanIsHangedOnHisOwnGallows_IsRighteous()
+        {
+            // Haman is hanged on the very gallows he raised for Mordecai — evil recoils on its author (Esther 7:9-10).
+            OracleHarness.Righteous(OracleHarness.Witness("Haman is hanged on the gallows he built",
+                new JustRecompense(), new Righteousness()));
+        }
+
+        [Fact]
+        public void TheJewsAreDeliveredAndDefendThemselves_IsADivineAct()
+        {
+            // By a counter-decree the Jews are saved, given rest from their enemies, and preserved (Esther 8:11-17; 9:1-5).
+            OracleHarness.DivineAct(OracleHarness.Grounded("God delivers the Jews and grants them rest",
+                Grounding.InGod(), new Deliverance(), new Protection(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void EstherAndMordecaiEstablishPurimWithGiftsToThePoor_IsRighteous()
+        {
+            // Days of feasting, joy, and sending portions and gifts to the poor are appointed forever (Esther 9:20-22).
+            OracleHarness.Righteous(OracleHarness.Witness("Purim kept with joy and gifts to the poor",
+                new Joy(), new Generosity(), new FeedingTheHungry()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/EthiopicSinodosOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/EthiopicSinodosOracleTests.cs
@@ -1,0 +1,72 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 74-81: the Ethiopic broader New Testament (Sinodos and related): Sirate Tsion, Tizaz,
+    // Gitsew, Abtilis, the two Books of the Covenant (Dominos), Clement, and Didascalia. These are
+    // books of church order and apostolic teaching; their calling is holiness, love, justice, and
+    // mercy to the penitent.
+    public class EthiopicSinodosOracleTests
+    {
+        [Fact]
+        public void SirateTsion_RightOrderAndHolyWorship_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("the order of Zion", new Worship(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void Tizaz_TheCommandToLoveGodAndNeighbor_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("love God and neighbor", new Compassion(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void Gitsew_RestoringTheErringInMercy_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("restoring the erring", new Forgiveness(), new Repentance()));
+        }
+
+        [Fact]
+        public void Abtilis_CharityToTheNeedy_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("charity to the needy", new Generosity(), new Compassion()));
+        }
+
+        [Fact]
+        public void FirstDominos_TheLordsTeachingAndMercy_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("the Book of the Covenant", new Worship(), new Compassion()));
+        }
+
+        [Fact]
+        public void SecondDominos_FaithfulnessAndHopeOfHisComing_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("faithfulness and hope", new CovenantFaithfulness(), new Trust()));
+        }
+
+        [Fact]
+        public void Clement_OrderRepentanceAndCharity_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("apostolic order via Clement", new Repentance(), new Generosity()));
+        }
+
+        [Fact]
+        public void Didascalia_MercyToThePenitentAndCareForOrphans_IsRighteous()
+        {
+            // The Didascalia urges receiving the penitent with mercy and caring for the orphan.
+            OracleHarness.Righteous(OracleHarness.Witness("mercy to the penitent, care for orphans",
+                new Compassion(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void Didascalia_RefusingMercyToThePenitent_IsSin()
+        {
+            // To crush the contrite rather than restore them offends the mercy of God.
+            OracleHarness.Sin(OracleHarness.Witness("refusing mercy to the penitent", new Condemnation()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/ExodusNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/ExodusNarrativeTests.cs
@@ -1,0 +1,112 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Exodus narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class ExodusNarrativeTests
+    {
+        [Fact]
+        public void PharaohEnslavesIsrael_IsSin()
+        {
+            // Pharaoh oppresses Israel with hard bondage (Exodus 1:11-14).
+            OracleHarness.Sin(OracleHarness.Witness("Pharaoh enslaves Israel", new Oppression(), new Wrongdoing()));
+        }
+
+        [Fact]
+        public void PharaohCommandsHebrewSonsDrowned_IsSin()
+        {
+            // "Every son that is born ye shall cast into the river." (Exodus 1:22)
+            Resolution r = OracleHarness.Witness("Pharaoh orders the Hebrew infants killed", new Murder(), new Bloodshed());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void TheMidwivesFearGodAndSpareTheChildren_IsRighteous()
+        {
+            // The midwives feared God and saved the male children alive (Exodus 1:17-21).
+            OracleHarness.Righteous(OracleHarness.Witness("the midwives spare the Hebrew sons", new ObedienceToGod(), new Protection(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void GodHearsAndRemembersHisCovenant_IsDivineAct()
+        {
+            // "God remembered his covenant with Abraham, with Isaac, and with Jacob." (Exodus 2:24)
+            OracleHarness.DivineAct(OracleHarness.Witness("God remembers his covenant with the patriarchs", new CovenantFaithfulness(), new Compassion()));
+        }
+
+        [Fact]
+        public void GodCallsMosesFromTheBurningBush_IsDivineAct()
+        {
+            // "I have surely seen the affliction of my people... and am come down to deliver them." (Exodus 3:7-8)
+            OracleHarness.DivineAct(OracleHarness.Witness("God calls Moses to deliver Israel", new Deliverance(), new Compassion(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void PharaohHardensHisHeartAndRefusesToReleaseIsrael_IsSin()
+        {
+            // Pharaoh will not let the people go and increases their burdens (Exodus 5:2-9).
+            OracleHarness.Sin(OracleHarness.Witness("Pharaoh refuses to free Israel and oppresses harder", new Rebellion(), new Oppression(), new Pride()));
+        }
+
+        [Fact]
+        public void GodSendsThePlaguesAsJustJudgment_IsDivineAct()
+        {
+            // "Against all the gods of Egypt I will execute judgment." (Exodus 12:12)
+            OracleHarness.DivineAct(OracleHarness.Witness("God judges Egypt through the plagues", new JustRecompense(), new DefendingTheWeak()));
+        }
+
+        [Fact]
+        public void IsraelKeepsThePassoverInObedience_IsRighteous()
+        {
+            // Israel keeps the Passover as the LORD commanded (Exodus 12:28).
+            OracleHarness.Righteous(OracleHarness.Witness("Israel keeps the first Passover", new ObedienceToGod(), new Fidelity(), new Trust()));
+        }
+
+        [Fact]
+        public void GodPassesOverAndDeliversIsraelFromEgypt_IsDivineAct()
+        {
+            // The LORD brings Israel out of Egypt by the blood of the lamb (Exodus 12:13, 51).
+            OracleHarness.DivineAct(OracleHarness.Witness("God delivers Israel out of Egypt", new Deliverance(), new Protection(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void GodPartsTheRedSeaAndSavesIsrael_IsDivineAct()
+        {
+            // "The LORD saved Israel that day out of the hand of the Egyptians." (Exodus 14:21-30)
+            OracleHarness.DivineAct(OracleHarness.Witness("God divides the Red Sea and saves Israel", new Deliverance(), new Protection(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodFeedsIsraelWithMannaInTheWilderness_IsDivineAct()
+        {
+            // "Behold, I will rain bread from heaven for you." (Exodus 16:4)
+            OracleHarness.DivineAct(OracleHarness.Witness("God feeds Israel with manna", new FeedingTheHungry(), new Compassion(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodGivesTheLawAtSinai_IsDivineAct()
+        {
+            // God speaks the Ten Commandments and establishes his covenant (Exodus 20:1-17; 24:7-8).
+            OracleHarness.DivineAct(OracleHarness.Witness("God gives the Law and covenant at Sinai", new CovenantFaithfulness(), new TeachingTruth(), new Righteousness()));
+        }
+
+        [Fact]
+        public void IsraelWorshipsTheGoldenCalf_IsSinGroundedInAnIdol()
+        {
+            // "These be thy gods, O Israel, which brought thee up out of the land of Egypt." (Exodus 32:4-8)
+            OracleHarness.Sin(OracleHarness.Grounded("Israel worships the golden calf", Grounding.InIdol("the golden calf"), new Idolatry(), new GravenImage(), new Rebellion()));
+        }
+
+        [Fact]
+        public void TheGloryOfTheLordFillsTheTabernacle_IsDivineAct()
+        {
+            // "The glory of the LORD filled the tabernacle." (Exodus 40:34-38)
+            OracleHarness.DivineAct(OracleHarness.Witness("God's glory fills the finished tabernacle", new CovenantFaithfulness(), new PromiseFulfilled(), new Worship()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/ExodusOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/ExodusOracleTests.cs
@@ -1,0 +1,52 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 02: Exodus.
+    public class ExodusOracleTests
+    {
+        [Fact]
+        public void GodDeliversIsrael_IsFaithfulDeliverance()
+        {
+            // "I have come down to rescue them." (Exodus 3:8)
+            OracleHarness.DivineAct(OracleHarness.Witness("the exodus", new Deliverance(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void PharaohOppressesAndKillsTheSons_IsGraveSin()
+        {
+            // Enslaving the Hebrews and ordering their sons drowned (Exodus 1).
+            OracleHarness.Sin(OracleHarness.Witness("Pharaoh's oppression", new Oppression(), new Murder()));
+        }
+
+        [Fact]
+        public void GodGivesTheRighteousLaw_IsADivineAct()
+        {
+            // The Law is God's righteous order for His people (Exodus 20).
+            OracleHarness.DivineAct(OracleHarness.Witness("the Law given at Sinai", new Righteousness(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TheGoldenCalf_IsSin()
+        {
+            // "These are your gods, Israel." (Exodus 32:4) Idolatry while the covenant is still fresh.
+            OracleHarness.Sin(OracleHarness.Witness("the golden calf", new Idolatry()));
+        }
+
+        [Fact]
+        public void WorshipGroundedInTheIdol_DriftsTowardNonBeing()
+        {
+            // The same act of worship cannot hold when offered to a dead idol (1 Meqabyan 1).
+            Resolution onGod = OracleHarness.Grounded("worship", Grounding.InGod(), new Worship());
+            Resolution onIdol = OracleHarness.Grounded("worship", Grounding.InIdol("the golden calf"), new Worship());
+
+            Assert.Equal(0.0, onGod.Disorder);
+            Assert.True(onIdol.Disorder > 0.0);
+            Assert.True(onIdol.Coherence < onGod.Coherence);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/EzekielNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/EzekielNarrativeTests.cs
@@ -1,0 +1,134 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Ezekiel narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class EzekielNarrativeTests
+    {
+        [Fact]
+        public void GodRevealsHisGloryByTheRiverChebar_IsADivineAct()
+        {
+            // "I looked, and, behold ... the likeness of the glory of the LORD." (Ezekiel 1:1-28)
+            // The throne-chariot vision opens the book: God revealed in ordered, holy glory.
+            OracleHarness.DivineAct(OracleHarness.Witness("God reveals His enthroned glory to Ezekiel by the Chebar",
+                new Worship(), new CreationOrder(), new Righteousness(),
+                new RejoicingInTruth(), new Goodness()));
+        }
+
+        [Fact]
+        public void GodCommissionsEzekielAsWatchmanToTheRebelliousHouse_IsADivineAct()
+        {
+            // "Son of man, I send thee ... a watchman unto the house of Israel." (Ezekiel 2:3-7; 3:17)
+            // God appoints the prophet to speak His truth and warn the people for their good.
+            OracleHarness.DivineAct(OracleHarness.Witness("God commissions Ezekiel as a watchman to warn Israel",
+                new TeachingTruth(), new Protection(), new CovenantFaithfulness(),
+                new HonoringTheVulnerable(), new Goodness()));
+        }
+
+        [Fact]
+        public void EzekielEatsTheScrollAndObeysTheHardCommission_IsRighteous()
+        {
+            // "Eat this roll, and go speak unto the house of Israel ... it was in my mouth as honey." (Ezekiel 3:1-4)
+            // The prophet humbly receives God's word and courageously goes where he is sent.
+            OracleHarness.Righteous(OracleHarness.Witness("Ezekiel eats the scroll and obeys his hard commission",
+                new ObedienceToGod(), new Humility(), new CourageousFaith(),
+                new TeachingTruth(), new Fidelity()));
+        }
+
+        [Fact]
+        public void JerusalemsBloodAndIdolatryProvokeJudgment_IsSin()
+        {
+            // "She hath changed my judgments into wickedness ... thy blood ... thine idols." (Ezekiel 5:6-9; 7:23)
+            // Jerusalem's defiling idolatry and bloodshed bring the indictment of the city.
+            Resolution r = OracleHarness.Grounded("Jerusalem fills the city with bloodshed and idols",
+                Grounding.InIdol("idols of Jerusalem"),
+                new Bloodshed(), new Idolatry(), new Defilement(), new Rebellion());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void TheEldersWorshipImagesInTheTempleAbominations_IsSin()
+        {
+            // "Behold the wicked abominations that they do here ... every form of creeping things ... and idols." (Ezekiel 8:9-16)
+            // The temple-vision exposes secret idolatry done in the very house of God.
+            OracleHarness.Sin(OracleHarness.Grounded("the elders worship images and idols within the temple",
+                Grounding.InIdol("temple abominations"),
+                new Idolatry(), new GravenImage(), new Defilement(), new Disobedience()));
+        }
+
+        [Fact]
+        public void TheWickedShepherdsDevourTheFlockAndNeglectTheWeak_IsSin()
+        {
+            // "Ye eat the fat ... but ye feed not the flock. The diseased ... ye have not strengthened." (Ezekiel 34:2-4)
+            // The false shepherds feed themselves and abandon the sick and scattered sheep.
+            OracleHarness.Sin(OracleHarness.Witness("the shepherds of Israel devour the flock and neglect the weak",
+                new Oppression(), new Indifference(), new SelfSeeking(),
+                new Heartlessness(), new WithholdingWhatIsDue()));
+        }
+
+        [Fact]
+        public void GodHimselfWillShepherdAndSeekTheLostSheep_IsADivineAct()
+        {
+            // "I will seek that which was lost ... bind up that which was broken ... feed them in good pasture." (Ezekiel 34:11-16)
+            // The LORD takes up the shepherd's office to seek, heal, and protect His flock.
+            OracleHarness.DivineAct(OracleHarness.Witness("God Himself shepherds Israel, seeking the lost and binding the broken",
+                new Compassion(), new Healing(), new Protection(),
+                new DefendingTheWeak(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void GodTakesNoPleasureInDeathButCallsTheWickedToRepent_IsADivineAct()
+        {
+            // "I have no pleasure in the death of him that dieth ... turn yourselves, and live." (Ezekiel 18:30-32; 33:11)
+            // God's righteous mercy: He offers life freely to all who repent and turn.
+            OracleHarness.DivineAct(OracleHarness.Witness("God calls the wicked to turn and live, taking no pleasure in death",
+                new Pardon(), new Forgiveness(), new Compassion(),
+                new Righteousness(), new Deliverance()));
+        }
+
+        [Fact]
+        public void GodPromisesANewHeartAndNewSpirit_IsADivineAct()
+        {
+            // "A new heart also will I give you ... I will take away the stony heart ... and give you an heart of flesh." (Ezekiel 36:25-27)
+            // God promises inward cleansing and renewal, fulfilling His covenant to restore His people.
+            OracleHarness.DivineAct(OracleHarness.Witness("God promises a new heart and a new spirit to His people",
+                new RestoringLife(), new Atonement(), new CovenantFaithfulness(),
+                new PromiseFulfilled(), new Goodness()));
+        }
+
+        [Fact]
+        public void GodRaisesTheValleyOfDryBonesToLife_IsADivineAct()
+        {
+            // "Behold, I will cause breath to enter into you, and ye shall live." (Ezekiel 37:1-14)
+            // The vision of dry bones: God restores a dead nation to living, breathing life.
+            OracleHarness.DivineAct(OracleHarness.Witness("God breathes life into the valley of dry bones and raises Israel",
+                new RestoringLife(), new Deliverance(), new Healing(),
+                new PromiseFulfilled(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void GodPromisesAnEverlastingCovenantOfPeaceAndDwelling_IsADivineAct()
+        {
+            // "I will make a covenant of peace with them ... my tabernacle also shall be with them." (Ezekiel 37:26-27)
+            // God seals an everlasting covenant of peace and pledges to dwell among His people.
+            OracleHarness.DivineAct(OracleHarness.Witness("God establishes an everlasting covenant of peace and dwells with His people",
+                new Peace(), new CovenantFaithfulness(), new PromiseFulfilled(),
+                new Fidelity(), new Goodness()));
+        }
+
+        [Fact]
+        public void TheGloryOfTheLordReturnsToTheRestoredTemple_IsADivineAct()
+        {
+            // "The glory of the LORD came into the house ... the LORD is there." (Ezekiel 43:1-5; 48:35)
+            // The closing vision: God's glory returns to fill the restored temple, ordered and holy.
+            OracleHarness.DivineAct(OracleHarness.Witness("The glory of the LORD returns to fill the restored temple",
+                new Worship(), new CreationOrder(), new PromiseFulfilled(),
+                new Righteousness(), new RestoringLife()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/EzraNehemiahNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/EzraNehemiahNarrativeTests.cs
@@ -1,0 +1,108 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Ezra-Nehemiah narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class EzraNehemiahNarrativeTests
+    {
+        [Fact]
+        public void GodStirsCyrusToReleaseTheExiles_IsADivineAct()
+        {
+            // The LORD stirs the spirit of Cyrus to fulfill His word through Jeremiah and free His people (Ezra 1:1-4).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD stirs Cyrus to release the exiles",
+                new CovenantFaithfulness(), new PromiseFulfilled(), new Deliverance()));
+        }
+
+        [Fact]
+        public void TheRemnantRebuildsTheAltarAndRestoresWorship_IsRighteous()
+        {
+            // Returned under Zerubbabel and Jeshua, they set up the altar and offer sacrifice to God (Ezra 3:1-6).
+            OracleHarness.Righteous(OracleHarness.Witness("the altar rebuilt and worship restored",
+                new Worship(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void ThePeopleShoutForJoyAtTheTempleFoundation_IsRighteous()
+        {
+            // When the foundation of the LORD's house is laid the people praise Him with a great shout (Ezra 3:10-11).
+            OracleHarness.Righteous(OracleHarness.Witness("joy at the laying of the temple foundation",
+                new Joy(), new Worship()));
+        }
+
+        [Fact]
+        public void GodFinishesTheHouseDespiteOpposition_IsADivineAct()
+        {
+            // The work prospers and the temple is completed because the eye of God watches over the elders (Ezra 5-6).
+            OracleHarness.DivineAct(OracleHarness.Witness("God protects and completes the rebuilding of His house",
+                new Protection(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void EzraReadsAndTeachesTheLawToThePeople_IsRighteous()
+        {
+            // Ezra reads the Book of the Law and gives the sense so the people understand (Nehemiah 8:1-8).
+            OracleHarness.Righteous(OracleHarness.Witness("Ezra teaches the Law to the assembly",
+                new TeachingTruth(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void ThePeopleMournAndThenRejoiceAtTheWord_IsRighteous()
+        {
+            // Hearing the Law the people weep in repentance, then keep the feast with great joy (Nehemiah 8:9-12).
+            OracleHarness.Righteous(OracleHarness.Witness("the people repent and then rejoice at the Law",
+                new Repentance(), new Joy()));
+        }
+
+        [Fact]
+        public void NehemiahCourageouslyRebuildsTheWall_IsRighteous()
+        {
+            // Against scorn and threat Nehemiah leads the people to rebuild Jerusalem's wall, trusting God (Nehemiah 4).
+            OracleHarness.Righteous(OracleHarness.Witness("Nehemiah rebuilds the wall in courageous faith",
+                new CourageousFaith(), new Protection()));
+        }
+
+        [Fact]
+        public void NehemiahRelievesThePoorFromUsury_IsRighteous()
+        {
+            // He rebukes the nobles for exacting usury and restores fields, vineyards, and money (Nehemiah 5:6-13).
+            OracleHarness.Righteous(OracleHarness.Witness("Nehemiah relieves the poor and restores what was taken",
+                new JustRecompense(), new Generosity()));
+        }
+
+        [Fact]
+        public void TheCovenantIsRenewedInConfession_IsRighteous()
+        {
+            // The Levites lead a great confession and the people bind themselves anew to the LORD (Nehemiah 9-10).
+            OracleHarness.Righteous(OracleHarness.Witness("the covenant renewed in confession",
+                new Repentance(), new Worship(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TheNoblesExactUsuryAndOppressTheirBrothers_IsSin()
+        {
+            // Before Nehemiah's rebuke, the nobles seize fields and enslave their own brothers (Nehemiah 5:1-5).
+            OracleHarness.Sin(OracleHarness.Witness("the nobles oppress the poor with usury",
+                new Oppression(), new Greed()));
+        }
+
+        [Fact]
+        public void ThePeopleBreakCovenantByMarryingForeignWomen_IsSin()
+        {
+            // The returned people intermarry with the peoples of the land, breaking faith with God (Ezra 9:1-2; Nehemiah 13:23-27).
+            OracleHarness.Sin(OracleHarness.Witness("breaking covenant by foreign intermarriage",
+                new CovenantBreaking(), new Disobedience()));
+        }
+
+        [Fact]
+        public void TheMerchantsProfaneTheSabbathByTrading_IsSin()
+        {
+            // Men tread wine presses and sell their wares on the Sabbath until Nehemiah shuts the gates (Nehemiah 13:15-22).
+            OracleHarness.Sin(OracleHarness.Witness("profaning the Sabbath with trade",
+                new SabbathBreaking(), new Disobedience()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/EzraNehemiahOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/EzraNehemiahOracleTests.cs
@@ -1,0 +1,44 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 15 & 16: Ezra & Nehemiah, and 2 Ezra / Ezra Sutuel.
+    public class EzraNehemiahOracleTests
+    {
+        [Fact]
+        public void GodBringsBackTheExiles_IsFaithfulDeliverance()
+        {
+            // The LORD moves Cyrus and restores His people to rebuild (Ezra 1).
+            OracleHarness.DivineAct(OracleHarness.Witness("the return from exile",
+                new CovenantFaithfulness(), new Deliverance()));
+        }
+
+        [Fact]
+        public void TheCovenantRenewalAndConfession_IsRighteous()
+        {
+            // The people confess and rededicate themselves to the LORD (Nehemiah 9).
+            OracleHarness.Righteous(OracleHarness.Witness("the covenant renewed", new Repentance(), new Worship()));
+        }
+
+        [Fact]
+        public void NehemiahEndsTheOppressionOfThePoor_IsRighteous()
+        {
+            // He rebukes the nobles for exacting usury and restores what was taken (Nehemiah 5).
+            OracleHarness.Righteous(OracleHarness.Witness("Nehemiah relieves the poor",
+                new JustRecompense(), new Generosity()));
+        }
+
+        [Fact]
+        public void GodsJudgmentIsBothJustAndMerciful_IsADivineAct()
+        {
+            // The apocalyptic Ezra wrestles with, and rests in, God's justice joined to His mercy
+            // (2 Ezra / 4 Ezra).
+            OracleHarness.DivineAct(OracleHarness.Witness("God's righteous, merciful judgment",
+                new Righteousness(), new Pardon()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/FirstCorinthiansNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/FirstCorinthiansNarrativeTests.cs
@@ -1,0 +1,112 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 1 Corinthians narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class FirstCorinthiansNarrativeTests
+    {
+        [Fact]
+        public void TheCrossIsTheWisdomAndPowerOfGod_IsADivineAct()
+        {
+            // "Christ crucified ... the power of God and the wisdom of God." (1 Corinthians 1:23-24)
+            OracleHarness.DivineAct(OracleHarness.Witness("the message of the cross", new SelfSacrifice(), new Deliverance()));
+        }
+
+        [Fact]
+        public void DivisionsAndPartyStrifeInTheChurch_IsSin()
+        {
+            // "One of you says, 'I follow Paul'; another, 'I follow Apollos.'" (1 Corinthians 1:11-12; 3:3)
+            OracleHarness.Sin(OracleHarness.Witness("the Corinthians quarrel into factions", new Discord(), new Faction()));
+        }
+
+        [Fact]
+        public void BoastingInHumanWisdomAndTeachers_IsSin()
+        {
+            // "Let no one boast about human leaders." (1 Corinthians 3:21; 4:7)
+            OracleHarness.Sin(OracleHarness.Witness("the church boasts in human wisdom", new Boasting(), new Pride()));
+        }
+
+        [Fact]
+        public void TheManLivingWithHisFathersWife_IsSin()
+        {
+            // "A man is sleeping with his father's wife." (1 Corinthians 5:1-2)
+            OracleHarness.Sin(OracleHarness.Witness("the incestuous man defiles the body", new SexualImmorality(), new Defilement()));
+            // Capital defilement drives disorder to its limit.
+            Assert.Equal(1.0, OracleHarness.Witness("the incestuous man defiles the body", new SexualImmorality(), new Defilement()).Disorder);
+        }
+
+        [Fact]
+        public void BelieversSuingOneAnotherBeforePagans_IsSin()
+        {
+            // "Brother goes to law against brother ... You yourselves cheat and do wrong." (1 Corinthians 6:6-8)
+            OracleHarness.Sin(OracleHarness.Witness("brother drags brother to court", new Wrongdoing(), new Discord()));
+        }
+
+        [Fact]
+        public void UnitingTheBodyWithAProstitute_IsSin()
+        {
+            // "Flee from sexual immorality ... your body is a temple of the Holy Spirit." (1 Corinthians 6:18-19)
+            OracleHarness.Sin(OracleHarness.Witness("joining the temple of the Spirit to immorality", new SexualImmorality(), new Impurity()));
+        }
+
+        [Fact]
+        public void WoundingTheWeakConscienceOverIdolFood_IsSin()
+        {
+            // "When you sin against them ... you sin against Christ." (1 Corinthians 8:11-12)
+            OracleHarness.Sin(OracleHarness.Witness("the strong despise the weak brother's conscience", new Indifference(), new Wrongdoing()));
+        }
+
+        [Fact]
+        public void PaulRefusesPayToRemoveEveryHindrance_IsRighteous()
+        {
+            // "I have not used any of these rights ... so as not to hinder the gospel." (1 Corinthians 9:12-19)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul lays down his rights for the gospel", new SelfSacrifice(), new SelfControl()));
+        }
+
+        [Fact]
+        public void WorshipingIdolsAtTheTempleFeasts_IsSin()
+        {
+            // "You cannot drink the cup of the Lord and the cup of demons." (1 Corinthians 10:14, 21)
+            OracleHarness.Sin(OracleHarness.Grounded("the Corinthians feast at idol altars", Grounding.InIdol("demons of the table"), new Idolatry()));
+        }
+
+        [Fact]
+        public void HumiliatingThePoorAtTheLordsTable_IsSin()
+        {
+            // "One remains hungry, another gets drunk ... you humiliate those who have nothing." (1 Corinthians 11:21-22)
+            OracleHarness.Sin(OracleHarness.Witness("the rich shame the poor at the supper", new Drunkenness(), new Oppression()));
+        }
+
+        [Fact]
+        public void TheOneSpiritGivesGiftsToEachForTheCommonGood_IsADivineAct()
+        {
+            // "To each one the manifestation of the Spirit is given for the common good." (1 Corinthians 12:7, 11)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Spirit distributes gifts to the body", new Generosity(), new CreationOrder()));
+        }
+
+        [Fact]
+        public void LoveIsPatientKindAndRejoicesInTruth_IsRighteous()
+        {
+            // "Love is patient, love is kind ... it rejoices with the truth." (1 Corinthians 13:4-6)
+            OracleHarness.Righteous(OracleHarness.Witness("the more excellent way of love", new Patience(), new Kindness(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void ChristRaisedFromTheDeadDefeatsDeath_IsADivineAct()
+        {
+            // "Christ has indeed been raised ... Death has been swallowed up in victory." (1 Corinthians 15:20, 54)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ is raised and death is undone", new RestoringLife(), new Deliverance()));
+        }
+
+        [Fact]
+        public void TheCollectionForTheLordsPeople_IsRighteous()
+        {
+            // "On the first day of every week ... set aside a sum of money for the saints." (1 Corinthians 16:1-3)
+            OracleHarness.Righteous(OracleHarness.Witness("the church gathers a gift for the poor saints", new Generosity(), new Compassion()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/FirstDominosNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/FirstDominosNarrativeTests.cs
@@ -1,0 +1,181 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 1 Book of the Covenant (Dominos) narrative oracle: the engine must return the verdict the book
+    // gives at each step. Canon: ETH (Ethiopic-only; best-effort). The "Book of the Covenant" is the
+    // Ethiopic Mäshafä Kidan (the Testament of Our Lord, Testamentum Domini). Book One opens with the
+    // risen Christ, on the evening after His resurrection, revealing Himself to the apostles (with
+    // Martha, Mary, and Salome) and unfolding to them the signs of the end and the coming of the
+    // antichrist; it then sets out the "Holy Order" of the Church: the bishop, presbyters, deacons,
+    // widows, the care of the poor, the sick, the prisoner, baptism, the Eucharist, and the discipline
+    // that guards the flock from immorality and false teaching. These tests trace its load-bearing
+    // events and teachings.
+    public class FirstDominosNarrativeTests
+    {
+        [Fact]
+        public void TheRisenLordRevealsHimselfToTheApostlesAfterTheResurrection_IsADivineAct()
+        {
+            // On the evening after His resurrection the Lord shows Himself living to the apostles and,
+            // at their request, begins to teach them the things that must come to pass. (1 Covenant /
+            // Testamentum Domini I, prologue: the self-revelation of the risen Lord)
+            // Christ, raised, teaching truth and keeping His covenant promise to His own.
+            OracleHarness.DivineAct(OracleHarness.Grounded("the risen Lord reveals Himself to the apostles and teaches them after His resurrection",
+                Grounding.InGod(),
+                new RestoringLife(), new TeachingTruth(), new PromiseFulfilled(),
+                new CovenantFaithfulness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void ChristForetellsTheSignsOfTheEndToWarnAndPrepareTheFaithful_IsADivineAct()
+        {
+            // The Lord unfolds to the apostles the signs of the end, that the faithful may watch, endure,
+            // and not be deceived. (1 Covenant I: the apocalyptic discourse, the signs of the end)
+            // Christ teaching truth and guarding His people: a warning given in faithfulness, not fear.
+            OracleHarness.DivineAct(OracleHarness.Grounded("Christ foretells the signs of the end to warn and prepare His faithful",
+                Grounding.InGod(),
+                new TeachingTruth(), new Protection(), new CovenantFaithfulness(),
+                new Fidelity(), new Goodness()));
+        }
+
+        [Fact]
+        public void TheLordChargesTheFaithfulToEndureAndKeepCovenantInPersecution_IsRighteous()
+        {
+            // The faithful are set in the midst of wolves, despised by the worldly; the Lord charges them
+            // to stand firm, keep His covenant, and hold fast in patience. (1 Covenant I: exhortation to
+            // endurance amid persecution)
+            // The disciple's steadfastness: courageous faith, patient endurance, and covenant loyalty.
+            OracleHarness.Righteous(OracleHarness.Grounded("the faithful endure persecution and keep the Lord's covenant",
+                Grounding.InGod(),
+                new CourageousFaith(), new Endurance(), new Patience(),
+                new CovenantFaithfulness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheAntichristExaltsHimselfAndPersecutesTheSaints_IsSin()
+        {
+            // The apocalyptic discourse names the antichrist, who exalts himself, deceives the nations,
+            // claims worship, and persecutes the saints. (1 Covenant I: the coming of the antichrist)
+            // The lawless one: pride, deceit, blasphemy, idolatrous self-worship, and oppression.
+            OracleHarness.Sin(OracleHarness.Grounded("the antichrist exalts himself, deceives the nations, claims worship, and persecutes the saints",
+                Grounding.InIdol("antichrist"),
+                new Pride(), new Deceit(), new Blasphemy(), new Idolatry(),
+                new Oppression(), new Rebellion(), new Lawlessness()));
+        }
+
+        [Fact]
+        public void TheApostlesWorshipTheRisenLordAndReceiveHisCovenant_IsRighteous()
+        {
+            // Hearing the Lord, the apostles fall down, worship Him, and receive the covenant He gives.
+            // (1 Covenant I: the apostles' response and the giving of the Testament)
+            // Right response to the risen Lord: worship, obedience, humility, and covenant faith.
+            OracleHarness.Righteous(OracleHarness.Grounded("the apostles worship the risen Lord and receive His covenant",
+                Grounding.InGod(),
+                new Worship(), new ObedienceToGod(), new Humility(),
+                new CovenantFaithfulness(), new Trust()));
+        }
+
+        [Fact]
+        public void TheChurchOrdainsTheBishopToShepherdAndGuardTheFlock_IsRighteous()
+        {
+            // The Order sets out the ordination of the bishop, who is to feed, guard, and teach the flock
+            // as a faithful shepherd. (1 Covenant I: the ordination and office of the bishop)
+            // Faithful obedience that protects and teaches the people of God.
+            OracleHarness.Righteous(OracleHarness.Witness("the Church ordains the bishop to shepherd, guard, and teach the flock",
+                new ObedienceToGod(), new Protection(), new TeachingTruth(),
+                new CovenantFaithfulness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheBishopMustBeBlamelessMercifulAndHospitable_IsRighteous()
+        {
+            // The bishop is to be without reproach, self-controlled, gentle, merciful to the poor, and
+            // given to hospitality. (1 Covenant I: the qualities required of the bishop)
+            // The ordering of a holy life: self-mastery, gentleness, welcome, mercy, and purity.
+            OracleHarness.Righteous(OracleHarness.Witness("the bishop must be blameless, self-controlled, gentle, hospitable, and merciful",
+                new SelfControl(), new Gentleness(), new Hospitality(),
+                new Compassion(), new Humility(), new Purity()));
+        }
+
+        [Fact]
+        public void TheWidowsAndDeaconsServeThePoorSickAndImprisoned_IsRighteous()
+        {
+            // The Order appoints the widows to prayer and the deacons to minister to the poor, the sick,
+            // and those in prison. (1 Covenant I: the order of widows and deacons; the care of the needy)
+            // Mercy embodied: feeding the hungry, tending the sick, and visiting the imprisoned.
+            OracleHarness.Righteous(OracleHarness.Witness("the widows pray and the deacons serve the poor, the sick, and the imprisoned",
+                new FeedingTheHungry(), new CaringForTheSick(), new VisitingThePrisoner(),
+                new HonoringTheVulnerable(), new SelfSacrifice(), new Kindness()));
+        }
+
+        [Fact]
+        public void TheChurchClothesTheNakedAndGivesDrinkToTheThirsty_IsRighteous()
+        {
+            // The faithful bring their offerings so that the naked are clothed and the thirsty given drink
+            // from the Church's gifts. (1 Covenant I: the offerings and the care of the destitute)
+            // Generosity in action: clothing the naked, giving drink, and honoring the lowly.
+            OracleHarness.Righteous(OracleHarness.Witness("the Church clothes the naked and gives drink to the thirsty from its offerings",
+                new ClothingTheNaked(), new GivingDrink(), new Generosity(),
+                new HonoringTheVulnerable(), new Compassion()));
+        }
+
+        [Fact]
+        public void TheConvertRenouncesEvilAndIsBaptizedUntoTheLord_IsRighteous()
+        {
+            // The Order of baptism: the catechumen renounces the devil and his works, is washed, and is
+            // sealed unto the Lord. (1 Covenant I: the order of baptism)
+            // A turning from evil to God: repentance, cleansing, and faithful worship.
+            OracleHarness.Righteous(OracleHarness.Witness("the convert renounces evil and is baptized and sealed unto the Lord",
+                new Repentance(), new Purity(), new Worship(),
+                new ObedienceToGod(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void TheChurchOffersTheEucharistWithThanksgivingAndWorship_IsRighteous()
+        {
+            // The order of the holy offering: the people gather, give thanks, and the Body and Blood of
+            // the Lord are offered in remembrance of Him. (1 Covenant I: the order of the Eucharist and
+            // the prayers of thanksgiving)
+            // The Church's right worship: thanksgiving, reverence, joy, and obedient remembrance.
+            OracleHarness.Righteous(OracleHarness.Grounded("the Church offers the Eucharist with thanksgiving and worship",
+                Grounding.InGod(),
+                new Worship(), new ObedienceToGod(), new Joy(),
+                new Peace(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheUnworthyManSeizesTheHolyOfficeForGain_IsSin()
+        {
+            // The Order warns against the man who pushes himself forward to office out of pride and greed
+            // rather than calling. (1 Covenant I: against unworthy and ambitious ordination)
+            // Ambition and avarice corrupting the holy office: pride, greed, and self-seeking.
+            OracleHarness.Sin(OracleHarness.Grounded("an unworthy, greedy man seizes the holy office for gain",
+                Grounding.InIdol("self"),
+                new Pride(), new Greed(), new SelfishAmbition(), new SelfSeeking(), new Boasting()));
+        }
+
+        [Fact]
+        public void TheClergymanGivenToDrunkennessAndFornicationDefilesHisOffice_IsSin()
+        {
+            // The Order forbids the clergy from drunkenness, fornication, and filthy living, and commands
+            // the deposing of such. (1 Covenant I: the discipline of the clergy)
+            // Debauchery defiling the holy office: drunkenness, immorality, and impurity.
+            OracleHarness.Sin(OracleHarness.Witness("a clergyman given to drunkenness and fornication defiles his office",
+                new Drunkenness(), new SexualImmorality(), new Debauchery(), new Impurity(), new Defilement()));
+        }
+
+        [Fact]
+        public void FalseTeachersCorruptTheApostlesDoctrineAndLeadTheFlockAstray_IsSin()
+        {
+            // The Order commands that heretics and false teachers who corrupt the doctrine of the Lord and
+            // His apostles be rejected. (1 Covenant I: against false teaching and heresy)
+            // Deceit and rebellion against the truth, sowing division among the faithful.
+            OracleHarness.Sin(OracleHarness.Witness("false teachers corrupt the apostolic doctrine and lead the flock astray",
+                new Deceit(), new FalseWitness(), new Rebellion(), new SowingDiscord(), new Blasphemy()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/FirstEnochNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/FirstEnochNarrativeTests.cs
@@ -1,0 +1,112 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 1 Enoch (ETH) narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class FirstEnochNarrativeTests
+    {
+        [Fact]
+        public void TheWatchersSwearAndDescendToTakeWivesOfMen_IsSin()
+        {
+            // "the angels, the children of heaven, saw and lusted after them ... and they all descended on Hermon and took unto themselves wives." (1 Enoch 6:1-2; 7:1)
+            OracleHarness.Sin(OracleHarness.Witness("the Watchers, sons of heaven, lust after the daughters of men and descend to take them as wives, defiling themselves", new Lust(), new SexualImmorality(), new Defilement()));
+            Assert.Equal(1.0, OracleHarness.Witness("the Watchers, sons of heaven, lust after the daughters of men and descend to take them as wives, defiling themselves", new Lust(), new SexualImmorality(), new Defilement()).Disorder);
+        }
+
+        [Fact]
+        public void TheGiantsDevourMankindAndSpillBlood_IsSin()
+        {
+            // "the giants ... devoured all the acquisitions of men ... they began to sin against birds, and beasts ... and to devour one another's flesh, and drink the blood." (1 Enoch 7:3-5)
+            OracleHarness.Sin(OracleHarness.Witness("the giants born of the Watchers devour the labor of men, then murder and feed on flesh and drink the blood of the earth", new Murder(), new Bloodshed(), new Oppression()));
+            Assert.Equal(1.0, OracleHarness.Witness("the giants born of the Watchers devour the labor of men, then murder and feed on flesh and drink the blood of the earth", new Murder(), new Bloodshed(), new Oppression()).Disorder);
+        }
+
+        [Fact]
+        public void AzazelTeachesWeaponsSorceryAndForbiddenArts_IsSin()
+        {
+            // "Azazel taught men to make swords ... and made known to them the metals ... and all kinds of costly stones ... and there arose much godlessness ... Semjaza taught enchantments." (1 Enoch 8:1-3)
+            OracleHarness.Sin(OracleHarness.Witness("Azazel teaches men to forge swords and ornaments and seductions, and the Watchers teach sorcery and enchantments, leading the world astray", new Sorcery(), new Deceit(), new Wrongdoing()));
+        }
+
+        [Fact]
+        public void TheCryOfTheEarthAndTheBloodOfMenAscends_IsRighteous()
+        {
+            // "the souls of men made their suit, saying, 'Bring our cause before the Most High.'" (1 Enoch 8:4; 9:3,10)
+            OracleHarness.Righteous(OracleHarness.Witness("the dying souls of men cry out and bring their cause before the Most High, mourning under the violence done to them", new Mourning(), new HungerForRighteousness(), new Endurance()));
+        }
+
+        [Fact]
+        public void TheArchangelsIntercedeAndPleadForJudgmentBeforeGod_IsRighteous()
+        {
+            // "Michael, Uriel, Raphael, and Gabriel looked down ... and said one to another: 'The earth made without inhabitant cries the voice ... unto the gates of heaven.'" (1 Enoch 9:1-3)
+            OracleHarness.Righteous(OracleHarness.Witness("the holy archangels Michael, Uriel, Raphael, and Gabriel behold the bloodshed and faithfully bring the plea of the earth before the throne of God", new Fidelity(), new ObedienceToGod(), new DefendingTheWeak()));
+        }
+
+        [Fact]
+        public void GodSendsRaphaelToBindAzazelAndHealTheEarth_IsADivineAct()
+        {
+            // "the Most High ... said to Raphael: 'Bind Azazel hand and foot ... and the whole earth has been corrupted ... and heal the earth which the angels have corrupted.'" (1 Enoch 10:4-7)
+            OracleHarness.DivineAct(OracleHarness.Witness("God sends Raphael to bind Azazel and to heal the earth that the Watchers corrupted, restoring its order", new Healing(), new Righteousness(), new CreationOrder()));
+        }
+
+        [Fact]
+        public void GodSendsGabrielAgainstTheGiantsToCleanseTheEarth_IsADivineAct()
+        {
+            // "to Gabriel said the Lord: 'Proceed against the bastards ... and the children of fornication, and destroy the children of the Watchers from amongst men.'" (1 Enoch 10:9-10)
+            OracleHarness.DivineAct(OracleHarness.Witness("God sends Gabriel to recompense the violent giants with just judgment and to cleanse the earth of their oppression", new JustRecompense(), new Righteousness(), new Protection()));
+        }
+
+        [Fact]
+        public void GodPromisesToCleanseTheEarthAndPlantRighteousness_IsADivineAct()
+        {
+            // "Cleanse the earth from all oppression ... and all the children of men shall become righteous ... and I will plant it in righteousness." (1 Enoch 10:16-22)
+            OracleHarness.DivineAct(OracleHarness.Witness("God promises to cleanse the earth of all oppression and plant the plant of righteousness and truth, blessing it with peace", new Righteousness(), new PromiseFulfilled(), new Peace()));
+        }
+
+        [Fact]
+        public void EnochIntercedesAndWritesThePetitionOfTheFallenWatchers_IsRighteous()
+        {
+            // "they besought me to draw up a petition for them ... And Enoch went and said: 'Azazel, thou shalt have no peace.'" (1 Enoch 13:1-6)
+            OracleHarness.Righteous(OracleHarness.Witness("Enoch the scribe of righteousness compassionately writes the petition of the fallen Watchers and carries their request before God", new Compassion(), new Trustworthiness(), new Righteousness()));
+        }
+
+        [Fact]
+        public void GodPronouncesTheWatchersHaveNoPeaceForForsakingHeaven_IsADivineAct()
+        {
+            // "Wherefore have ye left the high, holy, and eternal heaven ... and defiled yourselves with the daughters of men ... ye shall have no peace nor forgiveness of sin." (1 Enoch 15:3; 16:4)
+            OracleHarness.DivineAct(OracleHarness.Witness("God justly declares to the Watchers that they have no peace, having forsaken holy heaven for defilement, and renders righteous judgment", new Righteousness(), new JustRecompense(), new CreationOrder()));
+        }
+
+        [Fact]
+        public void EnochWalksWithGodAndIsShownTheVisionsOfHeaven_IsRighteous()
+        {
+            // "And Enoch was hidden ... and his activities had to do with the Watchers, and his days were with the holy ones." (1 Enoch 12:1-2; 14:8ff)
+            OracleHarness.Righteous(OracleHarness.Witness("Enoch walks faithfully with God, worshipping before the throne of glory and obediently receiving the visions of heaven", new Worship(), new Fidelity(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TheLuminariesTransgressTheirOrderedCoursesBecauseOfSin_IsSin()
+        {
+            // "in the days of the sinners the years shall be shortened ... and all things on the earth shall alter ... and the moon shall alter her order." (1 Enoch 80:2-8)
+            OracleHarness.Sin(OracleHarness.Witness("because of the sin of men the heavenly luminaries forsake their ordered courses and the seasons fall into confusion", new Chaos(), new Lawlessness(), new Wrongdoing()));
+        }
+
+        [Fact]
+        public void TheElectOneSitsToJudgeAndCastDownTheKingsAndMighty_IsADivineAct()
+        {
+            // "the Lord of Spirits seated him on the throne of His glory, and the spirit of righteousness was poured out upon him ... and he shall judge ... the kings and the mighty." (1 Enoch 62:2-9)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Elect One, the Son of Man, sits on the throne of glory and renders righteous judgment, delivering the oppressed and casting down the mighty", new Righteousness(), new JustRecompense(), new Deliverance()));
+        }
+
+        [Fact]
+        public void TheRighteousAndElectShallDwellInLightAndPeaceForever_IsADivineAct()
+        {
+            // "the righteous and elect shall be saved on that day ... and with that Son of Man shall they eat and lie down and rise up for ever and ever." (1 Enoch 58:2-3; 62:14)
+            OracleHarness.DivineAct(OracleHarness.Witness("God grants the righteous and elect an inheritance of unending light, peace, and joy in the presence of the Son of Man", new Peace(), new Joy(), new Goodness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/FirstJohnNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/FirstJohnNarrativeTests.cs
@@ -1,0 +1,156 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 1 John narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class FirstJohnNarrativeTests
+    {
+        [Fact]
+        public void ChristTheWordOfLifeIsProclaimedThatJoyMayBeComplete_IsADivineAct()
+        {
+            // "the life was made manifest ... we proclaim to you ... so that our joy may be complete." (1 John 1:1-4)
+            OracleHarness.DivineAct(OracleHarness.Witness("the eternal Word of life is made manifest and proclaimed by the apostles, so that the fellowship of the believers may be complete and their joy full", new TeachingTruth(), new RejoicingInTruth(), new RestoringLife(), new Joy()));
+        }
+
+        [Fact]
+        public void TheBloodOfJesusCleansesUsFromAllSin_IsADivineAct()
+        {
+            // "the blood of Jesus his Son cleanses us from all sin." (1 John 1:7)
+            OracleHarness.DivineAct(OracleHarness.Witness("walking in the light, the blood of Jesus the Son cleanses the believers from all sin and brings them into true fellowship", new Atonement(), new Purity(), new Deliverance()));
+        }
+
+        [Fact]
+        public void IfWeConfessOurSinsGodIsFaithfulToForgiveAndCleanse_IsADivineAct()
+        {
+            // "If we confess our sins, he is faithful and just to forgive us our sins and to cleanse us." (1 John 1:9)
+            OracleHarness.DivineAct(OracleHarness.Witness("God, faithful and just, forgives the confessed sins of the believers and cleanses them from all unrighteousness", new Pardon(), new Fidelity(), new Righteousness(), new Purity()));
+        }
+
+        [Fact]
+        public void ClaimingToBeWithoutSinIsSelfDeceptionThatRejectsTheTruth_IsSin()
+        {
+            // "If we say we have no sin, we deceive ourselves, and the truth is not in us." (1 John 1:8,10)
+            OracleHarness.Sin(OracleHarness.Witness("the proud heart claims to have no sin, deceiving itself, making God a liar and refusing the truth", new Deceit(), new Pride(), new Blasphemy()));
+        }
+
+        [Fact]
+        public void JesusChristTheRighteousIsOurAdvocateAndPropitiation_IsADivineAct()
+        {
+            // "we have an advocate ... Jesus Christ the righteous. He is the propitiation for our sins ... and for the whole world." (1 John 2:1-2)
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus Christ the righteous stands as advocate before the Father and is Himself the propitiation for the sins of the whole world", new Atonement(), new Righteousness(), new SelfSacrifice(), new Deliverance()));
+        }
+
+        [Fact]
+        public void WhoeverKeepsHisWordHasTheLoveOfGodPerfectedInHim_IsRighteous()
+        {
+            // "whoever keeps his word, in him truly the love of God is perfected ... walk in the same way in which he walked." (1 John 2:5-6)
+            OracleHarness.Righteous(OracleHarness.Witness("the believer keeps God's word and walks as Christ walked, so that the love of God is perfected in him", new ObedienceToGod(), new Kindness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void WhoeverHatesHisBrotherWalksInDarknessAndBlindness_IsSin()
+        {
+            // "Whoever ... hates his brother is still in darkness ... and walks in the darkness, and does not know where he is going." (1 John 2:9-11)
+            OracleHarness.Sin(OracleHarness.Witness("the one who claims the light yet hates his brother walks in darkness, blinded, and stumbles in discord", new Hatred(), new Discord(), new Deceit()));
+        }
+
+        [Fact]
+        public void LovingTheWorldAndItsDesiresIsNotFromTheFather_IsSin()
+        {
+            // "the desires of the flesh and the desires of the eyes and pride of life ... is not from the Father." (1 John 2:15-17)
+            OracleHarness.Sin(OracleHarness.Witness("the heart loves the world with the lust of the flesh, the lust of the eyes, and the proud boasting of life, which is not from the Father", new Lust(), new HaughtyEyes(), new Pride(), new Boasting()));
+        }
+
+        [Fact]
+        public void TheAntichristIsTheLiarWhoDeniesTheFatherAndTheSon_IsSin()
+        {
+            // "Who is the liar but he who denies that Jesus is the Christ? This is the antichrist." (1 John 2:22-23)
+            OracleHarness.Sin(OracleHarness.Witness("the antichrist lies and denies that Jesus is the Christ, rejecting both the Father and the Son", new Deceit(), new FalseWitness(), new Blasphemy(), new Rebellion()));
+        }
+
+        [Fact]
+        public void TheFatherLavishesHisLoveToMakeUsChildrenOfGod_IsADivineAct()
+        {
+            // "See what kind of love the Father has given to us, that we should be called children of God." (1 John 3:1-2)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Father lavishes His love upon the believers, naming them children of God and promising they shall be like Him when He appears", new Compassion(), new Kindness(), new CovenantFaithfulness(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void ChristAppearedToTakeAwaySinsAndDestroyTheWorksOfTheDevil_IsADivineAct()
+        {
+            // "he appeared to take away sins ... The reason the Son of God appeared was to destroy the works of the devil." (1 John 3:5,8)
+            OracleHarness.DivineAct(OracleHarness.Witness("the sinless Son of God appears to take away sins and to destroy the works of the devil, delivering the children of God", new Atonement(), new Deliverance(), new Righteousness(), new Protection()));
+        }
+
+        [Fact]
+        public void CainWhoWasOfTheEvilOneMurderedHisRighteousBrother_IsSin()
+        {
+            // "not like Cain, who was of the evil one and murdered his brother. And why did he murder him? Because ... his brother's were righteous." (1 John 3:12)
+            Resolution resolution = OracleHarness.Witness("Cain, being of the evil one, hates his righteous brother and rises up to murder him out of envy", new Murder(), new Hatred(), new Envy(), new Bloodshed());
+            OracleHarness.Sin(resolution);
+            Assert.Equal(1.0, resolution.Disorder);
+        }
+
+        [Fact]
+        public void WhoeverHatesHisBrotherIsAMurderer_IsSin()
+        {
+            // "Everyone who hates his brother is a murderer, and ... no murderer has eternal life abiding in him." (1 John 3:15)
+            Resolution resolution = OracleHarness.Witness("the one who hates his brother is in truth a murderer, having no eternal life abiding in him", new Hatred(), new Murder(), new Malice());
+            OracleHarness.Sin(resolution);
+            Assert.Equal(1.0, resolution.Disorder);
+        }
+
+        [Fact]
+        public void ChristLaidDownHisLifeAndSoWeLayDownOurLivesForTheBrothers_IsADivineAct()
+        {
+            // "he laid down his life for us, and we ought to lay down our lives for the brothers." (1 John 3:16)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ lays down His life for the brethren, the very measure by which we know love", new SelfSacrifice(), new Compassion(), new Protection()));
+        }
+
+        [Fact]
+        public void WeLoveNotInWordButInDeedByMeetingTheBrothersNeed_IsRighteous()
+        {
+            // "if anyone has the world's goods and sees his brother in need ... let us not love in word but in deed and in truth." (1 John 3:17-18)
+            OracleHarness.Righteous(OracleHarness.Witness("the believer who has goods sees his brother in need and opens his heart, loving not in word only but in deed and in truth", new Compassion(), new Generosity(), new RejoicingInTruth(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void GodSentHisOnlySonAsThePropitiationBecauseGodIsLove_IsADivineAct()
+        {
+            // "God is love ... God sent his only Son ... to be the propitiation for our sins." (1 John 4:8-10)
+            OracleHarness.DivineAct(OracleHarness.Witness("because God is love, He sends His only Son into the world as the propitiation for our sins, that we might live through Him", new SelfSacrifice(), new Atonement(), new Compassion(), new RestoringLife()));
+        }
+
+        [Fact]
+        public void IfGodSoLovedUsWeAlsoOughtToLoveOneAnother_IsRighteous()
+        {
+            // "if God so loved us, we also ought to love one another ... his love is perfected in us." (1 John 4:11-12)
+            OracleHarness.Righteous(OracleHarness.Witness("since God so loved them, the believers also love one another, and God's love is perfected and abides in them", new Kindness(), new Compassion(), new Fidelity()));
+        }
+
+        [Fact]
+        public void ClaimingToLoveGodWhileHatingABrotherIsTheWordOfALiar_IsSin()
+        {
+            // "If anyone says, 'I love God,' and hates his brother, he is a liar." (1 John 4:20)
+            OracleHarness.Sin(OracleHarness.Witness("the man claims to love God whom he has not seen while he hates the brother whom he has seen, and so is shown to be a liar", new Hatred(), new Deceit(), new FalseWitness()));
+        }
+
+        [Fact]
+        public void WhoeverIsBornOfGodOvercomesTheWorldThroughFaith_IsRighteous()
+        {
+            // "everyone who has been born of God overcomes the world. And this is the victory ... our faith." (1 John 5:4-5)
+            OracleHarness.Righteous(OracleHarness.Witness("the one born of God overcomes the world by believing that Jesus is the Son of God, and this faith is the victory", new CourageousFaith(), new Fidelity(), new Trust(), new Endurance()));
+        }
+
+        [Fact]
+        public void GodGivesUsEternalLifeWhichIsInHisSon_IsADivineAct()
+        {
+            // "God gave us eternal life, and this life is in his Son. Whoever has the Son has life." (1 John 5:11-13)
+            OracleHarness.DivineAct(OracleHarness.Witness("God testifies and gives the believers eternal life, and this life is in His Son, so that whoever has the Son has life", new RestoringLife(), new PromiseFulfilled(), new Trustworthiness(), new Goodness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/FirstMaccabeesNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/FirstMaccabeesNarrativeTests.cs
@@ -1,0 +1,142 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 1 Maccabees narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class FirstMaccabeesNarrativeTests
+    {
+        [Fact]
+        public void AntiochusPlundersTheTempleAndShedsBlood_IsSin()
+        {
+            // Antiochus Epiphanes enters the sanctuary in arrogance, strips the golden altar,
+            // lampstand, and vessels, and "shed much blood, and spoke with great arrogance." (1 Macc 1:20-24)
+            // Proud, sacrilegious plunder of God's house, steeped in bloodshed.
+            OracleHarness.Sin(OracleHarness.Witness("Antiochus plunders the temple in Jerusalem and sheds much blood",
+                new Theft(), new Defilement(), new Bloodshed(), new Pride(), new Blasphemy()));
+            Assert.Equal(1.0, OracleHarness.Witness("Antiochus plunders the temple in Jerusalem and sheds much blood",
+                new Theft(), new Defilement(), new Bloodshed(), new Pride(), new Blasphemy()).Disorder);
+        }
+
+        [Fact]
+        public void AntiochusOutlawsTheLawAndCommandsIdolatry_IsSin()
+        {
+            // The king decrees that all should "follow customs strange to the land," forbidding burnt
+            // offerings, profaning Sabbaths, building altars to idols, and sacrificing swine. (1 Macc 1:41-50)
+            // Lawless decree forcing apostasy, idolatry, and the breaking of God's covenant.
+            OracleHarness.Sin(OracleHarness.Witness("Antiochus outlaws the Law and commands the nations to worship idols",
+                new Idolatry(), new Lawlessness(), new CovenantBreaking(), new Oppression(), new Blasphemy()));
+        }
+
+        [Fact]
+        public void TheAbominationOfDesolationIsSetUpOnTheAltar_IsSin()
+        {
+            // "They erected a desolating sacrilege upon the altar of burnt offering," sacrificing on
+            // pagan altars and defiling the sanctuary. (1 Macc 1:54-59)
+            // The supreme defilement of God's holy place by idolatrous worship.
+            OracleHarness.Sin(OracleHarness.Witness("The abomination of desolation is set up on the altar of God",
+                new Defilement(), new Idolatry(), new Blasphemy(), new Lawlessness()));
+            Assert.Equal(1.0, OracleHarness.Witness("The abomination of desolation is set up on the altar of God",
+                new Defilement(), new Idolatry(), new Blasphemy(), new Lawlessness()).Disorder);
+        }
+
+        [Fact]
+        public void FaithfulIsraelitesChooseDeathRatherThanDefileThemselves_IsRighteous()
+        {
+            // "Many in Israel stood firm and resolved in their hearts not to eat unclean food. They chose
+            // to die rather than be defiled ... and they did die." (1 Macc 1:62-63)
+            // Faithful endurance unto death rather than break the covenant.
+            OracleHarness.Righteous(OracleHarness.Witness("Faithful Israelites choose to die rather than defile themselves",
+                new CourageousFaith(), new Endurance(), new Fidelity(), new ObedienceToGod(), new Purity()));
+        }
+
+        [Fact]
+        public void MattathiasRefusesToSacrificeToIdols_IsRighteous()
+        {
+            // "I and my sons and my brothers will live by the covenant of our fathers ... we will not obey
+            // the king's words by turning aside from our religion." (1 Macc 2:19-22)
+            // Steadfast covenant faithfulness and courageous refusal of idolatry.
+            OracleHarness.Righteous(OracleHarness.Witness("Mattathias refuses to forsake the covenant and sacrifice to idols",
+                new CovenantFaithfulness(), new CourageousFaith(), new ObedienceToGod(), new Fidelity()));
+        }
+
+        [Fact]
+        public void MattathiasBurnsWithZealAndTearsDownTheIdolAltar_IsRighteous()
+        {
+            // Mattathias "burned with zeal for the law," pulled down the pagan altar, and called out,
+            // "Let every one who is zealous for the law and supports the covenant come out with me!" (1 Macc 2:24-27)
+            // Holy zeal defending God's covenant and casting down idolatry.
+            OracleHarness.Righteous(OracleHarness.Grounded("Mattathias tears down the idol altar and rallies the zealous for the covenant",
+                Grounding.InGod(),
+                new CovenantFaithfulness(), new CourageousFaith(), new ObedienceToGod(), new Worship()));
+        }
+
+        [Fact]
+        public void TheFaithfulResolveToDefendLifeOnTheSabbath_IsRighteous()
+        {
+            // After a thousand are slaughtered for refusing to fight on the Sabbath, the people resolve,
+            // "Let us fight ... that we may not all die." (1 Macc 2:39-41)
+            // Wise, life-protecting defense of God's people without forsaking Him.
+            OracleHarness.Righteous(OracleHarness.Witness("The faithful resolve to defend their lives even on the Sabbath",
+                new Protection(), new DefendingTheWeak(), new CourageousFaith(), new Endurance()));
+        }
+
+        [Fact]
+        public void JudasMaccabeusPraysAndDeliversIsraelFromOppressors_IsRighteous()
+        {
+            // Judas Maccabeus, before battle, leads the people in prayer and fasting, then routs Apollonius
+            // and Seron, "and saved Israel." (1 Macc 3:10-26; 4:8-11)
+            // Courageous, trusting defense of God's people against the oppressor.
+            OracleHarness.Righteous(OracleHarness.Grounded("Judas Maccabeus prays and delivers Israel from her oppressors",
+                Grounding.InGod(),
+                new CourageousFaith(), new Trust(), new DefendingTheWeak(), new Deliverance(), new Protection()));
+        }
+
+        [Fact]
+        public void GodGivesVictoryToJudasOverTheMightyArmyOfGorgias_IsADivineAct()
+        {
+            // Against an overwhelming host, Judas cries, "It is not on the size of the army that victory
+            // ... depends, but strength comes from Heaven," and the Lord crushes the enemy. (1 Macc 3:18-19; 4:14-15)
+            // Scripture's verdict is the salvation Heaven works for the weak who trust Him.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God gives Judas the victory over the mighty army at Emmaus",
+                Grounding.InGod(),
+                new Deliverance(), new Protection(), new DefendingTheWeak(), new JustRecompense(),
+                new Fidelity(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void JudasCleansesAndRededicatesTheTemple_IsRighteous()
+        {
+            // Judas tears down the defiled altar, builds a new one, and rededicates the sanctuary with
+            // joy, song, and burnt offerings. (1 Macc 4:36-58)
+            // Joyful, worshipful restoration of God's house and covenant worship.
+            OracleHarness.Righteous(OracleHarness.Grounded("Judas cleanses the temple and rededicates it with worship and joy",
+                Grounding.InGod(),
+                new Worship(), new Joy(), new CovenantFaithfulness(), new RejoicingInTruth(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void NicanorBlasphemesAndThreatensToBurnTheTemple_IsSin()
+        {
+            // Nicanor stretches out his hand against the sanctuary in arrogance, threatening to burn
+            // God's house unless Judas is handed over, and blasphemes. (1 Macc 7:33-35)
+            // Proud blasphemy and threatened defilement of the holy place.
+            OracleHarness.Sin(OracleHarness.Witness("Nicanor blasphemes the temple and threatens to burn it down",
+                new Blasphemy(), new Pride(), new Defilement(), new Boasting(), new Oppression()));
+        }
+
+        [Fact]
+        public void SimonLeadsIsraelInPeaceJusticeAndCareForTheLowly_IsRighteous()
+        {
+            // Under Simon "the land had rest ... he made the poor man's heart glad," providing food,
+            // strengthening the lowly, and the people sat under their own vines in peace. (1 Macc 14:8-15)
+            // Just, generous, peace-giving stewardship that cares for the vulnerable.
+            OracleHarness.Righteous(OracleHarness.Witness("Simon governs Israel in peace, justice, and care for the lowly",
+                new Peace(), new Goodness(), new Generosity(), new HonoringTheVulnerable(),
+                new DefendingTheWeak(), new Peacemaking()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/FirstPeterNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/FirstPeterNarrativeTests.cs
@@ -1,0 +1,138 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 1 Peter narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class FirstPeterNarrativeTests
+    {
+        [Fact]
+        public void GodBegetsUsAgainToALivingHopeByTheResurrection_IsADivineAct()
+        {
+            // "he has caused us to be born again to a living hope through the resurrection of Jesus Christ." (1 Peter 1:3-5)
+            OracleHarness.DivineAct(OracleHarness.Witness("God in His great mercy begets believers again to a living hope, raising Christ and guarding an imperishable inheritance", new Compassion(), new RestoringLife(), new Deliverance()));
+        }
+
+        [Fact]
+        public void BelieversRejoiceWithJoyInTrialsThatTestTheirFaith_IsRighteous()
+        {
+            // "you rejoice ... though now for a little while ... you have been grieved by various trials, so that the tested genuineness of your faith ..." (1 Peter 1:6-7)
+            OracleHarness.Righteous(OracleHarness.Witness("the believers rejoice with inexpressible joy while their faith is tested and proven genuine through trials", new Joy(), new Endurance(), new Fidelity()));
+        }
+
+        [Fact]
+        public void BelieversAreToBeHolyAndSelfControlledAsGodIsHoly_IsRighteous()
+        {
+            // "be holy in all your conduct ... preparing your minds for action, and being sober-minded." (1 Peter 1:13-16)
+            OracleHarness.Righteous(OracleHarness.Witness("the believer girds up his mind, stays sober and self-controlled, and is holy in all conduct as God is holy", new SelfControl(), new Purity(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void RansomedByThePreciousBloodOfChristTheUnblemishedLamb_IsADivineAct()
+        {
+            // "you were ransomed ... with the precious blood of Christ, like that of a lamb without blemish." (1 Peter 1:18-19)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ the unblemished Lamb ransoms His people by His own precious blood, foreknown before the foundation of the world", new SelfSacrifice(), new Atonement(), new Deliverance()));
+        }
+
+        [Fact]
+        public void BelieversLoveOneAnotherEarnestlyFromAPureHeart_IsRighteous()
+        {
+            // "love one another earnestly from a pure heart, since you have been born again." (1 Peter 1:22)
+            OracleHarness.Righteous(OracleHarness.Witness("having purified their souls by obedience to the truth, the believers love one another earnestly from a pure heart", new Kindness(), new Purity(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void PutAwayMaliceDeceitHypocrisyEnvyAndSlander_IsSin()
+        {
+            // "put away all malice and all deceit and hypocrisy and envy and all slander." (1 Peter 2:1)
+            OracleHarness.Sin(OracleHarness.Witness("the flesh clings to malice and deceit and envy and slander against the brethren", new Malice(), new Deceit(), new Envy(), new Slander()));
+        }
+
+        [Fact]
+        public void TheChosenPeopleProclaimTheExcellenciesOfGodInWorship_IsRighteous()
+        {
+            // "a chosen race, a royal priesthood ... that you may proclaim the excellencies of him who called you." (1 Peter 2:9)
+            OracleHarness.Righteous(OracleHarness.Witness("the chosen royal priesthood proclaims the excellencies of God who called them out of darkness into His marvelous light", new Worship(), new RejoicingInTruth(), new Fidelity()));
+        }
+
+        [Fact]
+        public void ChristBoreOurSinsOnTheTreeAndByHisWoundsWeAreHealed_IsADivineAct()
+        {
+            // "He himself bore our sins in his body on the tree ... By his wounds you have been healed." (1 Peter 2:24-25)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ bears our sins in His body on the tree, suffering for the unrighteous, so that by His wounds we are healed and returned to the Shepherd", new SelfSacrifice(), new Atonement(), new Healing(), new RestoringLife()));
+        }
+
+        [Fact]
+        public void ChristCommittedNoSinAndDidNotRevileWhenReviled_IsADivineAct()
+        {
+            // "He committed no sin, neither was deceit found in his mouth. When he was reviled, he did not revile in return." (1 Peter 2:22-23)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ commits no sin and no deceit, and when reviled He does not revile but entrusts Himself to the righteous Judge", new Righteousness(), new Patience(), new SelfControl()));
+        }
+
+        [Fact]
+        public void ServantsEndureUnjustSufferingPatientlyDoingGood_IsRighteous()
+        {
+            // "if when you do good and suffer for it you endure, this is a gracious thing in the sight of God." (1 Peter 2:18-20)
+            OracleHarness.Righteous(OracleHarness.Witness("the servant submits and patiently endures unjust suffering while continuing to do good, which is gracious before God", new Patience(), new Endurance(), new Goodness(), new Humility()));
+        }
+
+        [Fact]
+        public void DoNotRepayEvilForEvilButBlessInstead_IsRighteous()
+        {
+            // "Do not repay evil for evil or reviling for reviling, but on the contrary, bless." (1 Peter 3:8-9)
+            OracleHarness.Righteous(OracleHarness.Witness("the believers do not repay evil for evil but show unity, sympathy, tender hearts, and bless those who revile them", new Forgiveness(), new Compassion(), new Peacemaking(), new Gentleness()));
+        }
+
+        [Fact]
+        public void BelieversGiveAGentleAndReverentDefenseOfTheirHope_IsRighteous()
+        {
+            // "always being prepared to make a defense ... yet do it with gentleness and respect." (1 Peter 3:15)
+            OracleHarness.Righteous(OracleHarness.Witness("the believer makes a defense for the hope within him with gentleness and reverence, keeping a good conscience", new CourageousFaith(), new Gentleness(), new TeachingTruth()));
+        }
+
+        [Fact]
+        public void LiveNoLongerInDebaucheryDrunkennessAndLawlessIdolatry_IsSin()
+        {
+            // "the time that is past suffices for ... living in sensuality, passions, drunkenness, orgies, drinking parties, and lawless idolatry." (1 Peter 4:3)
+            OracleHarness.Sin(OracleHarness.Witness("the Gentiles spend their days in sensuality, drunkenness, carousing, and lawless idolatry", new Debauchery(), new Drunkenness(), new Carousing(), new Idolatry()));
+        }
+
+        [Fact]
+        public void BelieversShowEarnestLoveAndHospitalityWithoutGrumbling_IsRighteous()
+        {
+            // "keep loving one another earnestly ... Show hospitality to one another without grumbling." (1 Peter 4:8-9)
+            OracleHarness.Righteous(OracleHarness.Witness("the believers keep loving one another earnestly and show hospitality without grumbling, covering a multitude of sins", new Kindness(), new Hospitality(), new Forgiveness()));
+        }
+
+        [Fact]
+        public void EachServesWithTheGiftReceivedAsGoodStewardsOfGrace_IsRighteous()
+        {
+            // "As each has received a gift, use it to serve one another, as good stewards of God's varied grace." (1 Peter 4:10-11)
+            OracleHarness.Righteous(OracleHarness.Witness("each believer uses the gift received to serve others as a good steward of God's grace, that God may be glorified", new Generosity(), new Fidelity(), new Goodness()));
+        }
+
+        [Fact]
+        public void EldersShepherdTheFlockHumblyNotForShamefulGain_IsRighteous()
+        {
+            // "shepherd the flock of God ... not for shameful gain, but eagerly; not domineering ... but being examples." (1 Peter 5:2-3)
+            OracleHarness.Righteous(OracleHarness.Witness("the elders willingly shepherd God's flock, not for shameful gain nor lording it over them, but as humble examples", new Protection(), new Humility(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void BelieversHumbleThemselvesAndCastTheirAnxietyOnGod_IsRighteous()
+        {
+            // "Humble yourselves ... under the mighty hand of God ... casting all your anxieties on him." (1 Peter 5:6-7)
+            OracleHarness.Righteous(OracleHarness.Witness("the believers humble themselves under God's mighty hand and cast all their anxiety on Him, trusting that He cares for them", new Humility(), new Trust(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void GodHimselfRestoresAndStrengthensThoseWhoSufferAWhile_IsADivineAct()
+        {
+            // "the God of all grace ... will himself restore, confirm, strengthen, and establish you." (1 Peter 5:10)
+            OracleHarness.DivineAct(OracleHarness.Witness("the God of all grace Himself restores, confirms, strengthens, and establishes the believers after they have suffered a little while", new RestoringLife(), new Healing(), new CovenantFaithfulness(), new Goodness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/FirstThessaloniansNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/FirstThessaloniansNarrativeTests.cs
@@ -1,0 +1,117 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 1 Thessalonians narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class FirstThessaloniansNarrativeTests
+    {
+        [Fact]
+        public void ThessaloniansTurnFromIdolsToServeTheLivingGod_IsRighteous()
+        {
+            // "You turned to God from idols to serve the living and true God." (1 Thessalonians 1:9)
+            OracleHarness.Righteous(OracleHarness.Witness("the Thessalonians forsake idols and worship the living God", new Repentance(), new Worship(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TheirWorkOfFaithAndLaborOfLove_IsRighteous()
+        {
+            // "Your work of faith and labor of love and steadfastness of hope." (1 Thessalonians 1:3)
+            OracleHarness.Righteous(OracleHarness.Witness("the church labors in faith, love, and steadfast hope", new Fidelity(), new Kindness(), new Endurance()));
+        }
+
+        [Fact]
+        public void PaulPreachesTheGospelGentlyNotToPleaseMen_IsRighteous()
+        {
+            // "We were gentle among you ... not trying to please men but God." (1 Thessalonians 2:4-7)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul declares the gospel gently, seeking to please God", new Gentleness(), new TeachingTruth(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void PaulLaborsNightAndDaySoAsNotToBurdenThem_IsRighteous()
+        {
+            // "We worked night and day, that we might not burden any of you." (1 Thessalonians 2:9)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul toils night and day to burden no one", new SelfSacrifice(), new Generosity()));
+        }
+
+        [Fact]
+        public void PaulExhortsThemAsAFatherCaresForHisChildren_IsRighteous()
+        {
+            // "Like a father with his children ... exhorting and encouraging." (1 Thessalonians 2:11-12)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul nurtures the church like a father his children", new Compassion(), new Kindness(), new TeachingTruth()));
+        }
+
+        [Fact]
+        public void TimothyIsSentToStrengthenAndEncourageTheChurch_IsRighteous()
+        {
+            // "We sent Timothy ... to establish and exhort you in your faith." (1 Thessalonians 3:2)
+            OracleHarness.Righteous(OracleHarness.Witness("Timothy is sent to strengthen the believers in their faith", new Protection(), new CovenantFaithfulness(), new Compassion()));
+        }
+
+        [Fact]
+        public void GodIsCalledToMakeTheirLoveIncreaseAndAbound_IsADivineAct()
+        {
+            // "May the Lord make you increase and abound in love for one another and for all." (1 Thessalonians 3:12)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Lord makes their love increase and abound for all", new Kindness(), new Compassion(), new Goodness()));
+        }
+
+        [Fact]
+        public void AbstainFromSexualImmoralityAndLivingInHoliness_IsRighteous()
+        {
+            // "This is the will of God ... that you abstain from sexual immorality ... in holiness and honor." (1 Thessalonians 4:3-4)
+            OracleHarness.Righteous(OracleHarness.Witness("the believers keep the body in holiness and honor", new Purity(), new SelfControl(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void DefraudingABrotherInTheMatterOfLust_IsSin()
+        {
+            // "That no one transgress and wrong his brother in this matter." (1 Thessalonians 4:6)
+            OracleHarness.Sin(OracleHarness.Witness("a man wrongs his brother through unbridled lust", new Lust(), new Wrongdoing()));
+        }
+
+        [Fact]
+        public void LoveOneAnotherAndLiveQuietlyMindingYourOwnAffairs_IsRighteous()
+        {
+            // "Love one another ... aspire to live quietly ... work with your hands." (1 Thessalonians 4:9-11)
+            OracleHarness.Righteous(OracleHarness.Witness("the church loves one another and lives a quiet, working life", new Kindness(), new Peace(), new SelfControl()));
+        }
+
+        [Fact]
+        public void ChristWillDescendAndRaiseTheDeadInChrist_IsADivineAct()
+        {
+            // "The dead in Christ will rise ... we will always be with the Lord." (1 Thessalonians 4:16-17)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Lord descends and raises the dead in Christ to be with him", new RestoringLife(), new Deliverance(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void EncourageOneAnotherAndBuildOneAnotherUp_IsRighteous()
+        {
+            // "Encourage one another and build one another up." (1 Thessalonians 5:11)
+            OracleHarness.Righteous(OracleHarness.Witness("the believers encourage and build up one another", new Kindness(), new Compassion(), new Peacemaking()));
+        }
+
+        [Fact]
+        public void HelpTheWeakBePatientAndRepayNoOneEvilForEvil_IsRighteous()
+        {
+            // "Help the weak, be patient with them all ... do good to one another and to everyone." (1 Thessalonians 5:14-15)
+            OracleHarness.Righteous(OracleHarness.Witness("the church helps the weak, repays no evil, and does good to all", new DefendingTheWeak(), new Patience(), new Goodness()));
+        }
+
+        [Fact]
+        public void RejoiceAlwaysPrayWithoutCeasingGiveThanks_IsRighteous()
+        {
+            // "Rejoice always, pray without ceasing, give thanks in all circumstances." (1 Thessalonians 5:16-18)
+            OracleHarness.Righteous(OracleHarness.Witness("the believers rejoice, pray, and give thanks always", new Joy(), new Worship(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheGodOfPeaceSanctifiesThemCompletelyAndIsFaithful_IsADivineAct()
+        {
+            // "May the God of peace sanctify you completely ... He who calls you is faithful." (1 Thessalonians 5:23-24)
+            OracleHarness.DivineAct(OracleHarness.Witness("the God of peace sanctifies them wholly and keeps his promise", new Peace(), new Fidelity(), new PromiseFulfilled()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/FirstTimothyNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/FirstTimothyNarrativeTests.cs
@@ -1,0 +1,124 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 1 Timothy narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class FirstTimothyNarrativeTests
+    {
+        [Fact]
+        public void PaulChargesTimothyToSilenceFalseTeachers_IsRighteous()
+        {
+            // "Command certain people not to teach false doctrines any longer." (1 Timothy 1:3-4)
+            OracleHarness.Righteous(OracleHarness.Witness("Timothy is charged to guard sound teaching", new TeachingTruth(), new Protection()));
+        }
+
+        [Fact]
+        public void TheFalseTeachersPromoteDisputesAndMyths_IsSin()
+        {
+            // "Myths and endless genealogies ... promote controversial speculations." (1 Timothy 1:4-6)
+            OracleHarness.Sin(OracleHarness.Witness("the false teachers stir up empty controversy", new Deceit(), new Discord()));
+        }
+
+        [Fact]
+        public void ChristCameIntoTheWorldToSaveSinners_IsADivineAct()
+        {
+            // "Christ Jesus came into the world to save sinners, of whom I am the worst." (1 Timothy 1:15)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ comes to save sinners", new Deliverance(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void ChristShowsMercyToPaulTheFormerBlasphemer_IsADivineAct()
+        {
+            // "I was shown mercy ... the grace of our Lord was poured out on me abundantly." (1 Timothy 1:13-16)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ pours out mercy on the chief of sinners", new Pardon(), new Compassion()));
+        }
+
+        [Fact]
+        public void PrayingForAllPeopleAndForKings_IsRighteous()
+        {
+            // "I urge ... petitions, prayers ... be made for all people, for kings and all those in authority." (1 Timothy 2:1-2)
+            OracleHarness.Righteous(OracleHarness.Witness("the church intercedes for all people and rulers", new Worship(), new Peacemaking()));
+        }
+
+        [Fact]
+        public void GodWantsAllPeopleToBeSavedThroughTheOneMediator_IsADivineAct()
+        {
+            // "God our Savior, who wants all people to be saved ... one mediator ... Christ Jesus." (1 Timothy 2:3-6)
+            OracleHarness.DivineAct(OracleHarness.Witness("God wills the salvation of all through the one mediator", new Deliverance(), new SelfSacrifice(), new Atonement()));
+        }
+
+        [Fact]
+        public void TheOverseerMustBeAboveReproachAndSelfControlled_IsRighteous()
+        {
+            // "Now the overseer is to be above reproach ... temperate, self-controlled ... hospitable." (1 Timothy 3:2-3)
+            OracleHarness.Righteous(OracleHarness.Witness("the overseer lives a blameless life", new SelfControl(), new Hospitality(), new Gentleness()));
+        }
+
+        [Fact]
+        public void DeaconsMustBeWorthyOfRespectAndSincere_IsRighteous()
+        {
+            // "Deacons ... are to be worthy of respect, sincere ... keep hold of the deep truths." (1 Timothy 3:8-9)
+            OracleHarness.Righteous(OracleHarness.Witness("the deacons serve with sincere and tested faith", new Trustworthiness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GreatIsTheMysteryOfGodlinessChristRevealed_IsADivineAct()
+        {
+            // "He appeared in the flesh ... was taken up in glory." (1 Timothy 3:16)
+            OracleHarness.DivineAct(OracleHarness.Witness("God is manifested in the flesh and glorified", new SelfSacrifice(), new Righteousness()));
+        }
+
+        [Fact]
+        public void DeceivingSpiritsForbidMarriageAndFoods_IsSin()
+        {
+            // "Some will abandon the faith and follow ... things taught by demons ... liars." (1 Timothy 4:1-3)
+            OracleHarness.Sin(OracleHarness.Grounded("apostates follow deceiving spirits and hypocritical lies", Grounding.InIdol("deceiving spirits"), new Deceit(), new Rebellion()));
+        }
+
+        [Fact]
+        public void TimothySetsAnExampleInSpeechAndPurity_IsRighteous()
+        {
+            // "Set an example ... in speech, in conduct, in love, in faith and in purity." (1 Timothy 4:12)
+            OracleHarness.Righteous(OracleHarness.Witness("Timothy is an example in love, faith, and purity", new Purity(), new Fidelity(), new Kindness()));
+        }
+
+        [Fact]
+        public void CaringForWidowsWhoAreTrulyInNeed_IsRighteous()
+        {
+            // "Give proper recognition to those widows who are really in need." (1 Timothy 5:3-5)
+            OracleHarness.Righteous(OracleHarness.Witness("the church honors and provides for true widows", new HonoringTheVulnerable(), new Compassion()));
+        }
+
+        [Fact]
+        public void RefusingToProvideForOnesOwnHousehold_IsSin()
+        {
+            // "Anyone who does not provide for ... their own household has denied the faith." (1 Timothy 5:8)
+            OracleHarness.Sin(OracleHarness.Witness("a believer abandons his own family in need", new WithholdingWhatIsDue(), new Heartlessness()));
+        }
+
+        [Fact]
+        public void TheLoveOfMoneyDrivesPeopleFromTheFaith_IsSin()
+        {
+            // "The love of money is a root of all kinds of evil ... pierced themselves with many griefs." (1 Timothy 6:9-10)
+            OracleHarness.Sin(OracleHarness.Witness("the love of money leads people into ruin", new Greed(), new Covetousness()));
+        }
+
+        [Fact]
+        public void TheRichAreToBeGenerousAndDoGood_IsRighteous()
+        {
+            // "Command them ... to be rich in good deeds, and to be generous and willing to share." (1 Timothy 6:17-18)
+            OracleHarness.Righteous(OracleHarness.Witness("the rich are generous, rich in good deeds, willing to share", new Generosity(), new Goodness(), new Humility()));
+        }
+
+        [Fact]
+        public void TimothyFightsTheGoodFightAndPursuesRighteousness_IsRighteous()
+        {
+            // "Pursue righteousness, godliness, faith, love, endurance and gentleness." (1 Timothy 6:11-12)
+            OracleHarness.Righteous(OracleHarness.Witness("Timothy pursues righteousness and fights the good fight of faith", new Righteousness(), new CourageousFaith(), new Endurance(), new Gentleness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/GalatiansNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/GalatiansNarrativeTests.cs
@@ -1,0 +1,138 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Galatians narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class GalatiansNarrativeTests
+    {
+        [Fact]
+        public void ChristGaveHimselfToRescueFromThePresentEvilAge_IsADivineAct()
+        {
+            // "Christ ... gave himself for our sins to rescue us from the present evil age." (Galatians 1:3-4)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ gives himself to deliver us", new SelfSacrifice(), new Deliverance()));
+        }
+
+        [Fact]
+        public void PreachingADifferentGospel_IsSin()
+        {
+            // "Some ... are trying to pervert the gospel of Christ. ... let them be under God's curse!" (Galatians 1:7-9)
+            OracleHarness.Sin(OracleHarness.Witness("the agitators pervert the gospel of Christ", new Deceit(), new SowingDiscord()));
+        }
+
+        [Fact]
+        public void PaulPreachesTheFaithHeOnceTriedToDestroy_IsRighteous()
+        {
+            // "The man who formerly persecuted us is now preaching the faith he once tried to destroy." (Galatians 1:23-24)
+            OracleHarness.Righteous(OracleHarness.Witness("the former persecutor now proclaims the truth", new Repentance(), new TeachingTruth()));
+        }
+
+        [Fact]
+        public void RememberingThePoorInTheGospelAgreement_IsRighteous()
+        {
+            // "All they asked was that we should continue to remember the poor." (Galatians 2:10)
+            OracleHarness.Righteous(OracleHarness.Witness("the apostles charge Paul to remember the poor", new Generosity(), new Compassion()));
+        }
+
+        [Fact]
+        public void PeterWithdrawsFromTheGentilesInFearOfTheCircumcisionGroup_IsSin()
+        {
+            // "He began to draw back ... fearing those of the circumcision group ... led astray by their hypocrisy." (Galatians 2:12-13)
+            OracleHarness.Sin(OracleHarness.Witness("Peter withdraws from the Gentile table in hypocrisy", new Deceit(), new Faction()));
+        }
+
+        [Fact]
+        public void PaulOpposesPeterToHisFaceForTheTruthOfTheGospel_IsRighteous()
+        {
+            // "I opposed him to his face, because he stood condemned ... not acting in line with the truth of the gospel." (Galatians 2:11, 14)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul confronts Peter for the truth of the gospel", new CourageousFaith(), new TeachingTruth()));
+        }
+
+        [Fact]
+        public void ChristLovedMeAndGaveHimselfForMe_IsADivineAct()
+        {
+            // "The Son of God, who loved me and gave himself for me." (Galatians 2:20)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Son of God loves and gives himself for me", new SelfSacrifice(), new Atonement()));
+        }
+
+        [Fact]
+        public void AbrahamBelievedGodAndItWasCreditedAsRighteousness_IsRighteous()
+        {
+            // "Abraham believed God, and it was credited to him as righteousness." (Galatians 3:6)
+            OracleHarness.Righteous(OracleHarness.Witness("Abraham trusts God and is counted righteous", new Trust(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void ChristRedeemsUsFromTheCurseOfTheLaw_IsADivineAct()
+        {
+            // "Christ redeemed us from the curse of the law by becoming a curse for us." (Galatians 3:13-14)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ redeems us by bearing the curse", new SelfSacrifice(), new Deliverance(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void GodSendsHisSonToRedeemAndAdoptUsAsHeirs_IsADivineAct()
+        {
+            // "God sent his Son ... to redeem those under the law, that we might receive adoption to sonship." (Galatians 4:4-7)
+            OracleHarness.DivineAct(OracleHarness.Witness("God redeems us and adopts us as sons and heirs", new Deliverance(), new PromiseFulfilled(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TurningBackToTheWeakElementalForces_IsSin()
+        {
+            // "How is it that you are turning back to those weak and miserable forces? ... slaves all over again." (Galatians 4:9)
+            OracleHarness.Sin(OracleHarness.Grounded("the Galatians turn back to enslaving elemental forces", Grounding.InIdol("the weak and miserable elemental forces"), new Idolatry()));
+        }
+
+        [Fact]
+        public void TheWholeLawIsFulfilledInLovingYourNeighbor_IsRighteous()
+        {
+            // "The entire law is fulfilled in keeping this one command: 'Love your neighbor as yourself.'" (Galatians 5:14)
+            OracleHarness.Righteous(OracleHarness.Witness("the law is fulfilled in loving the neighbor", new Kindness(), new SelfSacrifice(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void BitingAndDevouringOneAnother_IsSin()
+        {
+            // "If you bite and devour each other ... you will be destroyed by each other." (Galatians 5:15)
+            OracleHarness.Sin(OracleHarness.Witness("the Galatians bite and devour one another", new Discord(), new Hatred()));
+        }
+
+        [Fact]
+        public void TheWorksOfTheFlesh_IsSin()
+        {
+            // "The acts of the flesh ... sexual immorality, impurity, debauchery ... hatred, discord, jealousy, fits of rage." (Galatians 5:19-21)
+            OracleHarness.Sin(OracleHarness.Witness("the acts of the flesh are made plain", new SexualImmorality(), new Impurity(), new Debauchery(), new Idolatry(), new Sorcery(), new Hatred(), new Discord(), new Jealousy(), new FitsOfRage(), new SelfishAmbition(), new Faction(), new Envy(), new Drunkenness(), new Carousing()));
+        }
+
+        [Fact]
+        public void TheFruitOfTheSpirit_IsRighteous()
+        {
+            // "The fruit of the Spirit is love, joy, peace, forbearance, kindness, goodness, faithfulness, gentleness and self-control." (Galatians 5:22-23)
+            OracleHarness.Righteous(OracleHarness.Witness("the fruit of the Spirit is borne in the believer", new Kindness(), new Joy(), new Peace(), new Patience(), new Goodness(), new Fidelity(), new Gentleness(), new SelfControl()));
+        }
+
+        [Fact]
+        public void CarryingEachOthersBurdensFulfillsTheLawOfChrist_IsRighteous()
+        {
+            // "Carry each other's burdens, and in this way you will fulfill the law of Christ." (Galatians 6:2)
+            OracleHarness.Righteous(OracleHarness.Witness("the believers carry one another's burdens", new Compassion(), new SelfSacrifice(), new Gentleness()));
+        }
+
+        [Fact]
+        public void RestoringTheCaughtBrotherGently_IsRighteous()
+        {
+            // "If someone is caught in a sin ... restore that person gently." (Galatians 6:1)
+            OracleHarness.Righteous(OracleHarness.Witness("the spiritual restore the fallen brother gently", new Gentleness(), new Forgiveness(), new Humility()));
+        }
+
+        [Fact]
+        public void DoingGoodToAllEspeciallyTheHousehold_IsRighteous()
+        {
+            // "As we have opportunity, let us do good to all people, especially ... the family of believers." (Galatians 6:9-10)
+            OracleHarness.Righteous(OracleHarness.Witness("the church does good to all without growing weary", new Goodness(), new Generosity(), new Endurance()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/GeneralEpistlesOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/GeneralEpistlesOracleTests.cs
@@ -1,0 +1,90 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 65-72: Hebrews, James, 1-2 Peter, 1-3 John, Jude.
+    public class GeneralEpistlesOracleTests
+    {
+        [Fact]
+        public void Hebrews_SustainingAllThingsByHisWord_IsADivineAct()
+        {
+            // "Sustaining all things by his powerful word." (Hebrews 1:3) The grounding.
+            OracleHarness.DivineAct(OracleHarness.Witness("sustaining all things by His word", new CreationOrder()));
+        }
+
+        [Fact]
+        public void Hebrews_TheOnceForAllSacrifice_IsADivineAct()
+        {
+            // "He sacrificed for their sins once for all when he offered himself." (Hebrews 7:27)
+            OracleHarness.DivineAct(OracleHarness.Witness("the once-for-all sacrifice", new Atonement(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void James_PureReligionCaresForOrphansAndWidows_IsRighteous()
+        {
+            // "Look after orphans and widows in their distress." (James 1:27)
+            OracleHarness.Righteous(OracleHarness.Witness("care for orphans and widows", new HonoringTheVulnerable(), new Generosity()));
+        }
+
+        [Fact]
+        public void James_TheWithheldWagesCryOut_IsSin()
+        {
+            // "The wages you failed to pay ... are crying out against you." (James 5:4)
+            OracleHarness.Sin(OracleHarness.Witness("the withheld wages cry out", new WithholdingWhatIsDue()));
+        }
+
+        [Fact]
+        public void FirstPeter_HeBoreOurSinsInHisBody_IsADivineAct()
+        {
+            // "He himself bore our sins in his body on the cross." (1 Peter 2:24)
+            OracleHarness.DivineAct(OracleHarness.Witness("He bore our sins", new Atonement(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void SecondPeter_NotWillingThatAnyShouldPerish_IsADivineAct()
+        {
+            // "Not wanting anyone to perish, but everyone to come to repentance." (2 Peter 3:9)
+            OracleHarness.DivineAct(OracleHarness.Witness("God's patience toward all", new Patience(), new Compassion()));
+        }
+
+        [Fact]
+        public void FirstJohn_GodIsLove_IsADivineAct()
+        {
+            // "God is love." (1 John 4:8); "we ought to lay down our lives." (3:16)
+            OracleHarness.DivineAct(OracleHarness.Witness("God is love", new Compassion(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void FirstJohn_HavingNoPityOnABrotherInNeed_IsSin()
+        {
+            // "If anyone ... sees a brother in need but has no pity, how can the love of God be in
+            // them?" (1 John 3:17)
+            OracleHarness.Sin(OracleHarness.Witness("no pity on a brother in need", new Indifference()));
+        }
+
+        [Fact]
+        public void SecondJohn_WalkingInLoveAndTruth_IsRighteous()
+        {
+            // "Love one another ... walking in the truth." (2 John 4-6)
+            OracleHarness.Righteous(OracleHarness.Witness("walk in love and truth", new Compassion(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void ThirdJohn_DiotrephesSelfSeeking_IsSin()
+        {
+            // Diotrephes "loves to be first" and refuses the brothers (3 John 9-10).
+            OracleHarness.Sin(OracleHarness.Witness("Diotrephes loves to be first", new SelfSeeking(), new Pride()));
+        }
+
+        [Fact]
+        public void Jude_KeepYourselvesInGodsLove_IsRighteous()
+        {
+            // "Keep yourselves in God's love ... be merciful to those who doubt." (Jude 21-22)
+            OracleHarness.Righteous(OracleHarness.Witness("keep yourselves in God's love", new Compassion(), new Trust()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/GenesisNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/GenesisNarrativeTests.cs
@@ -1,0 +1,135 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Genesis narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class GenesisNarrativeTests
+    {
+        [Fact]
+        public void GodCreatesTheHeavensAndEarth_IsADivineAct()
+        {
+            // "In the beginning God created the heavens and the earth." (Genesis 1:1)
+            OracleHarness.DivineAct(OracleHarness.Witness("God creates and orders the cosmos", new CreationOrder(), new Goodness()));
+        }
+
+        [Fact]
+        public void GodRestsAndBlessesTheSeventhDay_IsADivineAct()
+        {
+            // "God blessed the seventh day and made it holy." (Genesis 2:3)
+            OracleHarness.DivineAct(OracleHarness.Witness("God blesses and hallows the Sabbath", new CreationOrder(), new Peace()));
+        }
+
+        [Fact]
+        public void TheSerpentDeceivesEve_IsSin()
+        {
+            // "The serpent deceived me, and I ate." (Genesis 3:13)
+            OracleHarness.Sin(OracleHarness.Witness("the serpent deceives Eve", new Deceit(), new Rebellion()));
+        }
+
+        [Fact]
+        public void CainMurdersAbel_IsCapitalSin()
+        {
+            // "Cain attacked his brother Abel and killed him." (Genesis 4:8)
+            Resolution r = OracleHarness.Witness("Cain murders Abel", new Murder(), new Bloodshed());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void EnochWalksWithGod_IsRighteous()
+        {
+            // "Enoch walked faithfully with God; then he was no more, because God took him away." (Genesis 5:24)
+            OracleHarness.Righteous(OracleHarness.Witness("Enoch walks with God", new Fidelity(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TheGenerationOfTheFlood_IsSin()
+        {
+            // "Every inclination of the thoughts of the human heart was only evil all the time." (Genesis 6:5)
+            OracleHarness.Sin(OracleHarness.Witness("the wickedness that brings the flood", new Wrongdoing(), new Bloodshed()));
+        }
+
+        [Fact]
+        public void NoahObeysAndBuildsTheArk_IsRighteous()
+        {
+            // "Noah did everything just as God commanded him." (Genesis 6:22; 7:5)
+            OracleHarness.Righteous(OracleHarness.Witness("Noah obeys and builds the ark", new ObedienceToGod(), new CourageousFaith(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodMakesTheRainbowCovenant_IsADivineAct()
+        {
+            // "I have set my rainbow in the clouds... the covenant between me and the earth." (Genesis 9:13)
+            OracleHarness.DivineAct(OracleHarness.Witness("God seals the covenant with Noah", new CovenantFaithfulness(), new PromiseFulfilled(), new Peacemaking()));
+        }
+
+        [Fact]
+        public void BabelBuildsAgainstHeaven_IsSin()
+        {
+            // "Let us build... a tower that reaches to the heavens, so that we may make a name for ourselves." (Genesis 11:4)
+            OracleHarness.Sin(OracleHarness.Witness("the tower of Babel", new Pride(), new Boasting(), new Rebellion()));
+        }
+
+        [Fact]
+        public void GodCallsAbramAndPromisesBlessing_IsADivineAct()
+        {
+            // "I will make you into a great nation, and I will bless you... and all peoples on earth will be blessed through you." (Genesis 12:2-3)
+            OracleHarness.DivineAct(OracleHarness.Witness("God calls and promises Abram", new PromiseFulfilled(), new Generosity(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void AbramBelievesTheLord_IsRighteous()
+        {
+            // "Abram believed the LORD, and he credited it to him as righteousness." (Genesis 15:6)
+            OracleHarness.Righteous(OracleHarness.Witness("Abram trusts God's promise", new Trust(), new Fidelity(), new Righteousness()));
+        }
+
+        [Fact]
+        public void AbrahamWelcomesTheThreeVisitors_IsRighteous()
+        {
+            // "He hurried... to meet them... 'Let me get you something to eat.'" (Genesis 18:2-5)
+            OracleHarness.Righteous(OracleHarness.Witness("Abraham welcomes the three visitors at Mamre", new Hospitality(), new Kindness(), new FeedingTheHungry()));
+        }
+
+        [Fact]
+        public void SodomsViolenceAgainstTheStrangers_IsCapitalSin()
+        {
+            // The men of Sodom demand to violate Lot's guests. (Genesis 19:4-9; Ezekiel 16:49)
+            Resolution r = OracleHarness.Witness("Sodom's violence against Lot's guests", new Defilement(), new Oppression(), new SexualImmorality());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void AbrahamOffersIsaacInObedientFaith_IsRighteous()
+        {
+            // "By faith Abraham, when God tested him, offered Isaac." Abraham trusts God to provide; no child is harmed. (Genesis 22:8-12; Hebrews 11:17)
+            OracleHarness.Righteous(OracleHarness.Witness("Abraham obeys at the binding of Isaac, trusting God to provide", new ObedienceToGod(), new CourageousFaith(), new Trust()));
+        }
+
+        [Fact]
+        public void JacobDeceivesIsaacForTheBlessing_IsSin()
+        {
+            // "Your brother came deceitfully and took your blessing." (Genesis 27:35)
+            OracleHarness.Sin(OracleHarness.Witness("Jacob deceives Isaac to steal Esau's blessing", new Deceit(), new Theft()));
+        }
+
+        [Fact]
+        public void JosephRefusesPotipharsWife_IsRighteous()
+        {
+            // "How then could I do such a wicked thing and sin against God?" (Genesis 39:9)
+            OracleHarness.Righteous(OracleHarness.Witness("Joseph refuses Potiphar's wife", new Purity(), new SelfControl(), new Fidelity()));
+        }
+
+        [Fact]
+        public void JosephForgivesAndProvidesForHisBrothers_IsRighteous()
+        {
+            // "You intended to harm me, but God intended it for good... So then, don't be afraid. I will provide for you." (Genesis 50:20-21)
+            OracleHarness.Righteous(OracleHarness.Witness("Joseph forgives his brothers and feeds them in the famine", new Forgiveness(), new Compassion(), new FeedingTheHungry()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/GenesisOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/GenesisOracleTests.cs
@@ -1,0 +1,75 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 01: Genesis. The engine must return the verdict Scripture gives at every step.
+    public class GenesisOracleTests
+    {
+        [Fact]
+        public void CreationIsVeryGood()
+        {
+            // "God saw all that he had made, and it was very good." (Genesis 1:31)
+            OracleHarness.DivineAct(OracleHarness.Witness("creation", new CreationOrder()));
+        }
+
+        [Fact]
+        public void TheFallIsSin()
+        {
+            // Eating what God forbade; death enters (Genesis 3:6; Romans 5:12).
+            OracleHarness.Sin(OracleHarness.Witness("the fall", new Disobedience(), new Rebellion()));
+        }
+
+        [Fact]
+        public void CainMurdersAbel()
+        {
+            // "Your brother's blood cries out to me from the ground." (Genesis 4:10)
+            OracleHarness.Sin(OracleHarness.Witness("Cain kills Abel", new Murder()));
+        }
+
+        [Fact]
+        public void TheEarthFilledWithViolence_IsSin()
+        {
+            // "The earth was filled with violence." (Genesis 6:11)
+            OracleHarness.Sin(OracleHarness.Witness("the violence before the flood", new Bloodshed(), new Wrongdoing()));
+        }
+
+        [Fact]
+        public void GodSavesNoah_IsFaithfulDeliverance()
+        {
+            // God preserves Noah and keeps covenant with creation (Genesis 6-9).
+            OracleHarness.DivineAct(OracleHarness.Witness("God saves Noah", new Deliverance(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void AbrahamBelievesGod_IsRighteousness()
+        {
+            // "Abram believed the LORD, and he credited it to him as righteousness." (Genesis 15:6)
+            OracleHarness.Righteous(OracleHarness.Witness("Abraham believes God", new Trust(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void SodomsCruelty_IsGraveSin()
+        {
+            // Inhospitality and attempted violation of the strangers (Genesis 19; Ezekiel 16:49).
+            OracleHarness.Sin(OracleHarness.Witness("Sodom's cruelty", new Oppression(), new Defilement()));
+        }
+
+        [Fact]
+        public void JosephForgivesHisBrothers_IsRighteous()
+        {
+            // "You intended to harm me, but God intended it for good." (Genesis 50:20)
+            OracleHarness.Righteous(OracleHarness.Witness("Joseph forgives his brothers", new Forgiveness(), new Compassion()));
+        }
+
+        [Fact]
+        public void TheBrothersSellJoseph_IsSin()
+        {
+            // Envy drives them to wrong their brother (Genesis 37).
+            OracleHarness.Sin(OracleHarness.Witness("the brothers sell Joseph", new Wrongdoing(), new Envy()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/GitsewNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/GitsewNarrativeTests.cs
@@ -1,0 +1,139 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Gitsew narrative oracle: the engine must return the verdict Scripture gives at each step.
+    // Canon: ETH (Ethiopic-only). Gitsew (Gessew / Gitzew) is one of the four parts of the
+    // apostolic Sinodos, a book of church order (~56 canons) attributed to the Apostles. It governs
+    // the study of Scripture and keeping of the commandments, the duties of husband and wife,
+    // the offices and duties of the ministers, the care of widows, baptism, vows of virginity,
+    // honor toward the martyrs and the faithful departed, and warnings against heresy. Best-effort.
+    public class GitsewNarrativeTests
+    {
+        [Fact]
+        public void TheApostlesDeliverTheChurchOrderInGodsAuthority_IsADivineAct()
+        {
+            // The Sinodos opens with the canons delivered through the Apostles by the authority of God,
+            // the church order handed down as commandment to the faithful. (Gitsew, prologue of the
+            // apostolic canons)
+            // God Himself teaching and ordering His Church through the apostolic deposit.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God delivers the apostolic church order to His Church through the Apostles",
+                Grounding.InGod(),
+                new TeachingTruth(), new CreationOrder(), new CovenantFaithfulness(), new Goodness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheFaithfulAreCommandedToStudyScriptureAndKeepTheCommandments_IsRighteous()
+        {
+            // The canons charge the faithful to give themselves to the study of the Scriptures and to
+            // the observance of the commandments of the Lord. (Gitsew, on study of Scripture)
+            // Obedient, truth-loving devotion to God's word.
+            OracleHarness.Righteous(OracleHarness.Witness("the faithful study the Scriptures and keep the commandments of the Lord",
+                new ObedienceToGod(), new TeachingTruth(), new RejoicingInTruth(), new Fidelity()));
+        }
+
+        [Fact]
+        public void HusbandAndWifeKeepTheirMutualDuties_IsRighteous()
+        {
+            // The canons set out the mutual duties of husband and wife, that they keep faith and honor
+            // toward one another in the Lord. (Gitsew, on the duties of husband and wife)
+            // Covenant faithfulness, purity, and kindness within marriage.
+            OracleHarness.Righteous(OracleHarness.Witness("husband and wife keep faith and honor toward one another",
+                new CovenantFaithfulness(), new Fidelity(), new Purity(), new Kindness(), new SelfControl()));
+        }
+
+        [Fact]
+        public void TheBishopShepherdsAndTeachesTheFlock_IsRighteous()
+        {
+            // The canons define the office and duty of the bishop, that he feed and teach the flock,
+            // guard the truth, and care for the people committed to him. (Gitsew, on the ministers)
+            // Faithful shepherding: teaching truth, guarding, and serving the vulnerable.
+            OracleHarness.Righteous(OracleHarness.Witness("the bishop shepherds, teaches, and guards the flock committed to him",
+                new TeachingTruth(), new Protection(), new CaringForTheSick(), new Fidelity(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void TheDeaconsServeTheNeedyAndMinisterAtTheTable_IsRighteous()
+        {
+            // The canons charge the deacons to minister, serving the poor, the sick, and the needs of
+            // the congregation. (Gitsew, on the office of deacon)
+            // Lowly, generous service to the hungry and the sick.
+            OracleHarness.Righteous(OracleHarness.Witness("the deacons serve the poor, feed the hungry, and tend the sick",
+                new FeedingTheHungry(), new CaringForTheSick(), new Generosity(), new Humility(), new Kindness()));
+        }
+
+        [Fact]
+        public void TheChurchCaresForTheWidows_IsRighteous()
+        {
+            // The canons set the duties of and toward the widows, that the church honor and provide for
+            // them. (Gitsew, on the duties of widows)
+            // Honoring and providing for the vulnerable, the very mark of pure religion.
+            OracleHarness.Righteous(OracleHarness.Witness("the church honors and provides for the widows",
+                new HonoringTheVulnerable(), new Compassion(), new Generosity(), new DefendingTheWeak(), new Kindness()));
+        }
+
+        [Fact]
+        public void BaptismIsAdministeredRightlyByTheOrderedMinister_IsRighteous()
+        {
+            // The canons appoint the method of baptism and forbid laymen to baptize, that the sacrament
+            // be kept in its right order. (Gitsew, on baptism)
+            // Obedient guarding of the sacrament according to God's appointed order.
+            OracleHarness.Righteous(OracleHarness.Witness("baptism is administered rightly by the ordained minister in its appointed order",
+                new ObedienceToGod(), new CreationOrder(), new Protection(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheVowOfVirginityIsKeptInPurity_IsRighteous()
+        {
+            // The canons commend the vow of virginity, kept in purity and self-mastery unto the Lord.
+            // (Gitsew, on vows of virginity)
+            // Pure, self-controlled consecration to God.
+            OracleHarness.Righteous(OracleHarness.Witness("the consecrated keep their vow of virginity in purity unto the Lord",
+                new Purity(), new SelfControl(), new Worship(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheFaithfulHonorTheMartyrsAndTheDeparted_IsRighteous()
+        {
+            // The canons enjoin honor toward the martyrs and respect to be shown to the faithful
+            // departed. (Gitsew, on the martyrs and the departed)
+            // Reverent remembrance and honor of those who endured for the faith.
+            OracleHarness.Righteous(OracleHarness.Witness("the faithful honor the martyrs and the faithful departed",
+                new Worship(), new HonoringTheVulnerable(), new Endurance(), new CourageousFaith(), new Mourning()));
+        }
+
+        [Fact]
+        public void APriestWhoBetraysHisOfficeAndDefilesTheSacred_IsSin()
+        {
+            // The canons warn and depose the minister who betrays his office, robbing the church and
+            // defiling holy things. (Gitsew, disciplinary canons against unworthy ministers)
+            // Treachery, theft, and defilement of what is holy.
+            OracleHarness.Sin(OracleHarness.Witness("a minister betrays his office, robs the church, and defiles holy things",
+                new Treachery(), new Theft(), new Defilement(), new Greed()));
+        }
+
+        [Fact]
+        public void TheHereticPervertsTheTruthAndDividesTheChurch_IsSin()
+        {
+            // The canons warn the faithful against heresy, the teaching that perverts the truth and
+            // tears the body of the church. (Gitsew, warning against heresy)
+            // Deceit, blasphemy, and sowing of discord against the truth.
+            OracleHarness.Sin(OracleHarness.Witness("the heretic perverts the truth and divides the church",
+                new Deceit(), new Blasphemy(), new SowingDiscord(), new Rebellion(), new DelightingInEvil()));
+        }
+
+        [Fact]
+        public void TheUnrepentantSinnerSpurnsTheChurchsDiscipline_IsSin()
+        {
+            // The canons set the treatment of sinners; the one who spurns correction and persists in
+            // wrongdoing is cut off until he repents. (Gitsew, on the treatment of sinners)
+            // Hardened disobedience and rebellion against the order of the Lord.
+            OracleHarness.Sin(OracleHarness.Witness("the unrepentant sinner spurns the church's discipline and persists in wrongdoing",
+                new Disobedience(), new Rebellion(), new Wrongdoing(), new Pride()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/GospelsOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/GospelsOracleTests.cs
@@ -1,0 +1,81 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 47-50: Matthew, Mark, Luke, John.
+    public class GospelsOracleTests
+    {
+        [Fact]
+        public void Matthew_TheWeightierMattersOfTheLaw_IsRighteous()
+        {
+            // "Justice, mercy and faithfulness." (Matthew 23:23) The whole character of God at once.
+            OracleHarness.Righteous(OracleHarness.Witness("the weightier matters",
+                new JustRecompense(), new Compassion(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void Matthew_TheUnforgivingServant_IsSin()
+        {
+            // Forgiven much, he would not forgive (Matthew 18:23-35).
+            OracleHarness.Sin(OracleHarness.Witness("the unforgiving servant", new Unforgiveness(), new Condemnation()));
+        }
+
+        [Fact]
+        public void Mark_JesusHealsAndForgives_IsADivineAct()
+        {
+            // "Your sins are forgiven ... get up, take your mat and walk." (Mark 2:5-11)
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus heals and forgives", new Healing(), new Pardon()));
+        }
+
+        [Fact]
+        public void Mark_TheSonOfManGivesHisLifeAsRansom_IsADivineAct()
+        {
+            // "The Son of Man came ... to give his life as a ransom for many." (Mark 10:45)
+            OracleHarness.DivineAct(OracleHarness.Witness("a ransom for many", new SelfSacrifice(), new Atonement()));
+        }
+
+        [Fact]
+        public void Luke_TheGoodSamaritan_IsRighteous()
+        {
+            // "Go and do likewise." (Luke 10:37)
+            OracleHarness.Righteous(OracleHarness.Witness("the Good Samaritan", new Compassion(), new Protection()));
+        }
+
+        [Fact]
+        public void Luke_TheProdigalReceivedBack_IsADivineAct()
+        {
+            // "This son of mine was dead and is alive again." (Luke 15:24) The Father's running mercy.
+            OracleHarness.DivineAct(OracleHarness.Witness("the prodigal received back", new Pardon(), new Compassion()));
+        }
+
+        [Fact]
+        public void John_TheWordMadeFleshAndJohn316_IsADivineAct()
+        {
+            // "The Word became flesh." (John 1:14); "For God so loved the world." (John 3:16)
+            OracleHarness.DivineAct(OracleHarness.Witness("God gives His Son", new SelfSacrifice(), new Compassion()));
+        }
+
+        [Fact]
+        public void John_NeitherDoICondemnYou_IsADivineAct()
+        {
+            // To the woman caught in adultery: "Neither do I condemn you ... go and sin no more."
+            // (John 8:11) Mercy that does not crush the broken.
+            OracleHarness.DivineAct(OracleHarness.Witness("neither do I condemn you", new Pardon(), new Compassion()));
+        }
+
+        [Fact]
+        public void John_TheCrossSavesTheWorld_IsPerfectlyCoherent()
+        {
+            // The fullness of God's character in one act (John 19; Romans 3:25-26).
+            Resolution r = OracleHarness.Witness("the cross",
+                new SelfSacrifice(), new Atonement(), new Pardon(), new CovenantFaithfulness());
+
+            Assert.Equal(1.0, r.Coherence);
+            Assert.Equal(0.0, r.Disorder);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/HabakkukNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/HabakkukNarrativeTests.cs
@@ -1,0 +1,168 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Habakkuk narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class HabakkukNarrativeTests
+    {
+        [Fact]
+        public void HabakkukCriesOutToGodOverViolenceAndAsksHowLong_IsRighteous()
+        {
+            // "O LORD, how long shall I cry, and thou wilt not hear! ... for spoiling and violence are before me." (Habakkuk 1:2-3)
+            // The prophet does not rebel but brings his honest lament to God, trusting Him with the question of injustice.
+            OracleHarness.Righteous(OracleHarness.Witness("Habakkuk cries out to the LORD over the violence and injustice in Judah and waits for His answer",
+                new Trust(), new Worship(), new CourageousFaith(),
+                new HungerForRighteousness(), new Endurance()));
+        }
+
+        [Fact]
+        public void JudahsLawSlackedAndJudgmentPervertedWithViolence_IsSin()
+        {
+            // "the law is slacked, and judgment doth never go forth ... the wicked doth compass about the righteous." (Habakkuk 1:4)
+            // In Judah the law is paralyzed and justice perverted as the wicked surround and crush the righteous.
+            OracleHarness.Sin(OracleHarness.Grounded("Judah lets the law slacken and perverts judgment while the wicked surround the righteous",
+                Grounding.InIdol("their own wickedness"),
+                new Lawlessness(), new Oppression(), new Wrongdoing(),
+                new WithholdingWhatIsDue(), new Treachery()));
+        }
+
+        [Fact]
+        public void GodRaisesUpTheChaldeansToExecuteHisAppointedJudgment_IsADivineAct()
+        {
+            // "I raise up the Chaldeans ... they are terrible and dreadful ... I will work a work in your days." (Habakkuk 1:5-7)
+            // God Himself sovereignly raises the Chaldeans as His instrument of judgment, working a wonder in His own time.
+            OracleHarness.DivineAct(OracleHarness.Witness("God raises up the Chaldeans as His appointed instrument of judgment upon a guilty Judah",
+                new JustRecompense(), new Righteousness(), new CovenantFaithfulness(),
+                new PromiseFulfilled(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheChaldeansAttributeTheirPowerToTheirOwnMightAsTheirGod_IsSin()
+        {
+            // "they shall scoff at the kings ... imputing this his power unto his god." (Habakkuk 1:10-11)
+            // The Babylonian sweeps up nations like sand and worships his own strength, crediting his might as his god.
+            OracleHarness.Sin(OracleHarness.Grounded("The Chaldean scoffs at kings and credits his conquering might to his own strength as his god",
+                Grounding.InIdol("his own might"),
+                new Pride(), new Boasting(), new Idolatry(),
+                new Oppression(), new Blasphemy()));
+        }
+
+        [Fact]
+        public void HabakkukStandsUponHisWatchToWaitForGodsAnswer_IsRighteous()
+        {
+            // "I will stand upon my watch ... and will watch to see what he will say unto me." (Habakkuk 2:1)
+            // Rather than abandon faith, the prophet posts himself like a watchman, expectantly waiting for God to speak.
+            OracleHarness.Righteous(OracleHarness.Witness("Habakkuk stands upon his watchtower to wait patiently and see what the LORD will answer him",
+                new Patience(), new Endurance(), new Trust(),
+                new CourageousFaith(), new Worship()));
+        }
+
+        [Fact]
+        public void GodDeclaresTheJustShallLiveByHisFaith_IsADivineAct()
+        {
+            // "the just shall live by his faith." (Habakkuk 2:4)
+            // God reveals the great gospel principle: the proud soul is not upright, but the righteous lives by faith.
+            OracleHarness.DivineAct(OracleHarness.Witness("God declares the vision and proclaims that the just shall live by his faith",
+                new TeachingTruth(), new Righteousness(), new Fidelity(),
+                new PromiseFulfilled(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TheBabylonianPlundersManyNationsAndIsNeverSatisfied_IsSin()
+        {
+            // "Woe to him that increaseth that which is not his ... that ladeth himself with thick clay!" (Habakkuk 2:6)
+            // The conqueror enlarges his greed like the grave, heaping up plunder and pledges that are not his own.
+            OracleHarness.Sin(OracleHarness.Grounded("The Babylonian heaps up the plunder of many nations in insatiable greed",
+                Grounding.InIdol("plunder"),
+                new Greed(), new Theft(), new Covetousness(),
+                new Oppression(), new SelfSeeking()));
+        }
+
+        [Fact]
+        public void TheBabylonianShedsBloodAndBuildsHisCityByIniquity_IsSin()
+        {
+            // "Woe to him that buildeth a town with blood, and stablisheth a city by iniquity!" (Habakkuk 2:12)
+            // The empire founds its glory on murder and oppression, building its walls with the blood of the slain.
+            OracleHarness.Sin(OracleHarness.Grounded("The Babylonian builds his city with blood and establishes it by iniquity",
+                Grounding.InIdol("conquest"),
+                new Bloodshed(), new Murder(), new Oppression(),
+                new Lawlessness(), new Wrongdoing()));
+            // capital vices (Bloodshed, Murder) drive disorder to its limit
+            Assert.Equal(1.0, OracleHarness.Grounded("The Babylonian builds his city with blood and establishes it by iniquity",
+                Grounding.InIdol("conquest"),
+                new Bloodshed(), new Murder(), new Oppression(),
+                new Lawlessness(), new Wrongdoing()).Disorder);
+        }
+
+        [Fact]
+        public void TheBabylonianMakesHisNeighborDrunkToGazeOnHisNakedness_IsSin()
+        {
+            // "Woe unto him that giveth his neighbour drink ... that thou mayest look on their nakedness!" (Habakkuk 2:15)
+            // He degrades the nations like a man who plies his neighbor with drink to shame and expose him.
+            OracleHarness.Sin(OracleHarness.Grounded("The Babylonian makes his neighbor drunk to gaze upon his shame and nakedness",
+                Grounding.InIdol("his own cruelty"),
+                new Defilement(), new Oppression(), new Malice(),
+                new DelightingInEvil(), new Drunkenness()));
+            // capital vice (Defilement) drives disorder to its limit
+            Assert.Equal(1.0, OracleHarness.Grounded("The Babylonian makes his neighbor drunk to gaze upon his shame and nakedness",
+                Grounding.InIdol("his own cruelty"),
+                new Defilement(), new Oppression(), new Malice(),
+                new DelightingInEvil(), new Drunkenness()).Disorder);
+        }
+
+        [Fact]
+        public void TheBabylonianWorshipsDumbIdolsOfWoodAndStone_IsSin()
+        {
+            // "Woe unto him that saith to the wood, Awake; to the dumb stone, Arise ... there is no breath at all in the midst of it." (Habakkuk 2:18-19)
+            // The maker trusts the graven image he carved, a dumb idol with no breath, forsaking the living God.
+            OracleHarness.Sin(OracleHarness.Grounded("The Babylonian worships the dumb graven images of wood and stone that he himself overlaid",
+                Grounding.InIdol("graven images"),
+                new Idolatry(), new GravenImage(), new Deceit(),
+                new Blasphemy(), new Pride()));
+        }
+
+        [Fact]
+        public void TheLordIsInHisHolyTempleAndAllTheEarthKeepsSilence_IsADivineAct()
+        {
+            // "But the LORD is in his holy temple: let all the earth keep silence before him." (Habakkuk 2:20)
+            // Over against the lifeless idols, the living LORD reigns in His holy temple and the whole earth falls silent.
+            OracleHarness.DivineAct(OracleHarness.Witness("The LORD is in His holy temple and all the earth keeps silence before Him",
+                new Worship(), new Righteousness(), new CreationOrder(),
+                new Goodness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void HabakkukPraysForGodToRevivceHisWorkAndRememberMercyInWrath_IsRighteous()
+        {
+            // "O LORD, revive thy work in the midst of the years ... in wrath remember mercy." (Habakkuk 3:2)
+            // Awed by God's renown, the prophet prays for His saving work to live again and pleads for mercy amid judgment.
+            OracleHarness.Righteous(OracleHarness.Witness("Habakkuk prays for God to revive His work in the midst of the years and in wrath to remember mercy",
+                new Worship(), new Trust(), new Humility(),
+                new CourageousFaith(), new HungerForRighteousness()));
+        }
+
+        [Fact]
+        public void GodMarchesForthForTheSalvationOfHisPeopleAndHisAnointed_IsADivineAct()
+        {
+            // "thou wentest forth for the salvation of thy people, even for salvation with thine anointed." (Habakkuk 3:13)
+            // God goes out in glory and power, splitting the earth, to save His people and deliver His anointed one.
+            OracleHarness.DivineAct(OracleHarness.Witness("God marches forth in glory for the salvation of His people and for the deliverance of His anointed",
+                new Deliverance(), new Protection(), new JustRecompense(),
+                new CovenantFaithfulness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void HabakkukRejoicesInGodEvenWhenTheFieldsYieldNothing_IsRighteous()
+        {
+            // "Although the fig tree shall not blossom ... yet I will rejoice in the LORD, I will joy in the God of my salvation." (Habakkuk 3:17-18)
+            // Though every crop and flock fail, the prophet chooses to rejoice in God his Savior, his strength and his joy.
+            OracleHarness.Righteous(OracleHarness.Witness("Habakkuk rejoices in the LORD and joys in the God of his salvation though the fig tree does not blossom and the fields yield nothing",
+                new Joy(), new Trust(), new Worship(),
+                new CourageousFaith(), new Endurance()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/HaggaiNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/HaggaiNarrativeTests.cs
@@ -1,0 +1,140 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Haggai narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class HaggaiNarrativeTests
+    {
+        [Fact]
+        public void ThePeopleSayTheTimeHasNotComeToBuildTheLordsHouse_IsSin()
+        {
+            // "This people say, The time is not come, the time that the LORD's house should be built." (Haggai 1:2)
+            // The remnant excuses its neglect of God's house, putting off the work He gave them to do.
+            OracleHarness.Sin(OracleHarness.Grounded("The people say the time has not yet come to rebuild the house of the LORD",
+                Grounding.InIdol("their own excuses"),
+                new Disobedience(), new Sloth(), new Indifference(),
+                new WithholdingWhatIsDue(), new Ingratitude()));
+        }
+
+        [Fact]
+        public void ThePeopleDwellInPaneledHousesWhileGodsHouseLiesWaste_IsSin()
+        {
+            // "Is it time for you ... to dwell in your cieled houses, and this house lie waste?" (Haggai 1:4)
+            // They lavish on their own paneled homes while the LORD's house sits in ruins, serving self before God.
+            OracleHarness.Sin(OracleHarness.Grounded("The people live in their own paneled houses while the house of God lies waste",
+                Grounding.InIdol("their own comfort"),
+                new SelfSeeking(), new Indifference(), new Sloth(),
+                new WithholdingWhatIsDue(), new Greed()));
+        }
+
+        [Fact]
+        public void GodWithholdsTheHarvestToCallThePeopleToConsiderTheirWays_IsADivineAct()
+        {
+            // "Ye have sown much, and bring in little ... Consider your ways." (Haggai 1:5-6,9-11)
+            // God justly withholds rain and increase, that His people might weigh their neglect and return to Him.
+            OracleHarness.DivineAct(OracleHarness.Witness("God withholds the harvest and the dew and calls the people to consider their ways",
+                new JustRecompense(), new Righteousness(), new TeachingTruth(),
+                new CovenantFaithfulness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void ZerubbabelJoshuaAndTheRemnantObeyTheVoiceOfTheLordAndFearHim_IsRighteous()
+        {
+            // "Then Zerubbabel ... and Joshua ... with all the remnant ... obeyed the voice of the LORD ... and the people did fear before the LORD." (Haggai 1:12)
+            // The governor, the high priest, and the people heed the prophet and turn back to the work in holy fear.
+            OracleHarness.Righteous(OracleHarness.Witness("Zerubbabel, Joshua, and all the remnant obey the voice of the LORD and fear before Him",
+                new ObedienceToGod(), new Repentance(), new Humility(),
+                new Worship(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void GodDeclaresIAmWithYouToReassureHisDiscouragedPeople_IsADivineAct()
+        {
+            // "I am with you, saith the LORD." (Haggai 1:13)
+            // Through His messenger God speaks His abiding presence over the people who have turned back to obey.
+            OracleHarness.DivineAct(OracleHarness.Witness("God declares through Haggai, I am with you, to His people who have returned to the work",
+                new Fidelity(), new CovenantFaithfulness(), new Protection(),
+                new Goodness(), new Compassion()));
+        }
+
+        [Fact]
+        public void GodStirsTheSpiritOfTheLeadersAndPeopleToWorkOnHisHouse_IsADivineAct()
+        {
+            // "And the LORD stirred up the spirit of Zerubbabel ... and ... Joshua ... and ... all the remnant; and they came and did work in the house of the LORD." (Haggai 1:14)
+            // God Himself awakens their hearts so that they take up the labor on His house.
+            OracleHarness.DivineAct(OracleHarness.Witness("The LORD stirs up the spirit of Zerubbabel, Joshua, and the remnant so they come and work on the house of God",
+                new CovenantFaithfulness(), new Fidelity(), new Goodness(),
+                new PromiseFulfilled(), new Righteousness()));
+        }
+
+        [Fact]
+        public void GodCommandsBeStrongAndWorkForMySpiritRemainsAmongYou_IsADivineAct()
+        {
+            // "Be strong ... and work: for I am with you ... my spirit remaineth among you: fear ye not." (Haggai 2:4-5)
+            // To the discouraged builders God pledges His presence and abiding Spirit, charging them to take courage.
+            OracleHarness.DivineAct(OracleHarness.Witness("God commands the builders to be strong and work, for He is with them and His Spirit remains among them",
+                new Fidelity(), new CovenantFaithfulness(), new Protection(),
+                new Goodness(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void GodPromisesTheLatterGloryOfTheHouseAndPeaceInThisPlace_IsADivineAct()
+        {
+            // "The glory of this latter house shall be greater than of the former ... and in this place will I give peace." (Haggai 2:9)
+            // God promises a surpassing glory for His house and the gift of His own peace within it.
+            OracleHarness.DivineAct(OracleHarness.Witness("God promises that the latter glory of this house shall surpass the former and that He will give peace in this place",
+                new PromiseFulfilled(), new Peace(), new CovenantFaithfulness(),
+                new Goodness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void ThePeoplesWorkAndOfferingsAreDefiledByTheirUncleanness_IsSin()
+        {
+            // "So is this people ... saith the LORD; and so is every work of their hands; and that which they offer there is unclean." (Haggai 2:14)
+            // By the priestly ruling, uncleanness spreads by touch, so their neglectful works and offerings are defiled.
+            OracleHarness.Sin(OracleHarness.Grounded("The people's works and offerings are pronounced unclean and defiled because of their uncleanness",
+                Grounding.InIdol("their own uncleanness"),
+                new Defilement(), new Impurity(), new Disobedience(),
+                new WithholdingWhatIsDue(), new Indifference()));
+            // capital vice (Defilement) drives disorder to its limit
+            Assert.Equal(1.0, OracleHarness.Grounded("The people's works and offerings are pronounced unclean and defiled because of their uncleanness",
+                Grounding.InIdol("their own uncleanness"),
+                new Defilement(), new Impurity(), new Disobedience(),
+                new WithholdingWhatIsDue(), new Indifference()).Disorder);
+        }
+
+        [Fact]
+        public void GodPromisesToBlessHisPeopleFromTheDayTheFoundationIsLaid_IsADivineAct()
+        {
+            // "Consider now from this day ... from the day that the foundation of the LORD's temple was laid ... from this day will I bless you." (Haggai 2:18-19)
+            // Where He had withheld, God now turns to bless His people from the day they resume His work.
+            OracleHarness.DivineAct(OracleHarness.Witness("God promises that from the day the temple foundation is laid He will bless His people",
+                new Generosity(), new Goodness(), new PromiseFulfilled(),
+                new CovenantFaithfulness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodDeclaresHeWillShakeTheHeavensAndOverthrowTheKingdoms_IsADivineAct()
+        {
+            // "I will shake the heavens and the earth; And I will overthrow the throne of kingdoms ... every one by the sword of his brother." (Haggai 2:21-22)
+            // God announces His sovereign judgment, toppling the powers of the nations in His appointed day.
+            OracleHarness.DivineAct(OracleHarness.Witness("God declares He will shake the heavens and the earth and overthrow the thrones and kingdoms of the nations",
+                new JustRecompense(), new Righteousness(), new Deliverance(),
+                new CovenantFaithfulness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodChoosesZerubbabelAsHisSignetAndServant_IsADivineAct()
+        {
+            // "I will take thee, O Zerubbabel ... my servant ... and will make thee as a signet: for I have chosen thee." (Haggai 2:23)
+            // God sets His chosen servant as a signet ring, a sign of His covenant favor and the promise to come.
+            OracleHarness.DivineAct(OracleHarness.Witness("God chooses Zerubbabel His servant and makes him as a signet ring",
+                new CovenantFaithfulness(), new PromiseFulfilled(), new Fidelity(),
+                new Goodness(), new Protection()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/HebrewsNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/HebrewsNarrativeTests.cs
@@ -1,0 +1,208 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Hebrews narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class HebrewsNarrativeTests
+    {
+        [Fact]
+        public void GodSpeaksToUsByHisSonTheHeirOfAllThings_IsADivineAct()
+        {
+            // "In these last days he has spoken to us by his Son ... through whom also he made the universe." (Hebrews 1:1-2)
+            OracleHarness.DivineAct(OracleHarness.Witness("God speaks his final word through the Son who upholds all things", new TeachingTruth(), new CreationOrder(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheSonPurifiesSinsAndSitsDownAtTheRightHand_IsADivineAct()
+        {
+            // "After he had provided purification for sins, he sat down at the right hand of the Majesty in heaven." (Hebrews 1:3)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Son makes purification for sins and is enthroned", new Atonement(), new Righteousness()));
+        }
+
+        [Fact]
+        public void TheSonLovedRighteousnessAndHatedWickedness_IsADivineAct()
+        {
+            // "You have loved righteousness and hated wickedness; therefore God ... has anointed you." (Hebrews 1:8-9)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Son loves righteousness and rules with a righteous scepter", new Righteousness(), new JustRecompense()));
+        }
+
+        [Fact]
+        public void NeglectingSoGreatASalvationAndDriftingAway_IsSin()
+        {
+            // "How shall we escape if we ignore so great a salvation?" (Hebrews 2:1-3)
+            OracleHarness.Sin(OracleHarness.Witness("the hearers drift away and neglect the great salvation", new Disobedience(), new Indifference()));
+        }
+
+        [Fact]
+        public void ChristTastedDeathForEveryoneAndDestroyedTheDevilsPower_IsADivineAct()
+        {
+            // "That by the grace of God he might taste death for everyone ... and free those held in slavery by fear of death." (Hebrews 2:9-15)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ tastes death for everyone and delivers those enslaved by fear", new SelfSacrifice(), new Deliverance(), new Atonement()));
+        }
+
+        [Fact]
+        public void ChristTheMercifulHighPriestMakesAtonementForThePeople_IsADivineAct()
+        {
+            // "A merciful and faithful high priest ... to make atonement for the sins of the people." (Hebrews 2:17-18)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ becomes a merciful high priest and makes atonement", new Compassion(), new Fidelity(), new Atonement()));
+        }
+
+        [Fact]
+        public void TheWildernessGenerationRebelledAndHardenedTheirHearts_IsSin()
+        {
+            // "Do not harden your hearts as you did in the rebellion ... where your ancestors tested me." (Hebrews 3:7-12)
+            OracleHarness.Sin(OracleHarness.Witness("the wilderness generation rebels and hardens its heart against God", new Rebellion(), new Disobedience()));
+        }
+
+        [Fact]
+        public void LetUsHoldFirmlyToOurConfessionAndDrawNearWithConfidence_IsRighteous()
+        {
+            // "Let us hold firmly to the faith we profess ... let us then approach God's throne of grace with confidence." (Hebrews 4:14-16)
+            OracleHarness.Righteous(OracleHarness.Witness("the faithful hold fast their confession and draw near to the throne of grace", new CourageousFaith(), new Endurance(), new Trust()));
+        }
+
+        [Fact]
+        public void ChristLearnedObedienceAndBecameTheSourceOfEternalSalvation_IsADivineAct()
+        {
+            // "He learned obedience from what he suffered ... he became the source of eternal salvation for all who obey him." (Hebrews 5:8-9)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ obeys through suffering and becomes the source of eternal salvation", new ObedienceToGod(), new Deliverance(), new Endurance()));
+        }
+
+        [Fact]
+        public void GodIsNotUnjustToForgetTheirWorkAndLoveShownToHisName_IsADivineAct()
+        {
+            // "God is not unjust; he will not forget your work and the love you have shown him as you have helped his people." (Hebrews 6:10)
+            OracleHarness.DivineAct(OracleHarness.Witness("God justly remembers the love and labor shown to his name", new JustRecompense(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodConfirmsHisPromiseWithAnOathThatCannotLie_IsADivineAct()
+        {
+            // "It is impossible for God to lie ... we who have fled to take hold of the hope set before us." (Hebrews 6:17-19)
+            OracleHarness.DivineAct(OracleHarness.Witness("God confirms his unchanging promise with an oath he cannot break", new PromiseFulfilled(), new Trustworthiness(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void ChristTheEternalPriestAlwaysLivesToInterceedForThem_IsADivineAct()
+        {
+            // "He always lives to intercede for them ... a high priest who is holy, blameless, pure." (Hebrews 7:25-26)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ the holy high priest forever lives to intercede and save completely", new Purity(), new Deliverance(), new Righteousness()));
+        }
+
+        [Fact]
+        public void GodMediatesABetterCovenantAndRemembersTheirSinsNoMore_IsADivineAct()
+        {
+            // "I will forgive their wickedness and will remember their sins no more." (Hebrews 8:6-12)
+            OracleHarness.DivineAct(OracleHarness.Witness("God establishes a better covenant and remembers their sins no more", new Pardon(), new CovenantFaithfulness(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void ChristOffersHisOwnBloodOnceForAllToCleanseTheConscience_IsADivineAct()
+        {
+            // "He entered the Most Holy Place once for all by his own blood ... to cleanse our consciences." (Hebrews 9:12-14)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ offers himself once for all to cleanse the conscience and obtain redemption", new SelfSacrifice(), new Atonement(), new Healing()));
+        }
+
+        [Fact]
+        public void ChristCameToDoTheWillOfGodAndPerfectsThoseBeingMadeHoly_IsADivineAct()
+        {
+            // "Here I am ... I have come to do your will ... by that will we have been made holy through the sacrifice of the body of Jesus Christ once for all." (Hebrews 10:7-14)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ does the Father's will and by one sacrifice perfects the sanctified", new ObedienceToGod(), new SelfSacrifice(), new Atonement()));
+        }
+
+        [Fact]
+        public void DeliberatelyTramplingTheSonAndProfaningTheBloodOfTheCovenant_IsSin()
+        {
+            // "Anyone who has trampled the Son of God underfoot ... and who has insulted the Spirit of grace." (Hebrews 10:26-29)
+            OracleHarness.Sin(OracleHarness.Witness("the apostate tramples the Son and profanes the blood of the covenant", new Blasphemy(), new CovenantBreaking(), new Rebellion()));
+        }
+
+        [Fact]
+        public void NoahInHolyFearBuiltAnArkToSaveHisHousehold_IsRighteous()
+        {
+            // "By faith Noah ... in holy fear built an ark to save his family." (Hebrews 11:7)
+            OracleHarness.Righteous(OracleHarness.Witness("Noah by faith builds the ark and saves his household", new CourageousFaith(), new ObedienceToGod(), new Protection()));
+        }
+
+        [Fact]
+        public void AbrahamObeyedAndOfferedIsaacTrustingGodToRaiseTheDead_IsRighteous()
+        {
+            // "By faith Abraham, when God tested him, offered Isaac ... reasoned that God could raise the dead." (Hebrews 11:8-19)
+            OracleHarness.Righteous(OracleHarness.Witness("Abraham by faith obeys and offers up Isaac, trusting God to raise the dead", new CourageousFaith(), new ObedienceToGod(), new Trust()));
+        }
+
+        [Fact]
+        public void MosesChoseToSufferWithGodsPeopleRatherThanEnjoySinsPleasures_IsRighteous()
+        {
+            // "He chose to be mistreated along with the people of God rather than to enjoy the fleeting pleasures of sin." (Hebrews 11:24-26)
+            OracleHarness.Righteous(OracleHarness.Witness("Moses chooses to suffer with God's people rather than the pleasures of sin", new CourageousFaith(), new SelfSacrifice(), new Endurance()));
+        }
+
+        [Fact]
+        public void TheFaithfulEnduredSufferingAndTortureLookingForResurrection_IsRighteous()
+        {
+            // "Others were tortured ... so that they might gain an even better resurrection." (Hebrews 11:35-38)
+            OracleHarness.Righteous(OracleHarness.Witness("the faithful endure torture and affliction, awaiting a better resurrection", new Endurance(), new CourageousFaith(), new Fidelity()));
+        }
+
+        [Fact]
+        public void RunWithEnduranceFixingEyesOnJesusWhoEnduredTheCross_IsRighteous()
+        {
+            // "Let us run with perseverance ... fixing our eyes on Jesus ... who for the joy set before him endured the cross." (Hebrews 12:1-2)
+            OracleHarness.Righteous(OracleHarness.Witness("the saints run with endurance, fixing their eyes on Jesus who endured the cross", new Endurance(), new CourageousFaith(), new Joy()));
+        }
+
+        [Fact]
+        public void TheLordDisciplinesThoseHeLovesForTheirGood_IsADivineAct()
+        {
+            // "The Lord disciplines the one he loves ... that we may share in his holiness ... a harvest of righteousness." (Hebrews 12:6-11)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Lord disciplines those he loves to yield a harvest of righteousness", new JustRecompense(), new Righteousness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void EsauSoldHisInheritanceForASingleMealAndDespisedTheBirthright_IsSin()
+        {
+            // "See that no one is ... godless like Esau, who for a single meal sold his inheritance rights." (Hebrews 12:16-17)
+            OracleHarness.Sin(OracleHarness.Grounded("Esau despises his birthright and sells his inheritance for one meal", Grounding.InIdol("his appetite"), new Gluttony(), new Ingratitude()));
+        }
+
+        [Fact]
+        public void KeepOnLovingOneAnotherAndShowHospitalityToStrangers_IsRighteous()
+        {
+            // "Keep on loving one another ... show hospitality to strangers, for ... some have entertained angels." (Hebrews 13:1-2)
+            OracleHarness.Righteous(OracleHarness.Witness("the brethren love one another and show hospitality to strangers", new Kindness(), new Hospitality(), new Compassion()));
+        }
+
+        [Fact]
+        public void RememberThePrisonersAndThoseMistreatedAsThoughSufferingWithThem_IsRighteous()
+        {
+            // "Continue to remember those in prison as if you were together with them ... those who are mistreated." (Hebrews 13:3)
+            OracleHarness.Righteous(OracleHarness.Witness("the faithful remember the prisoners and the mistreated as their own", new VisitingThePrisoner(), new Compassion(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void KeepTheMarriageBedPureAndFreeYourselvesFromTheLoveOfMoney_IsRighteous()
+        {
+            // "Marriage should be honored by all, and the marriage bed kept pure ... keep your lives free from the love of money." (Hebrews 13:4-5)
+            OracleHarness.Righteous(OracleHarness.Witness("the saints honor marriage in purity and keep free from the love of money", new Purity(), new SelfControl(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void DoNotForgetToDoGoodAndToShareForSuchSacrificesPleaseGod_IsRighteous()
+        {
+            // "Do not forget to do good and to share with others, for with such sacrifices God is pleased." (Hebrews 13:16)
+            OracleHarness.Righteous(OracleHarness.Witness("the believers do good and share with others as a pleasing sacrifice", new Generosity(), new Goodness(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void TheGodOfPeaceRaisedJesusAndEquipsThemToDoHisWill_IsADivineAct()
+        {
+            // "May the God of peace, who through the blood of the eternal covenant brought back ... Jesus ... equip you." (Hebrews 13:20-21)
+            OracleHarness.DivineAct(OracleHarness.Witness("the God of peace raises Jesus and equips his people for every good work", new RestoringLife(), new CovenantFaithfulness(), new Peace()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/HoseaNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/HoseaNarrativeTests.cs
@@ -1,0 +1,160 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Hosea narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class HoseaNarrativeTests
+    {
+        [Fact]
+        public void HoseaObeysGodAndTakesGomerAsASignToIsrael_IsRighteous()
+        {
+            // "Go, take unto thee a wife of whoredoms ... So he went and took Gomer." (Hosea 1:2-3)
+            // Hosea obeys a costly command, enacting God's faithful love toward a faithless people.
+            OracleHarness.Righteous(OracleHarness.Witness("Hosea obeys God and takes Gomer as a living sign to Israel",
+                new ObedienceToGod(), new Fidelity(), new SelfSacrifice(),
+                new CourageousFaith(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void GodNamesTheChildrenAsSignsOfComingJudgment_IsADivineAct()
+        {
+            // "Call his name Jezreel ... Lo-ruhamah ... Lo-ammi." (Hosea 1:4-9)
+            // God names the children to teach Israel the truth of judgment for her covenant-breaking.
+            OracleHarness.DivineAct(OracleHarness.Witness("God names Hosea's children as signs warning Israel of judgment",
+                new TeachingTruth(), new Righteousness(), new RejoicingInTruth(),
+                new CovenantFaithfulness(), new JustRecompense()));
+        }
+
+        [Fact]
+        public void IsraelPlaysTheHarlotAndForsakesTheLordForBaals_IsSin()
+        {
+            // "She went after her lovers, and forgat me, saith the LORD." (Hosea 2:5-13)
+            // Israel commits spiritual adultery, attributing her gifts to Baal and forsaking her God.
+            Resolution r = OracleHarness.Grounded("Israel plays the harlot and runs after the Baals, forsaking the LORD",
+                Grounding.InIdol("Baal"),
+                new Idolatry(), new Adultery(), new CovenantBreaking(),
+                new Ingratitude(), new Treachery());
+            OracleHarness.Sin(r);
+        }
+
+        [Fact]
+        public void GodWoosFaithlessIsraelBackIntoTheWilderness_IsADivineAct()
+        {
+            // "Therefore ... I will allure her ... and speak comfortably unto her." (Hosea 2:14-15)
+            // Rather than abandon her, God tenderly draws His unfaithful people back to Himself.
+            OracleHarness.DivineAct(OracleHarness.Witness("God allures faithless Israel into the wilderness to win her back",
+                new Compassion(), new Kindness(), new CovenantFaithfulness(),
+                new Forgiveness(), new RestoringLife()));
+        }
+
+        [Fact]
+        public void GodBetrothsIsraelToHimselfForeverInRighteousness_IsADivineAct()
+        {
+            // "I will betroth thee unto me for ever ... in righteousness ... in lovingkindness, and in mercies." (Hosea 2:19-20)
+            // God pledges an everlasting covenant of faithful, righteous, merciful love.
+            OracleHarness.DivineAct(OracleHarness.Witness("God betroths Israel to Himself forever in righteousness and mercy",
+                new CovenantFaithfulness(), new Righteousness(), new Compassion(),
+                new PromiseFulfilled(), new Fidelity()));
+        }
+
+        [Fact]
+        public void HoseaRedeemsAndLovesBackHisAdulterousWife_IsRighteous()
+        {
+            // "Go yet, love a woman ... So I bought her to me for fifteen pieces of silver." (Hosea 3:1-3)
+            // Hosea buys back and loves his estranged wife, picturing God's redeeming love for Israel.
+            OracleHarness.Righteous(OracleHarness.Witness("Hosea redeems Gomer and loves her again despite her adultery",
+                new Forgiveness(), new SelfSacrifice(), new Atonement(),
+                new CovenantFaithfulness(), new Kindness()));
+        }
+
+        [Fact]
+        public void IsraelIsChargedWithBloodshedDeceitAndNoKnowledgeOfGod_IsSin()
+        {
+            // "By swearing, and lying ... they break out, and blood toucheth blood." (Hosea 4:1-2)
+            // God's controversy with the land: no truth, no mercy, no knowledge of God, only bloodshed.
+            Resolution r = OracleHarness.Grounded("Israel fills the land with bloodshed, lying, and theft, forsaking the knowledge of God",
+                Grounding.InIdol("Israel's lovers"),
+                new Bloodshed(), new Deceit(), new Theft(),
+                new Lawlessness(), new CovenantBreaking());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void TheProstitutingPeopleSacrificeOnTheHilltopsToIdols_IsSin()
+        {
+            // "They sacrifice upon the tops of the mountains ... thy daughters shall commit whoredom." (Hosea 4:12-14)
+            // A spirit of whoredoms leads Israel into idolatrous sacrifice and ritual immorality.
+            OracleHarness.Sin(OracleHarness.Grounded("Israel sacrifices on the hilltops and gives herself to idolatrous whoredom",
+                Grounding.InIdol("idols of the high places"),
+                new Idolatry(), new SexualImmorality(), new Defilement(),
+                new Rebellion(), new Disobedience()));
+        }
+
+        [Fact]
+        public void GodDesiresMercyAndKnowledgeOfHimRatherThanSacrifice_IsADivineAct()
+        {
+            // "For I desired mercy, and not sacrifice; and the knowledge of God more than burnt offerings." (Hosea 6:6)
+            // God reveals the heart of true religion: steadfast love and knowing Him above mere ritual.
+            OracleHarness.DivineAct(OracleHarness.Witness("God declares He desires mercy and knowledge of Him rather than sacrifice",
+                new Compassion(), new TeachingTruth(), new Righteousness(),
+                new Worship(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void IsraelMakesKingsAndIdolsWithoutGodAndSowsTheWind_IsSin()
+        {
+            // "They have set up kings, but not by me ... of their silver and gold have they made them idols." (Hosea 8:4-7)
+            // Israel exalts herself, crowns kings of her own will, and casts idols, sowing the wind.
+            Resolution r = OracleHarness.Grounded("Israel sets up kings without God and makes idols of her silver and gold",
+                Grounding.InIdol("the calf of Samaria"),
+                new Idolatry(), new GravenImage(), new Rebellion(),
+                new Pride(), new Disobedience());
+            OracleHarness.Sin(r);
+        }
+
+        [Fact]
+        public void HoseaPleadsWithIsraelToReturnAndSowRighteousness_IsRighteous()
+        {
+            // "Sow to yourselves in righteousness ... seek the LORD, till he come and rain righteousness." (Hosea 10:12)
+            // The prophet calls the people to repentance, to break up fallow ground and seek the LORD.
+            OracleHarness.Righteous(OracleHarness.Witness("Hosea pleads with Israel to sow righteousness and seek the LORD",
+                new Repentance(), new TeachingTruth(), new HungerForRighteousness(),
+                new Worship(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodRecallsHisFatherlyLoveAndRefusesToGiveUpEphraim_IsADivineAct()
+        {
+            // "When Israel was a child, then I loved him ... How shall I give thee up, Ephraim?" (Hosea 11:1-8)
+            // God's heart recoils within Him; His compassion overrides wrath toward His wayward son.
+            OracleHarness.DivineAct(OracleHarness.Witness("God recalls His fatherly love and refuses to give up Ephraim",
+                new Compassion(), new Kindness(), new CovenantFaithfulness(),
+                new HonoringTheVulnerable(), new Forgiveness()));
+        }
+
+        [Fact]
+        public void HoseaCallsIsraelToReturnConfessAndReceiveHealing_IsRighteous()
+        {
+            // "O Israel, return unto the LORD thy God ... Take with you words, and turn to the LORD." (Hosea 14:1-2)
+            // The closing call: repentance and confession, that God may heal their backsliding.
+            OracleHarness.Righteous(OracleHarness.Witness("Hosea calls Israel to return to the LORD with words of confession",
+                new Repentance(), new Humility(), new Worship(),
+                new TeachingTruth(), new Trust()));
+        }
+
+        [Fact]
+        public void GodPromisesToHealBacksliddenIsraelAndLoveHerFreely_IsADivineAct()
+        {
+            // "I will heal their backsliding, I will love them freely ... I will be as the dew unto Israel." (Hosea 14:4-7)
+            // God answers repentance with free, healing love and the promise of renewed, ordered life.
+            OracleHarness.DivineAct(OracleHarness.Witness("God promises to heal Israel's backsliding and love her freely",
+                new Healing(), new Forgiveness(), new RestoringLife(),
+                new Compassion(), new PromiseFulfilled()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/IsaiahNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/IsaiahNarrativeTests.cs
@@ -1,0 +1,153 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Isaiah narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class IsaiahNarrativeTests
+    {
+        [Fact]
+        public void JudahsRebellionAndBloodGuiltOfThePeople_IsSin()
+        {
+            // "Ah sinful nation ... they have forsaken the LORD ... your hands are full of blood." (Isaiah 1:2-4,15)
+            // The opening indictment: a covenant people steeped in rebellion and bloodshed.
+            Resolution r = OracleHarness.Witness("Judah rebels against the LORD, hands full of blood",
+                new Rebellion(), new Bloodshed(), new CovenantBreaking(), new Wrongdoing());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void GodCallsJudahToCeaseEvilAndDefendTheOppressed_IsADivineAct()
+        {
+            // "Cease to do evil ... seek judgment, relieve the oppressed, judge the fatherless, plead for the widow." (Isaiah 1:16-17)
+            // God's own summons to washed-clean justice and mercy toward the vulnerable.
+            OracleHarness.DivineAct(OracleHarness.Witness("God calls Judah to defend the orphan and widow",
+                new Righteousness(), new DefendingTheWeak(), new HonoringTheVulnerable(),
+                new JustRecompense(), new Goodness()));
+        }
+
+        [Fact]
+        public void GodOffersToMakeScarletSinsWhiteAsSnow_IsADivineAct()
+        {
+            // "Though your sins be as scarlet, they shall be as white as snow." (Isaiah 1:18)
+            // The LORD freely offers cleansing pardon to the repentant.
+            OracleHarness.DivineAct(OracleHarness.Witness("God offers to wash scarlet sins white as snow",
+                new Pardon(), new Forgiveness(), new Atonement(),
+                new CovenantFaithfulness(), new Compassion()));
+        }
+
+        [Fact]
+        public void IsaiahSeesTheThriceHolyLordEnthroned_IsADivineAct()
+        {
+            // "Holy, holy, holy, is the LORD of hosts: the whole earth is full of his glory." (Isaiah 6:1-3)
+            // The throne-room vision: God revealed in unapproachable holiness and ordered glory.
+            OracleHarness.DivineAct(OracleHarness.Witness("Isaiah beholds the thrice-holy LORD enthroned in glory",
+                new Worship(), new Righteousness(), new CreationOrder(),
+                new RejoicingInTruth(), new Goodness()));
+        }
+
+        [Fact]
+        public void IsaiahConfessesUncleanLipsAndIsSentByGod_IsRighteous()
+        {
+            // "Woe is me ... I am a man of unclean lips ... Here am I; send me." (Isaiah 6:5-8)
+            // The prophet's humble repentance, cleansing, and courageous commission.
+            OracleHarness.Righteous(OracleHarness.Witness("Isaiah confesses his uncleanness and answers 'Here am I; send me'",
+                new Repentance(), new Humility(), new ObedienceToGod(),
+                new CourageousFaith(), new TeachingTruth()));
+        }
+
+        [Fact]
+        public void GodGivesTheSignOfImmanuelTheChildBorn_IsADivineAct()
+        {
+            // "A virgin shall conceive ... call his name Immanuel ... unto us a child is born." (Isaiah 7:14; 9:6-7)
+            // God's promised gift of the Prince of Peace, fulfilling His covenant promise.
+            OracleHarness.DivineAct(OracleHarness.Witness("God gives the sign of Immanuel, the child born, Prince of Peace",
+                new PromiseFulfilled(), new Deliverance(), new Peace(),
+                new CovenantFaithfulness(), new Goodness()));
+        }
+
+        [Fact]
+        public void AssyriaBoastsInItsOwnStrengthAndPride_IsSin()
+        {
+            // "By the strength of my hand I have done it ... Shall the axe boast itself?" (Isaiah 10:13-15)
+            // The Assyrian's arrogant self-exaltation against the God who wields him.
+            OracleHarness.Sin(OracleHarness.Grounded("Assyria boasts in its own might against God",
+                Grounding.InIdol("Assyria"),
+                new Pride(), new Boasting(), new Insolence(), new HaughtyEyes()));
+        }
+
+        [Fact]
+        public void TheRighteousBranchJudgesWithRighteousnessForThePoor_IsADivineAct()
+        {
+            // "With righteousness shall he judge the poor ... the wolf shall dwell with the lamb." (Isaiah 11:1-9)
+            // The Branch from Jesse rules in Spirit-filled righteousness and restored creation-peace.
+            OracleHarness.DivineAct(OracleHarness.Witness("The Branch of Jesse judges righteously for the poor and brings creation-peace",
+                new Righteousness(), new DefendingTheWeak(), new Peace(),
+                new CreationOrder(), new Goodness()));
+        }
+
+        [Fact]
+        public void BabylonsPrideAimsToExaltItselfAboveGod_IsSin()
+        {
+            // "I will ascend into heaven ... I will be like the most High." (Isaiah 14:12-15)
+            // The king of Babylon's god-defying pride and ambition cast down to the pit.
+            OracleHarness.Sin(OracleHarness.Grounded("Babylon's king exalts himself to be like the Most High",
+                Grounding.InIdol("Babylon"),
+                new Pride(), new Boasting(), new SelfishAmbition(), new Rebellion()));
+        }
+
+        [Fact]
+        public void TrueFastingIsToLooseOppressionAndFeedTheHungry_IsADivineAct()
+        {
+            // "Loose the bands of wickedness ... deal thy bread to the hungry ... bring the poor that are cast out to thy house." (Isaiah 58:6-7)
+            // God names the fast He chooses: liberating the oppressed and clothing the naked.
+            OracleHarness.DivineAct(OracleHarness.Witness("God names the true fast: loose oppression, feed the hungry, clothe the naked",
+                new DefendingTheWeak(), new FeedingTheHungry(), new ClothingTheNaked(),
+                new Compassion(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void TheSufferingServantIsWoundedToBearOurSins_IsADivineAct()
+        {
+            // "He was wounded for our transgressions ... with his stripes we are healed." (Isaiah 53:4-6,12)
+            // The Servant pours out His soul as a sin-offering, bearing the iniquity of many.
+            OracleHarness.DivineAct(OracleHarness.Witness("The Suffering Servant bears our sins, wounded for our healing",
+                new Atonement(), new SelfSacrifice(), new Healing(),
+                new Forgiveness(), new Righteousness()));
+        }
+
+        [Fact]
+        public void GodComfortsHisPeopleAndCarriesTheLambsInHisArms_IsADivineAct()
+        {
+            // "Comfort ye my people ... he shall gather the lambs with his arm, and carry them in his bosom." (Isaiah 40:1,11)
+            // The Shepherd-God tenderly comforts, gathers, and gently leads His flock.
+            OracleHarness.DivineAct(OracleHarness.Witness("God comforts His people and carries the lambs in His bosom",
+                new Compassion(), new Gentleness(), new Protection(),
+                new CovenantFaithfulness(), new Goodness()));
+        }
+
+        [Fact]
+        public void IdolatersWorshipTheWorkOfTheirOwnHands_IsSin()
+        {
+            // "He burneth part thereof in the fire ... and the residue thereof he maketh a god." (Isaiah 44:9-20)
+            // The folly of bowing to a carved block, the work of one's own hands.
+            OracleHarness.Sin(OracleHarness.Grounded("the craftsman bows down to the idol he carved",
+                Grounding.InIdol("graven image"),
+                new Idolatry(), new GravenImage(), new Deceit(), new Disobedience()));
+        }
+
+        [Fact]
+        public void GodPromisesNewHeavensAndNewEarthOfPeace_IsADivineAct()
+        {
+            // "I create new heavens and a new earth ... the wolf and the lamb shall feed together." (Isaiah 65:17-25)
+            // God's final promise: a re-created order of joy, peace, and unbroken life.
+            OracleHarness.DivineAct(OracleHarness.Witness("God creates new heavens and a new earth of peace and joy",
+                new CreationOrder(), new RestoringLife(), new Peace(),
+                new Joy(), new PromiseFulfilled()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JamesNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JamesNarrativeTests.cs
@@ -1,0 +1,153 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // James narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class JamesNarrativeTests
+    {
+        [Fact]
+        public void TestingOfFaithProducesSteadfastEndurance_IsRighteous()
+        {
+            // "the testing of your faith produces steadfastness ... that you may be perfect and complete." (James 1:3-4)
+            OracleHarness.Righteous(OracleHarness.Witness("the believer counts trials all joy because tested faith produces steadfast endurance", new Endurance(), new Fidelity(), new Joy()));
+        }
+
+        [Fact]
+        public void GodGivesWisdomGenerouslyToAllWhoAsk_IsADivineAct()
+        {
+            // "let him ask God, who gives generously to all without reproach." (James 1:5)
+            OracleHarness.DivineAct(OracleHarness.Witness("God gives wisdom generously and graciously to all who ask Him", new Generosity(), new Kindness(), new Goodness()));
+        }
+
+        [Fact]
+        public void EveryGoodAndPerfectGiftComesDownFromTheFatherOfLights_IsADivineAct()
+        {
+            // "Every good gift and every perfect gift is from above, coming down from the Father of lights." (James 1:17)
+            OracleHarness.DivineAct(OracleHarness.Witness("the unchanging Father of lights sends down every good and perfect gift", new Generosity(), new Goodness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodBroughtUsForthByTheWordOfTruth_IsADivineAct()
+        {
+            // "Of his own will he brought us forth by the word of truth." (James 1:18)
+            OracleHarness.DivineAct(OracleHarness.Witness("of His own will God brought us forth by the word of truth as firstfruits", new RestoringLife(), new TeachingTruth(), new Goodness()));
+        }
+
+        [Fact]
+        public void TheBelieverMustBeQuickToHearSlowToAngerAndPure_IsRighteous()
+        {
+            // "let every person be quick to hear, slow to speak, slow to anger ... receive the implanted word." (James 1:19-21)
+            OracleHarness.Righteous(OracleHarness.Witness("the believer is quick to hear, slow to anger, putting away filth in meekness", new SelfControl(), new Meekness(), new Purity()));
+        }
+
+        [Fact]
+        public void PureReligionVisitsOrphansAndWidowsAndKeepsUnstained_IsRighteous()
+        {
+            // "Religion that is pure ... is this: to visit orphans and widows in their affliction, and to keep oneself unstained." (James 1:27)
+            OracleHarness.Righteous(OracleHarness.Witness("pure religion visits orphans and widows in affliction and keeps oneself unstained", new HonoringTheVulnerable(), new Compassion(), new Purity()));
+        }
+
+        [Fact]
+        public void ShowingPartialityAndDishonoringThePoor_IsSin()
+        {
+            // "you have shown partiality ... you have dishonored the poor man." (James 2:1-6)
+            OracleHarness.Sin(OracleHarness.Witness("they fawn on the rich in fine clothes and dishonor and oppress the poor", new Oppression(), new Greed(), new Pride()));
+        }
+
+        [Fact]
+        public void LovingYourNeighborAsYourselfFulfillsTheRoyalLaw_IsRighteous()
+        {
+            // "If you really fulfill the royal law ... 'You shall love your neighbor as yourself,' you are doing well." (James 2:8)
+            OracleHarness.Righteous(OracleHarness.Witness("the believer fulfills the royal law, loving his neighbor as himself", new Kindness(), new Compassion(), new Goodness()));
+        }
+
+        [Fact]
+        public void WithholdingFoodAndClothingFromTheNeedyBrother_IsSin()
+        {
+            // "If a brother or sister is poorly clothed and lacking in daily food, and one of you says ... but does not give them the things needed." (James 2:15-16)
+            OracleHarness.Sin(OracleHarness.Witness("they dismiss a brother lacking food and clothing without giving what the body needs", new Indifference(), new Heartlessness(), new WithholdingWhatIsDue()));
+        }
+
+        [Fact]
+        public void AbrahamOfferedIsaacAndFaithWasCompletedByWorks_IsRighteous()
+        {
+            // "Was not Abraham our father justified by works when he offered up his son Isaac on the altar?" (James 2:21-23)
+            OracleHarness.Righteous(OracleHarness.Witness("Abraham obeys God and offers up Isaac, his faith completed by works of obedience", new ObedienceToGod(), new CourageousFaith(), new Fidelity()));
+        }
+
+        [Fact]
+        public void RahabReceivedTheMessengersAndSentThemSafely_IsRighteous()
+        {
+            // "And in the same way was not also Rahab the prostitute justified by works when she received the messengers and sent them out by another way?" (James 2:25)
+            OracleHarness.Righteous(OracleHarness.Witness("Rahab welcomes the messengers and sends them safely out another way", new Hospitality(), new Protection(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void TheUntamedTongueBlessesGodAndCursesMen_IsSin()
+        {
+            // "With it we bless our Lord and Father, and with it we curse people ... this ought not to be so." (James 3:8-10)
+            OracleHarness.Sin(OracleHarness.Witness("the restless tongue, full of deadly poison, both curses men and sows strife", new Slander(), new Discord(), new Malice()));
+        }
+
+        [Fact]
+        public void WisdomFromAboveIsPurePeaceableAndGentle_IsRighteous()
+        {
+            // "the wisdom from above is first pure, then peaceable, gentle, open to reason, full of mercy and good fruits." (James 3:17)
+            OracleHarness.Righteous(OracleHarness.Witness("the wisdom from above is pure, peaceable, and gentle, full of mercy and good fruits", new Purity(), new Peace(), new Gentleness(), new Compassion()));
+        }
+
+        [Fact]
+        public void EarthlyWisdomIsJealousyAndSelfishAmbitionBreedingDisorder_IsSin()
+        {
+            // "where jealousy and selfish ambition exist, there will be disorder and every vile practice." (James 3:14-16)
+            OracleHarness.Sin(OracleHarness.Witness("bitter jealousy and selfish ambition boast against the truth, breeding disorder", new Jealousy(), new SelfishAmbition(), new Boasting()));
+        }
+
+        [Fact]
+        public void QuarrelsAndCovetousMurderingDesiresWageWarWithin_IsSin()
+        {
+            // "What causes quarrels and fights among you? ... You desire and do not have, so you murder." (James 4:1-2)
+            OracleHarness.Sin(OracleHarness.Witness("warring passions covet and quarrel and murder to seize what they lust for", new Murder(), new Covetousness(), new Discord()));
+            Assert.Equal(1.0, OracleHarness.Witness("warring passions covet and quarrel and murder to seize what they lust for", new Murder(), new Covetousness(), new Discord()).Disorder);
+        }
+
+        [Fact]
+        public void FriendshipWithTheWorldIsEnmityWithGod_IsSin()
+        {
+            // "friendship with the world is enmity with God ... You adulterous people!" (James 4:4)
+            OracleHarness.Sin(OracleHarness.Witness("the adulterous heart befriends the world in pride and makes itself an enemy of God", new Adultery(), new Pride(), new Rebellion()));
+        }
+
+        [Fact]
+        public void HumbleYourselvesBeforeTheLordAndHeWillExaltYou_IsRighteous()
+        {
+            // "Humble yourselves before the Lord, and he will exalt you." (James 4:7-10)
+            OracleHarness.Righteous(OracleHarness.Witness("the believer submits to God, draws near, and humbles himself before the Lord", new Humility(), new ObedienceToGod(), new Repentance()));
+        }
+
+        [Fact]
+        public void TheRichDefraudTheirLaborersOfWithheldWages_IsSin()
+        {
+            // "the wages of the laborers ... which you kept back by fraud, are crying out." (James 5:1-4)
+            OracleHarness.Sin(OracleHarness.Witness("the rich hoard treasure and keep back by fraud the wages of their laborers", new WithholdingWhatIsDue(), new Oppression(), new Greed()));
+        }
+
+        [Fact]
+        public void ThePrayerOfFaithWillSaveTheSickAndRaiseThemUp_IsADivineAct()
+        {
+            // "the prayer of faith will save the one who is sick, and the Lord will raise him up." (James 5:14-15)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Lord answers the prayer of faith, healing the sick and forgiving sins", new Healing(), new Forgiveness(), new RestoringLife()));
+        }
+
+        [Fact]
+        public void TurningASinnerFromHisWanderingSavesHisSoul_IsRighteous()
+        {
+            // "whoever brings back a sinner from his wandering will save his soul from death." (James 5:19-20)
+            OracleHarness.Righteous(OracleHarness.Witness("the brother turns a wanderer back from error, saving his soul and covering sins", new Deliverance(), new Compassion(), new Forgiveness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JeremiahNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JeremiahNarrativeTests.cs
@@ -1,0 +1,118 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Jeremiah narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class JeremiahNarrativeTests
+    {
+        [Fact]
+        public void GodCallsAndConsecratesJeremiahBeforeBirth_IsADivineAct()
+        {
+            // Before Jeremiah was formed in the womb the LORD knew, consecrated, and appointed him a prophet (Jeremiah 1:4-10).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD consecrates Jeremiah and appoints him a prophet to the nations",
+                new CreationOrder(), new Protection(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void JudahForsakesGodForBrokenCisterns_IsSin()
+        {
+            // My people have forsaken Me, the fountain of living waters, for broken cisterns that hold no water (Jeremiah 2:13).
+            OracleHarness.Sin(OracleHarness.Witness("Judah forsakes the LORD for worthless idols",
+                new Idolatry(), new CovenantBreaking()));
+        }
+
+        [Fact]
+        public void GodPleadsWithBackslidingIsraelToReturn_IsADivineAct()
+        {
+            // Return, faithless Israel, declares the LORD; I will not look on you in anger, for I am merciful (Jeremiah 3:12-14).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD pleads with faithless Israel to return and be forgiven",
+                new Compassion(), new Forgiveness(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void JudahsLeadersOppressTheFatherlessAndNeedy_IsSin()
+        {
+            // Among My people are wicked men; they grow rich and do not defend the orphan's cause or the rights of the needy (Jeremiah 5:26-28).
+            OracleHarness.Sin(OracleHarness.Witness("the wealthy of Judah oppress the fatherless and the needy",
+                new Oppression(), new Greed(), new WithholdingWhatIsDue()));
+        }
+
+        [Fact]
+        public void JerusalemBurnsTheirSonsToBaalInTheValley_IsSin()
+        {
+            // They built the high places of Baal to burn their sons in the fire, which I never commanded (Jeremiah 7:31; 19:5).
+            Resolution r = OracleHarness.Grounded("Judah sacrifices its children to Baal in the Valley of Hinnom",
+                Grounding.InIdol("Baal"), new ChildSacrifice(), new Idolatry(), new Bloodshed());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void TheProphetsAndPriestsHealTheWoundDeceitfully_IsSin()
+        {
+            // From prophet to priest everyone deals falsely, crying Peace, peace, when there is no peace (Jeremiah 6:13-14; 8:10-11).
+            OracleHarness.Sin(OracleHarness.Witness("priests and prophets deal falsely and cry peace where there is none",
+                new Deceit(), new Greed(), new FalseWitness()));
+        }
+
+        [Fact]
+        public void GodPromisesAnEverlastingCovenantWrittenOnTheHeart_IsADivineAct()
+        {
+            // Behold, the days come when I will make a new covenant, write My law on their hearts, and forgive their iniquity (Jeremiah 31:31-34).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD promises a new covenant and forgives their iniquity",
+                new PromiseFulfilled(), new CovenantFaithfulness(), new Forgiveness(), new Healing()));
+        }
+
+        [Fact]
+        public void GodPromisesToBringJudahHomeAfterSeventyYears_IsADivineAct()
+        {
+            // When seventy years are completed I will visit you and bring you back to this place, plans for welfare and a future (Jeremiah 29:10-14).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD promises to gather His people home after seventy years",
+                new PromiseFulfilled(), new Deliverance(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void JeremiahFaithfullyPreachesDespitePersecution_IsRighteous()
+        {
+            // Though beaten, put in stocks, and threatened with death, Jeremiah keeps speaking the LORD's word (Jeremiah 20:1-9; 26:12-15).
+            OracleHarness.Righteous(OracleHarness.Witness("Jeremiah keeps proclaiming the LORD's word under persecution",
+                new CourageousFaith(), new TeachingTruth(), new Endurance(), new Fidelity()));
+        }
+
+        [Fact]
+        public void KingJehoiakimCutsAndBurnsTheScrollOfTheWord_IsSin()
+        {
+            // As Jehudi read, the king cut the scroll and threw it into the fire, refusing the word of the LORD (Jeremiah 36:23-25).
+            OracleHarness.Sin(OracleHarness.Witness("King Jehoiakim cuts and burns the scroll of the LORD's word",
+                new Rebellion(), new Blasphemy(), new Disobedience()));
+        }
+
+        [Fact]
+        public void JeremiahBuysTheFieldAtAnathothInHope_IsRighteous()
+        {
+            // While the city is besieged, Jeremiah buys the field at Anathoth as a sign that houses and fields shall again be bought (Jeremiah 32:6-15).
+            OracleHarness.Righteous(OracleHarness.Witness("Jeremiah redeems the field at Anathoth as a sign of restoration",
+                new CourageousFaith(), new Trust(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void OfficialsCastJeremiahIntoTheMiryCistern_IsSin()
+        {
+            // The officials, hating his words, lower Jeremiah into a cistern of mud to die of hunger (Jeremiah 38:4-6).
+            OracleHarness.Sin(OracleHarness.Witness("the officials cast Jeremiah into the miry cistern to die",
+                new Hatred(), new Oppression(), new Malice()));
+        }
+
+        [Fact]
+        public void EbedMelechRescuesJeremiahFromTheCistern_IsRighteous()
+        {
+            // Ebed-melech the Cushite pleads for Jeremiah and lifts him from the cistern with rags and ropes (Jeremiah 38:7-13).
+            OracleHarness.Righteous(OracleHarness.Witness("Ebed-melech mercifully rescues Jeremiah from the cistern",
+                new Compassion(), new Deliverance(), new DefendingTheWeak(), new Kindness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JobNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JobNarrativeTests.cs
@@ -1,0 +1,129 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Job narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class JobNarrativeTests
+    {
+        [Fact]
+        public void JobIsBlamelessAndUpright_IsRighteous()
+        {
+            // "That man was blameless and upright, one who feared God and turned away from evil." (Job 1:1)
+            OracleHarness.Righteous(OracleHarness.Witness(
+                "Job lives blameless, upright, fearing God",
+                new Righteousness(), new ObedienceToGod(), new Purity()));
+        }
+
+        [Fact]
+        public void JobSanctifiesAndOffersBurntOfferingsForHisChildren_IsRighteous()
+        {
+            // "Job ... offered burnt offerings according to the number of them all ... Thus Job did continually." (Job 1:5)
+            OracleHarness.Righteous(OracleHarness.Witness(
+                "Job rises early to sacrifice and intercede for his children",
+                new Worship(), new Atonement()));
+        }
+
+        [Fact]
+        public void TheAdversaryAccusesAndSchemesAgainstJob_IsSin()
+        {
+            // "Does Job fear God for nothing? ... stretch out your hand and touch all that he has." (Job 1:9-11)
+            OracleHarness.Sin(OracleHarness.Witness(
+                "the accuser schemes to ruin the righteous Job",
+                new WickedScheming(), new Slander(), new Malice()));
+        }
+
+        [Fact]
+        public void JobWorshipsAfterLosingEverything_IsRighteous()
+        {
+            // "The Lord gave, and the Lord has taken away; blessed be the name of the Lord." (Job 1:20-21)
+            OracleHarness.Righteous(OracleHarness.Witness(
+                "stripped of all, Job falls down and worships and trusts God",
+                new Worship(), new Trust(), new Endurance()));
+        }
+
+        [Fact]
+        public void JobDoesNotChargeGodWithWrong_IsRighteous()
+        {
+            // "In all this Job did not sin or charge God with wrong." (Job 1:22; 2:10)
+            OracleHarness.Righteous(OracleHarness.Witness(
+                "Job receives evil from God's hand without sinning",
+                new Patience(), new Fidelity(), new SelfControl()));
+        }
+
+        [Fact]
+        public void JobsWifeCounselsHimToCurseGod_IsSin()
+        {
+            // "Do you still hold fast your integrity? Curse God and die." (Job 2:9)
+            OracleHarness.Sin(OracleHarness.Witness(
+                "Job's wife urges him to curse God and die",
+                new Blasphemy(), new Rebellion()));
+        }
+
+        [Fact]
+        public void JobsFriendsCondemnTheInnocentSufferer_IsSin()
+        {
+            // The friends accuse the blameless man of hidden guilt with false witness. (Job 8:6; 22:5-9)
+            OracleHarness.Sin(OracleHarness.Witness(
+                "the friends condemn the innocent and bear false witness against Job",
+                new Condemnation(), new FalseWitness(), new Slander()));
+        }
+
+        [Fact]
+        public void JobRecountsHisCareForThePoorAndVulnerable_IsRighteous()
+        {
+            // "I delivered the poor ... the blind ... the lame ... I was a father to the needy." (Job 29:12-16)
+            OracleHarness.Righteous(OracleHarness.Witness(
+                "Job recalls delivering the poor, the orphan, the blind, and the needy",
+                new Deliverance(), new DefendingTheWeak(), new HonoringTheVulnerable(), new Compassion()));
+        }
+
+        [Fact]
+        public void JobOathOfFeedingTheHungryAndClothingTheNaked_IsRighteous()
+        {
+            // "I have not eaten my morsel alone ... if I have seen anyone perish for lack of clothing." (Job 31:16-20)
+            OracleHarness.Righteous(OracleHarness.Witness(
+                "Job swears he fed the hungry and clothed the naked",
+                new FeedingTheHungry(), new ClothingTheNaked(), new Generosity()));
+        }
+
+        [Fact]
+        public void GodAnswersJobOutOfTheWhirlwind_IsADivineAct()
+        {
+            // "Where were you when I laid the foundation of the earth?" (Job 38:4)
+            OracleHarness.DivineAct(OracleHarness.Witness(
+                "God answers from the whirlwind, declaring the order of creation",
+                new CreationOrder(), new TeachingTruth(), new Goodness()));
+        }
+
+        [Fact]
+        public void JobRepentsInDustAndAshes_IsRighteous()
+        {
+            // "I despise myself, and repent in dust and ashes." (Job 42:6)
+            OracleHarness.Righteous(OracleHarness.Witness(
+                "Job repents before God in dust and ashes",
+                new Repentance(), new Humility(), new PovertyOfSpirit()));
+        }
+
+        [Fact]
+        public void JobIntercedesForHisFriends_IsRighteous()
+        {
+            // "My servant Job shall pray for you ... and the Lord accepted Job's prayer." (Job 42:8-9)
+            OracleHarness.Righteous(OracleHarness.Witness(
+                "Job prays for the friends who wronged him",
+                new Forgiveness(), new Atonement(), new Peacemaking()));
+        }
+
+        [Fact]
+        public void GodRestoresJobsFortunesTwofold_IsADivineAct()
+        {
+            // "And the Lord restored the fortunes of Job ... gave Job twice as much as he had before." (Job 42:10)
+            OracleHarness.DivineAct(OracleHarness.Witness(
+                "God restores Job and gives him double for his trouble",
+                new RestoringLife(), new JustRecompense(), new Goodness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JobOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JobOracleTests.cs
@@ -1,0 +1,40 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 22: Job.
+    public class JobOracleTests
+    {
+        [Fact]
+        public void JobsIntegrityUnderSuffering_IsRighteous()
+        {
+            // "Though he slay me, yet will I trust in him." (Job 13:15; 1:21-22)
+            OracleHarness.Righteous(OracleHarness.Witness("Job holds his integrity", new Trust(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void GodsSovereigntyOverCreationsOrder_IsADivineAct()
+        {
+            // "Where were you when I laid the earth's foundation?" (Job 38)
+            OracleHarness.DivineAct(OracleHarness.Witness("God answers from the whirlwind", new CreationOrder()));
+        }
+
+        [Fact]
+        public void TheComfortersFalseAccusation_IsSin()
+        {
+            // They condemn the innocent sufferer with false counsel (Job 42:7).
+            OracleHarness.Sin(OracleHarness.Witness("the comforters accuse Job falsely", new Condemnation(), new Deceit()));
+        }
+
+        [Fact]
+        public void GodVindicatesAndRestoresJob_IsADivineAct()
+        {
+            // God vindicates Job and restores him (Job 42).
+            OracleHarness.DivineAct(OracleHarness.Witness("God vindicates Job", new Righteousness(), new Compassion()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JoelNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JoelNarrativeTests.cs
@@ -1,0 +1,126 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Joel narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class JoelNarrativeTests
+    {
+        [Fact]
+        public void JoelCallsTheElttersToTellTheComingGenerations_IsRighteous()
+        {
+            // Tell your children of it, and let your children tell their children, and their children another generation (Joel 1:2-3).
+            OracleHarness.Righteous(OracleHarness.Witness("Joel teaches the elders to recount the LORD's dealings to every coming generation",
+                new TeachingTruth(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void JoelSummonsThePeopleToFastAndLament_IsRighteous()
+        {
+            // Sanctify a fast, call a solemn assembly; gather the elders and cry out to the LORD (Joel 1:13-14).
+            OracleHarness.Righteous(OracleHarness.Witness("Joel summons the priests and the people to a solemn fast and lament before the LORD",
+                new Mourning(), new Worship(), new Repentance()));
+        }
+
+        [Fact]
+        public void TheDayOfTheLordAdvancesAsTerribleJudgment_IsADivineAct()
+        {
+            // The day of the LORD is great and very terrible; a day of darkness and gloom, of clouds and thick darkness (Joel 2:1-2,11).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD musters His army and brings the great and terrible Day of the LORD in just judgment",
+                new JustRecompense(), new Righteousness()));
+        }
+
+        [Fact]
+        public void GodCallsForWholeheartedReturnWithRendedHearts_IsADivineAct()
+        {
+            // Return to Me with all your heart, with fasting, weeping, and mourning; rend your hearts and not your garments (Joel 2:12-13).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD calls His people to return to Him with all their heart, for He is gracious and merciful",
+                new Compassion(), new CovenantFaithfulness(), new Forgiveness()));
+        }
+
+        [Fact]
+        public void GodIsGraciousMercifulAndRelentsFromDisaster_IsADivineAct()
+        {
+            // For He is gracious and merciful, slow to anger, abounding in steadfast love, and relents over disaster (Joel 2:13).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD shows Himself gracious, slow to anger, abounding in steadfast love, relenting from the threatened disaster",
+                new Compassion(), new Patience(), new Pardon(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void ThePeopleRepentAndSanctifyAFast_IsRighteous()
+        {
+            // Blow the trumpet in Zion, consecrate a fast, gather the people, even nursing infants; let the priests weep (Joel 2:15-17).
+            OracleHarness.Righteous(OracleHarness.Witness("Israel consecrates a fast, gathers as one assembly, and weeps before the LORD in repentance",
+                new Repentance(), new Mourning(), new Humility(), new Worship()));
+        }
+
+        [Fact]
+        public void GodPitiesHisLandAndRestoresHerHarvest_IsADivineAct()
+        {
+            // Then the LORD became jealous for His land and had pity on His people; behold, I am sending you grain, wine, and oil (Joel 2:18-19).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD has pity on His people and sends grain, wine, and oil to satisfy them",
+                new Compassion(), new Generosity(), new FeedingTheHungry(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void GodRestoresTheYearsTheLocustHasEaten_IsADivineAct()
+        {
+            // I will restore to you the years that the swarming locust has eaten; you shall eat in plenty and be satisfied (Joel 2:25-26).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD restores the years the locust devoured and satisfies His people with plenty",
+                new RestoringLife(), new Generosity(), new PromiseFulfilled(), new Healing()));
+        }
+
+        [Fact]
+        public void GodPoursOutHisSpiritOnAllFlesh_IsADivineAct()
+        {
+            // I will pour out My Spirit on all flesh; your sons and daughters shall prophesy (Joel 2:28-29).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD pours out His Spirit on all flesh, that sons and daughters and servants might prophesy",
+                new Generosity(), new PromiseFulfilled(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void WhoeverCallsOnTheNameOfTheLordShallBeSaved_IsADivineAct()
+        {
+            // And everyone who calls on the name of the LORD shall be saved (Joel 2:32).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD promises deliverance to everyone who calls upon His name",
+                new Deliverance(), new PromiseFulfilled(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TheNationsSoldGodsPeopleAndShedInnocentBlood_IsSin()
+        {
+            // They have scattered My people, sold a girl for wine, and shed innocent blood in their land (Joel 3:2-3,19).
+            Resolution r = OracleHarness.Witness("Tyre, Sidon, and the nations sell the children of Judah and shed innocent blood in their land",
+                new Bloodshed(), new Oppression(), new Greed());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void GodJudgesTheNationsInTheValleyOfDecision_IsADivineAct()
+        {
+            // I will gather all the nations into the Valley of Jehoshaphat and enter into judgment with them there (Joel 3:12-14).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD gathers the nations into the valley of decision and judges them justly for their deeds",
+                new JustRecompense(), new Righteousness(), new DefendingTheWeak()));
+        }
+
+        [Fact]
+        public void GodIsARefugeAndStrongholdForHisPeople_IsADivineAct()
+        {
+            // The LORD is a refuge to His people and a stronghold to the people of Israel (Joel 3:16).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD becomes a refuge and stronghold for His people in the day of judgment",
+                new Protection(), new Deliverance(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void GodPardonsAndDwellsInZionForever_IsADivineAct()
+        {
+            // I will avenge their blood, which I have not yet avenged, for the LORD dwells in Zion (Joel 3:20-21).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD pardons His people, restores Judah forever, and dwells with them in Zion",
+                new Pardon(), new RestoringLife(), new CovenantFaithfulness(), new PromiseFulfilled()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JohnNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JohnNarrativeTests.cs
@@ -1,0 +1,174 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // John narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class JohnNarrativeTests
+    {
+        [Fact]
+        public void TheWordBecomesFleshAndDwellsAmongUs_IsADivineAct()
+        {
+            // "And the Word was made flesh, and dwelt among us, ... full of grace and truth." (John 1:1-14)
+            // The eternal Word, by whom all things were made, takes on flesh to dwell with His creation.
+            OracleHarness.DivineAct(OracleHarness.Witness("The Word who was God becomes flesh and dwells among us, full of grace and truth",
+                new SelfSacrifice(), new CreationOrder(), new RejoicingInTruth(),
+                new Humility(), new Goodness()));
+        }
+
+        [Fact]
+        public void JohnTheBaptistTestifiesToTheLightAndPointsToTheLamb_IsRighteous()
+        {
+            // "Behold the Lamb of God, which taketh away the sin of the world." (John 1:23-36)
+            // The forerunner bears witness to the Light, decreasing himself so that Christ may increase.
+            OracleHarness.Righteous(OracleHarness.Witness("John the Baptist testifies to the Light and points to Jesus as the Lamb of God",
+                new TeachingTruth(), new Humility(), new CourageousFaith(),
+                new ObedienceToGod(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void JesusTurnsWaterIntoWineAtCana_IsADivineAct()
+        {
+            // "This beginning of miracles did Jesus in Cana of Galilee, and manifested forth his glory." (John 2:1-11)
+            // At the wedding feast Christ provides abundant good wine, His first sign, blessing the celebration.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus turns water into wine at the wedding in Cana as the first of His signs",
+                new Generosity(), new Kindness(), new Joy(),
+                new CreationOrder(), new Goodness()));
+        }
+
+        [Fact]
+        public void JesusTeachesNicodemusThatGodSoLovedTheWorld_IsADivineAct()
+        {
+            // "For God so loved the world, that he gave his only begotten Son ... that ... whosoever believeth in him should not perish." (John 3:1-16)
+            // By night Christ teaches that one must be born again, and reveals the Father's saving love for the world.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus teaches Nicodemus that one must be born again and that God so loved the world He gave His only Son",
+                new TeachingTruth(), new SelfSacrifice(), new Deliverance(),
+                new CovenantFaithfulness(), new Goodness()));
+        }
+
+        [Fact]
+        public void JesusOffersLivingWaterToTheSamaritanWomanAtTheWell_IsADivineAct()
+        {
+            // "Whosoever drinketh of the water that I shall give him shall never thirst." (John 4:7-26)
+            // Crossing every barrier, Christ gives the outcast woman living water and reveals Himself as Messiah.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus offers living water to the Samaritan woman at the well and reveals Himself as Messiah",
+                new GivingDrink(), new HonoringTheVulnerable(), new TeachingTruth(),
+                new Kindness(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void JesusHealsTheManAtThePoolOfBethesdaOnTheSabbath_IsADivineAct()
+        {
+            // "Jesus saith unto him, Rise, take up thy bed, and walk. And immediately the man was made whole." (John 5:1-9)
+            // Christ heals the man infirm thirty-eight years, restoring strength to one long abandoned.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus heals the man infirm thirty-eight years at the pool of Bethesda on the Sabbath",
+                new Healing(), new Compassion(), new HonoringTheVulnerable(),
+                new RestoringLife(), new Goodness()));
+        }
+
+        [Fact]
+        public void JesusFeedsTheFiveThousandFromFiveLoavesAndTwoFishes_IsADivineAct()
+        {
+            // "And Jesus took the loaves ... he distributed to the disciples ... and they were filled." (John 6:5-13)
+            // Christ multiplies a boy's small meal to feed the multitude, with twelve baskets left over.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus feeds the five thousand from five barley loaves and two small fishes",
+                new FeedingTheHungry(), new Compassion(), new Generosity(),
+                new CreationOrder(), new Goodness()));
+        }
+
+        [Fact]
+        public void JesusDefendsTheWomanCaughtInAdulteryAndForgivesHer_IsADivineAct()
+        {
+            // "He that is without sin among you, let him first cast a stone ... Neither do I condemn thee: go, and sin no more." (John 8:3-11)
+            // Christ silences her accusers and, refusing condemnation, releases the woman with mercy and a call to repent.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus shields the woman caught in adultery from stoning and tells her He does not condemn her, go and sin no more",
+                new Pardon(), new DefendingTheWeak(), new Forgiveness(),
+                new Compassion(), new Righteousness()));
+        }
+
+        [Fact]
+        public void JesusHealsTheManBornBlind_IsADivineAct()
+        {
+            // "He went his way therefore, and washed, and came seeing." (John 9:1-7)
+            // Christ anoints the eyes of the man born blind and gives him sight, manifesting the works of God.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus anoints the eyes of the man born blind so that he washes and comes back seeing",
+                new Healing(), new Compassion(), new RestoringLife(),
+                new HonoringTheVulnerable(), new Goodness()));
+        }
+
+        [Fact]
+        public void JesusTheGoodShepherdLaysDownHisLifeForTheSheep_IsADivineAct()
+        {
+            // "I am the good shepherd: the good shepherd giveth his life for the sheep." (John 10:11-15)
+            // Christ declares Himself the Good Shepherd who knows His own and lays down His life to protect them.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus declares Himself the Good Shepherd who lays down His life for the sheep",
+                new SelfSacrifice(), new Protection(), new DefendingTheWeak(),
+                new CovenantFaithfulness(), new Goodness()));
+        }
+
+        [Fact]
+        public void JesusWeepsAndRaisesLazarusFromTheTomb_IsADivineAct()
+        {
+            // "Lazarus, come forth. And he that was dead came forth." (John 11:33-44)
+            // Christ groans in compassion, weeps, and calls Lazarus four days dead out of the grave alive.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus weeps with the mourners and raises Lazarus from the tomb after four days dead",
+                new RestoringLife(), new Compassion(), new Mourning(),
+                new Healing(), new Goodness()));
+        }
+
+        [Fact]
+        public void JesusWashesTheDisciplesFeet_IsADivineAct()
+        {
+            // "If I then, your Lord and Master, have washed your feet; ye also ought to wash one another's feet." (John 13:4-15)
+            // The Lord girds Himself with a towel and serves His disciples, teaching humble love by example.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus girds Himself with a towel and washes His disciples' feet as an example of humble service",
+                new Humility(), new SelfSacrifice(), new Kindness(),
+                new TeachingTruth(), new Gentleness()));
+        }
+
+        [Fact]
+        public void JudasIscariotBetraysJesusForMoney_IsSin()
+        {
+            // "And after the sop Satan entered into him. ... He then having received the sop went immediately out." (John 13:21-30)
+            // Judas, the thief who carried the bag, hands his Master over to those who seek His blood.
+            OracleHarness.Sin(OracleHarness.Grounded("Judas Iscariot accepts the sop and goes out into the night to betray Jesus",
+                Grounding.InIdol("the money bag he carried"),
+                new Treachery(), new Greed(), new Theft(),
+                new Deceit(), new WickedScheming()));
+        }
+
+        [Fact]
+        public void PeterDeniesJesusThreeTimesInTheCourtyard_IsSin()
+        {
+            // "Peter then denied again: and immediately the cock crew." (John 18:17-27)
+            // Afraid in the high priest's courtyard, Peter swears three times that he does not know his Lord.
+            OracleHarness.Sin(OracleHarness.Grounded("Peter denies that he knows Jesus three times before the cock crows",
+                Grounding.InIdol("fear of the bystanders"),
+                new Treachery(), new Deceit(), new FalseWitness(),
+                new CovenantBreaking(), new Disobedience()));
+        }
+
+        [Fact]
+        public void JesusLaysDownHisLifeOnTheCrossAndItIsFinished_IsADivineAct()
+        {
+            // "When Jesus therefore had received the vinegar, he said, It is finished: and ... gave up the ghost." (John 19:28-30)
+            // The Lamb of God offers Himself wholly, completing the work of atonement for the sin of the world.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus lays down His life on the cross, declares It is finished, and gives up His spirit",
+                new SelfSacrifice(), new Atonement(), new Deliverance(),
+                new PromiseFulfilled(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TheRisenJesusRestoresPeterAndCommandsFeedMySheep_IsADivineAct()
+        {
+            // "Simon, son of Jonas, lovest thou me? ... Feed my sheep." (John 21:15-17)
+            // The risen Christ tenderly restores the one who denied Him, pardoning Peter and recommissioning him.
+            OracleHarness.DivineAct(OracleHarness.Witness("The risen Jesus restores Peter by the lake, pardoning his denial and commanding him to feed His sheep",
+                new Forgiveness(), new Pardon(), new RestoringLife(),
+                new Kindness(), new CovenantFaithfulness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JonahNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JonahNarrativeTests.cs
@@ -1,0 +1,142 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Jonah narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class JonahNarrativeTests
+    {
+        [Fact]
+        public void GodCommandsJonahToCryAgainstNineveh_IsADivineAct()
+        {
+            // "Arise, go to Nineveh, that great city, and cry against it." (Jonah 1:1-2)
+            // God sends His prophet to a wicked Gentile city, in mercy giving them warning before judgment.
+            OracleHarness.DivineAct(OracleHarness.Witness("God commands Jonah to go and cry against Nineveh",
+                new TeachingTruth(), new Righteousness(), new Compassion(),
+                new JustRecompense(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void JonahFleesFromTheLordTowardTarshish_IsSin()
+        {
+            // "But Jonah rose up to flee unto Tarshish from the presence of the LORD." (Jonah 1:3)
+            // Jonah disobeys the clear command of God, rebelling and running from his calling.
+            Resolution r = OracleHarness.Witness("Jonah flees from the presence of the LORD toward Tarshish",
+                new Disobedience(), new Rebellion(), new SelfSeeking());
+            OracleHarness.Sin(r);
+        }
+
+        [Fact]
+        public void GodHurlsAGreatWindAndTempestUponTheSea_IsADivineAct()
+        {
+            // "But the LORD sent out a great wind into the sea, and there was a mighty tempest." (Jonah 1:4)
+            // God in righteous sovereignty disciplines His fleeing prophet, ordering even the storm.
+            OracleHarness.DivineAct(OracleHarness.Witness("God hurls a great wind and mighty tempest upon the sea to halt Jonah",
+                new Righteousness(), new JustRecompense(), new CreationOrder(),
+                new TeachingTruth(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void JonahConfessesHeFearsTheLordGodOfHeaven_IsRighteous()
+        {
+            // "I am an Hebrew; and I fear the LORD, the God of heaven, which hath made the sea." (Jonah 1:9)
+            // Jonah testifies truly to the sailors of the one Creator God whom he worships.
+            OracleHarness.Righteous(OracleHarness.Witness("Jonah confesses to the sailors that he fears the LORD, God of heaven who made the sea",
+                new TeachingTruth(), new Worship(), new RejoicingInTruth(),
+                new Trustworthiness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void JonahAsksToBeCastIntoTheSeaToSpareTheSailors_IsRighteous()
+        {
+            // "Take me up, and cast me forth into the sea ... for my sake this great tempest is upon you." (Jonah 1:12)
+            // Owning his guilt, Jonah offers his own life to save the imperiled mariners.
+            OracleHarness.Righteous(OracleHarness.Witness("Jonah tells the sailors to cast him into the sea so they may be spared",
+                new SelfSacrifice(), new Repentance(), new Protection(),
+                new Humility(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void GodPreparesAGreatFishToSwallowAndPreserveJonah_IsADivineAct()
+        {
+            // "Now the LORD had prepared a great fish to swallow up Jonah." (Jonah 1:17)
+            // The judgment of the deep becomes the means of mercy; God preserves the prophet alive.
+            OracleHarness.DivineAct(OracleHarness.Witness("God prepares a great fish to swallow Jonah and preserve him from the deep",
+                new Deliverance(), new Protection(), new Compassion(),
+                new RestoringLife(), new CreationOrder()));
+        }
+
+        [Fact]
+        public void JonahPraysAndGivesThanksFromTheBellyOfTheFish_IsRighteous()
+        {
+            // "I cried by reason of mine affliction unto the LORD ... with the voice of thanksgiving." (Jonah 2:1-9)
+            // From the depths Jonah turns back to God in repentant prayer, worship, and trust.
+            OracleHarness.Righteous(OracleHarness.Witness("Jonah prays from the fish's belly with repentance, thanksgiving, and trust in the LORD",
+                new Repentance(), new Worship(), new Trust(),
+                new Humility(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void GodDeliversJonahOntoDryLand_IsADivineAct()
+        {
+            // "And the LORD spake unto the fish, and it vomited out Jonah upon the dry land." (Jonah 2:10)
+            // God answers the prophet's repentance, raising him out of the deep and restoring him to life and mission.
+            OracleHarness.DivineAct(OracleHarness.Witness("God commands the fish to deliver Jonah safely onto the dry land",
+                new Deliverance(), new RestoringLife(), new Compassion(),
+                new Forgiveness(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void JonahObeysAndProclaimsGodsWordToNineveh_IsRighteous()
+        {
+            // "So Jonah arose, and went unto Nineveh, according to the word of the LORD ... Yet forty days." (Jonah 3:1-4)
+            // The second time, Jonah obeys and faithfully delivers the warning God gave him.
+            OracleHarness.Righteous(OracleHarness.Witness("Jonah obeys the second call and proclaims God's warning throughout Nineveh",
+                new ObedienceToGod(), new TeachingTruth(), new Fidelity(),
+                new CourageousFaith(), new Trustworthiness()));
+        }
+
+        [Fact]
+        public void NinevehRepentsInFastingAndSackcloth_IsRighteous()
+        {
+            // "So the people of Nineveh believed God ... and put on sackcloth ... and cried mightily unto God." (Jonah 3:5-8)
+            // The whole city, from king to commoner, humbles itself, fasts, and turns from its evil way.
+            OracleHarness.Righteous(OracleHarness.Witness("Nineveh believes God, fasts in sackcloth, and turns from its evil way",
+                new Repentance(), new Humility(), new Mourning(),
+                new Worship(), new HungerForRighteousness()));
+        }
+
+        [Fact]
+        public void GodRelentsAndSparesRepentantNineveh_IsADivineAct()
+        {
+            // "And God saw their works, that they turned from their evil way; and God repented of the evil ... and did it not." (Jonah 3:10)
+            // Seeing genuine repentance, God in mercy withholds the threatened judgment and spares the city.
+            OracleHarness.DivineAct(OracleHarness.Witness("God sees Nineveh's repentance and relents, sparing the city from judgment",
+                new Compassion(), new Forgiveness(), new Pardon(),
+                new Deliverance(), new Kindness()));
+        }
+
+        [Fact]
+        public void JonahIsAngryAndResentsGodsMercyToNineveh_IsSin()
+        {
+            // "But it displeased Jonah exceedingly, and he was very angry." (Jonah 4:1-3)
+            // Jonah begrudges the grace shown to his enemies, nursing rage and a grudge against God's compassion.
+            Resolution r = OracleHarness.Witness("Jonah is exceedingly angry and resents God's mercy toward Nineveh",
+                new FitsOfRage(), new Grudge(), new Hatred(), new SelfSeeking());
+            OracleHarness.Sin(r);
+        }
+
+        [Fact]
+        public void GodGentlyTeachesJonahHisCompassionForNineveh_IsADivineAct()
+        {
+            // "Should not I spare Nineveh, that great city, wherein are more than sixscore thousand persons?" (Jonah 4:6-11)
+            // God appoints the gourd, the worm, and the wind, then teaches Jonah the breadth of His pity.
+            OracleHarness.DivineAct(OracleHarness.Witness("God gently reasons with Jonah by the gourd, teaching His compassion for Nineveh",
+                new TeachingTruth(), new Compassion(), new Patience(),
+                new Gentleness(), new HonoringTheVulnerable()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JosephasNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JosephasNarrativeTests.cs
@@ -1,0 +1,128 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Josephas son of Bengorion (Ethiopic Zëna Ayhud / Sefer Yosippon, canon tag ETH) narrative oracle:
+    // the engine must return the verdict Scripture/the chronicle gives at each step. Best-effort, Ethiopic-only.
+    public class JosephasNarrativeTests
+    {
+        [Fact]
+        public void AntiochusDefilesTheTempleAndOutlawsTheLaw_IsSin()
+        {
+            // Antiochus enters Jerusalem, plunders and profanes the sanctuary, forbids the Law and
+            // covenant worship, and commands the people to sacrifice to idols. (Yosippon, on Antiochus' persecution)
+            // Proud, sacrilegious tyranny that defiles God's house and forces apostasy.
+            OracleHarness.Sin(OracleHarness.Witness("Antiochus defiles the temple, outlaws the Law, and commands idolatry",
+                new Defilement(), new Idolatry(), new Blasphemy(), new Oppression(), new Lawlessness(), new Pride()));
+            Assert.Equal(1.0, OracleHarness.Witness("Antiochus defiles the temple, outlaws the Law, and commands idolatry",
+                new Defilement(), new Idolatry(), new Blasphemy(), new Oppression(), new Lawlessness(), new Pride()).Disorder);
+        }
+
+        [Fact]
+        public void HannahAndHerSevenSonsChooseDeathRatherThanEatUncleanFood_IsRighteous()
+        {
+            // The mother and her seven sons are tortured and slain one by one, yet refuse to break God's
+            // Law, encouraging one another to die in faith. (Yosippon, the mother of the seven martyrs)
+            // Courageous, enduring, faithful covenant-keeping unto death.
+            OracleHarness.Righteous(OracleHarness.Witness("Hannah and her seven sons choose death rather than forsake God's Law",
+                new CourageousFaith(), new Endurance(), new Fidelity(), new ObedienceToGod(), new Purity(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void MattathiasRefusesToSacrificeAndRalliesTheZealousForTheCovenant_IsRighteous()
+        {
+            // Mattathias refuses to obey the king's decree, tears down the idol altar, and calls all who are
+            // zealous for the Law to come out with him. (Yosippon, the rising of the Hasmoneans)
+            // Steadfast covenant faithfulness and courageous refusal of idolatry.
+            OracleHarness.Righteous(OracleHarness.Grounded("Mattathias refuses the idol altar and rallies the zealous for the covenant",
+                Grounding.InGod(),
+                new CovenantFaithfulness(), new CourageousFaith(), new ObedienceToGod(), new Worship(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodDeliversJudasAndTheFaithfulAgainstTheGreaterArmy_IsADivineAct()
+        {
+            // Judas and the few cry that strength comes from Heaven, and the Lord routs the vast pagan host
+            // and saves Israel. (Yosippon, the Maccabean victories)
+            // Scripture's verdict is the deliverance Heaven works for the weak who trust Him.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God delivers Judas and the faithful few against the mighty pagan army",
+                Grounding.InGod(),
+                new Deliverance(), new Protection(), new DefendingTheWeak(), new JustRecompense(),
+                new Fidelity(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void JudasCleansesAndRededicatesTheSanctuaryWithJoy_IsRighteous()
+        {
+            // Judas casts out the defilement, restores the altar, and rededicates God's house with song,
+            // sacrifice, and gladness. (Yosippon, the purification of the temple)
+            // Joyful, worshipful restoration of covenant worship.
+            OracleHarness.Righteous(OracleHarness.Grounded("Judas cleanses and rededicates the sanctuary with worship and joy",
+                Grounding.InGod(),
+                new Worship(), new Joy(), new CovenantFaithfulness(), new RejoicingInTruth(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void HerodMurdersHisOwnKinToSeizeAndHoldThePower_IsSin()
+        {
+            // Herod, suspicious and cruel, puts to death his own wife, sons, and rivals to secure his throne.
+            // (Yosippon, the reign of Herod)
+            // Jealous, treacherous bloodshed and murder for the sake of power.
+            OracleHarness.Sin(OracleHarness.Witness("Herod murders his own wife and sons to secure his throne",
+                new Murder(), new Bloodshed(), new Treachery(), new Jealousy(), new Pride()));
+            Assert.Equal(1.0, OracleHarness.Witness("Herod murders his own wife and sons to secure his throne",
+                new Murder(), new Bloodshed(), new Treachery(), new Jealousy(), new Pride()).Disorder);
+        }
+
+        [Fact]
+        public void TheZealotFactionsTearJerusalemApartInCivilStrife_IsSin()
+        {
+            // Inside the besieged city the rival factions fight one another, burn the storehouses of grain,
+            // and shed the blood of their own people. (Yosippon, the war within Jerusalem)
+            // Faction, discord, and bloodshed that destroy the city from within.
+            OracleHarness.Sin(OracleHarness.Witness("The zealot factions war on one another and shed blood within Jerusalem",
+                new Faction(), new Discord(), new Bloodshed(), new SowingDiscord(), new Chaos()));
+            Assert.Equal(1.0, OracleHarness.Witness("The zealot factions war on one another and shed blood within Jerusalem",
+                new Faction(), new Discord(), new Bloodshed(), new SowingDiscord(), new Chaos()).Disorder);
+        }
+
+        [Fact]
+        public void TheStarvingMotherSlaysAndDevoursHerOwnChildInTheSiege_IsSin()
+        {
+            // In the famine of the siege a desperate mother kills and eats her own infant. (Yosippon, the
+            // horrors of the famine in besieged Jerusalem)
+            // The unnatural slaughter of one's own child, the abyss of the city's ruin.
+            OracleHarness.Sin(OracleHarness.Witness("A starving mother slays and devours her own child during the siege",
+                new ChildSacrifice(), new Murder(), new Bloodshed(), new Defilement()));
+            Assert.Equal(1.0, OracleHarness.Witness("A starving mother slays and devours her own child during the siege",
+                new ChildSacrifice(), new Murder(), new Bloodshed(), new Defilement()).Disorder);
+        }
+
+        [Fact]
+        public void TheRomansBurnTheTempleAndSackTheHolyCity_IsSin()
+        {
+            // The Roman army storms Jerusalem, sets the sanctuary aflame, slaughters the people, and plunders
+            // the holy vessels. (Yosippon, the destruction of the Second Temple)
+            // Sacrilegious bloodshed, plunder, and oppression against God's house and people.
+            OracleHarness.Sin(OracleHarness.Witness("The Romans burn the temple and sack the holy city of Jerusalem",
+                new Bloodshed(), new Defilement(), new Theft(), new Oppression(), new Murder()));
+            Assert.Equal(1.0, OracleHarness.Witness("The Romans burn the temple and sack the holy city of Jerusalem",
+                new Bloodshed(), new Defilement(), new Theft(), new Oppression(), new Murder()).Disorder);
+        }
+
+        [Fact]
+        public void TheRemnantMournsTheRuinedSanctuaryAndTurnsBackToGod_IsRighteous()
+        {
+            // The surviving remnant weeps over the burned house of God, confesses, and turns again to the
+            // Lord in humble sorrow. (Yosippon, the lament after Jerusalem's fall)
+            // Humble mourning, repentance, and renewed trust in God amid the ruin.
+            OracleHarness.Righteous(OracleHarness.Grounded("The remnant mourns the ruined sanctuary and turns back to God",
+                Grounding.InGod(),
+                new Mourning(), new Repentance(), new Humility(), new Trust(), new Fidelity()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JoshuaNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JoshuaNarrativeTests.cs
@@ -1,0 +1,117 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Joshua narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class JoshuaNarrativeTests
+    {
+        [Fact]
+        public void GodCommissionsJoshuaToBeStrongAndCourageous_IsADivineAct()
+        {
+            // "Be strong and courageous... for the LORD your God will be with you wherever you go." (Joshua 1:5-9)
+            OracleHarness.DivineAct(OracleHarness.Witness("God commissions Joshua and pledges to be with him always", new CovenantFaithfulness(), new PromiseFulfilled(), new Fidelity()));
+        }
+
+        [Fact]
+        public void RahabHidesTheSpiesAndProtectsThem_IsRighteous()
+        {
+            // "But the woman had taken the two men and hidden them." (Joshua 2:4-6)
+            OracleHarness.Righteous(OracleHarness.Witness("Rahab hides the Israelite spies and shelters them from harm", new Protection(), new Hospitality(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void GodStopsTheJordanSoIsraelCrossesOnDryGround_IsADivineAct()
+        {
+            // "The water from upstream stopped flowing... and the people crossed over." (Joshua 3:13-17)
+            OracleHarness.DivineAct(OracleHarness.Witness("God halts the Jordan so Israel crosses into the land on dry ground", new Deliverance(), new PromiseFulfilled(), new CreationOrder()));
+        }
+
+        [Fact]
+        public void IsraelSetsUpTwelveStonesAsAMemorial_IsRighteous()
+        {
+            // "These stones are to be a memorial to the people of Israel forever." (Joshua 4:5-7)
+            OracleHarness.Righteous(OracleHarness.Witness("Israel raises twelve memorial stones to remember God's faithfulness", new Worship(), new CovenantFaithfulness(), new TeachingTruth()));
+        }
+
+        [Fact]
+        public void GodGivesJerichoIntoIsraelsHand_IsADivineAct()
+        {
+            // "See, I have delivered Jericho into your hands." (Joshua 6:2, 20)
+            OracleHarness.DivineAct(OracleHarness.Witness("God delivers Jericho into Israel's hand as the walls fall", new Deliverance(), new PromiseFulfilled(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void RahabAndHerHouseholdAreSparedAndDelivered_IsRighteous()
+        {
+            // "Joshua spared Rahab the prostitute, with her family... because she hid the men." (Joshua 6:25)
+            OracleHarness.Righteous(OracleHarness.Witness("Rahab and her household are spared and brought to safety for her faith", new Deliverance(), new Protection(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void AchanStealsTheDevotedThingsAtJericho_IsSin()
+        {
+            // "Achan... took some of the devoted things; so the LORD's anger burned against Israel." (Joshua 7:1, 20-21)
+            OracleHarness.Sin(OracleHarness.Witness("Achan steals the devoted spoil of Jericho and hides it", new Theft(), new Covetousness(), new Disobedience(), new Deceit()));
+        }
+
+        [Fact]
+        public void JoshuaRenewsTheCovenantAndReadsTheLawAtMountEbal_IsRighteous()
+        {
+            // "Joshua read all the words of the law... There was not a word... that Joshua did not read." (Joshua 8:34-35)
+            OracleHarness.Righteous(OracleHarness.Witness("Joshua renews the covenant and reads all the law to Israel at Mount Ebal", new ObedienceToGod(), new TeachingTruth(), new Worship(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TheGibeonitesDeceiveIsraelIntoATreaty_IsSin()
+        {
+            // "They... resorted to a ruse... 'We have come from a distant country.'" (Joshua 9:3-6, 22)
+            OracleHarness.Sin(OracleHarness.Witness("the Gibeonites deceive Israel with a lying ruse to secure a treaty", new Deceit(), new FalseWitness()));
+        }
+
+        [Fact]
+        public void IsraelKeepsItsOathToTheGibeonites_IsRighteous()
+        {
+            // "We have given them our oath by the LORD... we cannot touch them now." (Joshua 9:18-20)
+            OracleHarness.Righteous(OracleHarness.Witness("Israel honors its sworn oath and spares the Gibeonites despite the deception", new CovenantFaithfulness(), new Trustworthiness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void JoshuaDefendsTheGibeoniteAlliesFromTheFiveKings_IsRighteous()
+        {
+            // "Do not abandon your servants. Come up to us quickly and save us." (Joshua 10:6-7)
+            OracleHarness.Righteous(OracleHarness.Witness("Joshua marches to rescue the Gibeonites from the five attacking kings", new Protection(), new DefendingTheWeak(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void GodMakesTheSunStandStillAtGibeon_IsADivineAct()
+        {
+            // "The sun stood still... until the nation avenged itself on its enemies." (Joshua 10:12-14)
+            OracleHarness.DivineAct(OracleHarness.Witness("God halts the sun over Gibeon to give Israel victory", new Deliverance(), new JustRecompense(), new CreationOrder()));
+        }
+
+        [Fact]
+        public void GodGivesIsraelRestInTheLandAsHePromised_IsADivineAct()
+        {
+            // "Not one of all the LORD's good promises... failed; every one was fulfilled." (Joshua 21:43-45)
+            OracleHarness.DivineAct(OracleHarness.Witness("God gives Israel the land and rest, fulfilling every good promise", new PromiseFulfilled(), new CovenantFaithfulness(), new Fidelity(), new Peace()));
+        }
+
+        [Fact]
+        public void CalebReceivesHebronForHisWholehearedFaith_IsRighteous()
+        {
+            // "Hebron has belonged to Caleb... ever since, because he followed the LORD... wholeheartedly." (Joshua 14:13-14)
+            OracleHarness.Righteous(OracleHarness.Witness("Caleb receives Hebron as his just inheritance for following God wholeheartedly", new JustRecompense(), new CourageousFaith(), new Fidelity()));
+        }
+
+        [Fact]
+        public void JoshuaChargesIsraelToChooseAndServeTheLordAtShechem_IsRighteous()
+        {
+            // "Choose for yourselves this day whom you will serve... as for me and my household, we will serve the LORD." (Joshua 24:14-15)
+            OracleHarness.Righteous(OracleHarness.Witness("Joshua charges Israel to put away idols and serve the LORD alone at Shechem", new Worship(), new ObedienceToGod(), new CovenantFaithfulness(), new TeachingTruth()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JoshuaOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JoshuaOracleTests.cs
@@ -1,0 +1,35 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 06: Joshua.
+    public class JoshuaOracleTests
+    {
+        [Fact]
+        public void GodKeepsThePromiseOfTheLand_IsADivineAct()
+        {
+            // "Not one of all the LORD's good promises ... failed." (Joshua 21:45)
+            OracleHarness.DivineAct(OracleHarness.Witness("the promise of the land kept",
+                new CovenantFaithfulness(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void RahabHidesTheSpiesByFaith_IsRighteous()
+        {
+            // Rahab shelters the messengers, trusting Israel's God (Joshua 2; Hebrews 11:31).
+            OracleHarness.Righteous(OracleHarness.Witness("Rahab hides the spies",
+                new CourageousFaith(), new Protection()));
+        }
+
+        [Fact]
+        public void AchansTreachery_IsSin()
+        {
+            // Achan takes what was devoted and hides it (Joshua 7).
+            OracleHarness.Sin(OracleHarness.Witness("Achan's theft", new Theft(), new Disobedience()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JubileesBookNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JubileesBookNarrativeTests.cs
@@ -1,0 +1,156 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Jubilees narrative oracle: the engine must return the verdict Scripture gives at each step.
+    // Jubilees retells Genesis through early Exodus as the angel of the presence dictates the heavenly
+    // tablets to Moses on Sinai, with strong emphasis on the Sabbath, the calendar, and covenant law.
+    public class JubileesBookNarrativeTests
+    {
+        [Fact]
+        public void GodCreatesTheHeavensAndEarthInSixDays_IsADivineAct()
+        {
+            // "On the first day He created the heavens ... and on the sixth day ... He finished all His work." (Jubilees 2:1-16)
+            // The ordered six-day creation establishes the order of all reality.
+            OracleHarness.DivineAct(OracleHarness.Witness("God creates the heavens and the earth in six ordered days",
+                new CreationOrder(), new Goodness(), new Fidelity(), new Worship()));
+        }
+
+        [Fact]
+        public void GodSanctifiesTheSeventhDayAsTheSabbath_IsADivineAct()
+        {
+            // "He gave us the Sabbath day ... to keep Sabbath thereon from all work." (Jubilees 2:17-33)
+            // God blesses and hallows the seventh day as an everlasting covenant sign.
+            OracleHarness.DivineAct(OracleHarness.Witness("God blesses and sanctifies the seventh day as the Sabbath",
+                new CreationOrder(), new CovenantFaithfulness(), new Worship(),
+                new Goodness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void AdamAndEveTransgressTheCommandInEden_IsSin()
+        {
+            // The serpent deceives Eve and they eat the forbidden fruit, breaking the command. (Jubilees 3:17-25)
+            // Disobedience and deceit shatter the order of the garden and bring death.
+            OracleHarness.Sin(OracleHarness.Witness("Adam and Eve disobey God's command in the garden, deceived by the serpent",
+                new Disobedience(), new Deceit(), new CovenantBreaking(), new Rebellion()));
+        }
+
+        [Fact]
+        public void CainMurdersHisBrotherAbel_IsSin()
+        {
+            // "Cain slew Abel his brother ... and his blood cried from the ground." (Jubilees 4:1-6)
+            // The first murder is capital bloodshed that defiles the earth.
+            Resolution r = OracleHarness.Witness("Cain murders his brother Abel in the field",
+                new Murder(), new Bloodshed(), new Hatred(), new Envy());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void TheWatchersDefileThemselvesWithTheDaughtersOfMen_IsSin()
+        {
+            // The angels who were Watchers sin with the daughters of men, begetting the giants. (Jubilees 5:1-11)
+            // Their fornication and corruption fill the earth with violence and uncleanness.
+            Resolution r = OracleHarness.Witness("the Watchers defile themselves with the daughters of men and corrupt the earth",
+                new SexualImmorality(), new Defilement(), new Lust(), new Rebellion());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void NoahWalksBlamelesslyAndBuildsTheArkInObedience_IsRighteous()
+        {
+            // Noah found grace and did according to all God commanded, building the ark. (Jubilees 5:19; 6:1)
+            // His blameless obedience preserves life through the flood.
+            OracleHarness.Righteous(OracleHarness.Witness("Noah obeys God and builds the ark to preserve life",
+                new ObedienceToGod(), new Righteousness(), new Fidelity(),
+                new CourageousFaith(), new Protection()));
+        }
+
+        [Fact]
+        public void GodEstablishesHisCovenantWithNoahAfterTheFlood_IsADivineAct()
+        {
+            // God sets His bow in the cloud and covenants never again to destroy the earth by flood. (Jubilees 6:1-16)
+            // The everlasting covenant and the feast of weeks are ordained.
+            OracleHarness.DivineAct(OracleHarness.Witness("God makes His covenant with Noah and sets the bow in the cloud",
+                new CovenantFaithfulness(), new PromiseFulfilled(), new Goodness(),
+                new Fidelity(), new CreationOrder()));
+        }
+
+        [Fact]
+        public void GodCommandsNoahToAbstainFromBloodAndKeepRighteousness_IsADivineAct()
+        {
+            // Noah is charged to eat no blood, to do judgment and righteousness, and to cover blamelessness. (Jubilees 7:20-33)
+            // God ordains the law against bloodshed to keep the earth from defilement.
+            OracleHarness.DivineAct(OracleHarness.Witness("God commands Noah to shun blood and walk in righteousness",
+                new Righteousness(), new ObedienceToGod(), new CovenantFaithfulness(),
+                new CreationOrder(), new Goodness()));
+        }
+
+        [Fact]
+        public void AbramBurnsTheHouseOfIdolsAndRefusesTheStars_IsRighteous()
+        {
+            // Abram rejects the idols of his fathers, burns the house of idols, and worships the Creator. (Jubilees 11:16-17; 12:1-14)
+            // He turns from idolatry to courageous, true worship of the one God.
+            OracleHarness.Righteous(OracleHarness.Witness("Abram forsakes idolatry and worships the Creator alone",
+                new Worship(), new CourageousFaith(), new ObedienceToGod(),
+                new Fidelity(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void GodCovenantsWithAbrahamAndPromisesTheLand_IsADivineAct()
+        {
+            // God appears to Abram, makes covenant, and promises seed, blessing, and the land. (Jubilees 14:1-20; 15:1-10)
+            // The covenant of circumcision is given as an everlasting ordinance.
+            OracleHarness.DivineAct(OracleHarness.Witness("God covenants with Abraham and promises the land and seed",
+                new CovenantFaithfulness(), new PromiseFulfilled(), new Fidelity(),
+                new Goodness(), new Trustworthiness()));
+        }
+
+        [Fact]
+        public void MastemaAndTheSodomitesWorkUncleannessAndViolence_IsSin()
+        {
+            // The men of Sodom are wholly sinful, defiling themselves and working violence. (Jubilees 16:5-6)
+            // Prince Mastema's people fill the land with uncleanness and bloodshed and are destroyed.
+            Resolution r = OracleHarness.Grounded("the men of Sodom defile themselves with violence and uncleanness",
+                Grounding.InIdol("Mastema"),
+                new Bloodshed(), new Defilement(), new SexualImmorality(), new Oppression());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void AbrahamObeysGodInTheBindingOfIsaac_IsRighteous()
+        {
+            // Tempted by Mastema, Abraham obeys to offer Isaac, and is found faithful. (Jubilees 17:15-18:19)
+            // His obedience and faith under trial prove his covenant faithfulness.
+            OracleHarness.Righteous(OracleHarness.Witness("Abraham obeys God in the binding of Isaac and is found faithful",
+                new ObedienceToGod(), new CourageousFaith(), new Fidelity(),
+                new CovenantFaithfulness(), new Trust()));
+        }
+
+        [Fact]
+        public void GodSmitesEgyptAndDeliversIsraelAtThePassover_IsADivineAct()
+        {
+            // On the night of the Passover God smites Egypt and brings Israel out by His mighty hand. (Jubilees 49:1-23)
+            // The Lord delivers His covenant people and ordains the Passover forever.
+            OracleHarness.DivineAct(OracleHarness.Witness("God delivers Israel from Egypt and ordains the Passover",
+                new Deliverance(), new CovenantFaithfulness(), new PromiseFulfilled(),
+                new JustRecompense(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodGivesTheSabbathLawOnSinaiThroughMoses_IsADivineAct()
+        {
+            // The Lord commands the keeping of the Sabbath as an everlasting law from the heavenly tablets. (Jubilees 50:1-13)
+            // The Sabbath rest is sealed as the holy sign of the covenant.
+            OracleHarness.DivineAct(OracleHarness.Witness("God gives the everlasting Sabbath law to Israel through Moses on Sinai",
+                new CovenantFaithfulness(), new CreationOrder(), new Worship(),
+                new Fidelity(), new TeachingTruth()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JubileesOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JubileesOracleTests.cs
@@ -1,0 +1,36 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 13: Jubilees (Ethiopic-unique). The heavenly tablets hold law, history, and judgment as
+    // one record, the source of the engine's HeavenlyTablets substrate.
+    public class JubileesOracleTests
+    {
+        [Fact]
+        public void TheDecreedOrderOfCreation_IsGood()
+        {
+            // Creation and its seasons are ordained and written on the heavenly tablets (Jubilees 2).
+            OracleHarness.DivineAct(OracleHarness.Witness("the decreed order of creation",
+                new CreationOrder(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void KeepingTheAppointedCovenant_IsRighteous()
+        {
+            // The feasts and the covenant are ordained on the tablets; keeping them is righteous (Jub 6).
+            OracleHarness.Righteous(OracleHarness.Witness("keeping the appointed covenant",
+                new Worship(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TransgressingTheDecreedOrder_IsSin()
+        {
+            // To transgress what is written and ordained is to rebel (Jubilees).
+            OracleHarness.Sin(OracleHarness.Witness("transgressing the decree", new Disobedience()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JudeNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JudeNarrativeTests.cs
@@ -1,0 +1,105 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Jude narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class JudeNarrativeTests
+    {
+        [Fact]
+        public void ContendingEarnestlyForTheFaithOnceDelivered_IsRighteous()
+        {
+            // "contend for the faith that was once for all delivered to the saints." (Jude 3)
+            OracleHarness.Righteous(OracleHarness.Witness("the beloved contend earnestly for the faith once for all delivered to the saints", new CourageousFaith(), new Fidelity(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void UngodlyIntrudersPervertingGraceAndDenyingChrist_IsSin()
+        {
+            // "ungodly people, who pervert the grace of our God into sensuality and deny our only Master and Lord." (Jude 4)
+            OracleHarness.Sin(OracleHarness.Witness("ungodly intruders creep in to pervert grace into sensuality and deny their only Master", new Debauchery(), new Lawlessness(), new Blasphemy()));
+        }
+
+        [Fact]
+        public void TheLordSavedHisPeopleOutOfTheLandOfEgypt_IsADivineAct()
+        {
+            // "the Lord, having saved a people out of the land of Egypt." (Jude 5)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Lord saves and brings His people out of the land of Egypt", new Deliverance(), new Fidelity(), new Goodness()));
+        }
+
+        [Fact]
+        public void UnbelievingIsraelDestroyedForRefusingToTrustTheLord_IsSin()
+        {
+            // "afterward destroyed those who did not believe." (Jude 5)
+            OracleHarness.Sin(OracleHarness.Witness("those saved out of Egypt afterward did not believe and rebelled against the Lord", new Disobedience(), new Rebellion(), new Ingratitude()));
+        }
+
+        [Fact]
+        public void TheAngelsWhoLeftTheirProperDwelling_IsSin()
+        {
+            // "the angels who did not stay within their own position of authority, but left their proper dwelling." (Jude 6)
+            OracleHarness.Sin(OracleHarness.Witness("the angels abandon their proper dwelling, rebelling in pride against their appointed position", new Rebellion(), new Pride(), new Disobedience()));
+        }
+
+        [Fact]
+        public void SodomAndGomorrahPursuingUnnaturalDesire_IsSin()
+        {
+            // "Sodom and Gomorrah ... indulged in sexual immorality and pursued unnatural desire." (Jude 7)
+            OracleHarness.Sin(OracleHarness.Witness("Sodom and Gomorrah indulge in sexual immorality and pursue unnatural desire, defiling themselves", new SexualImmorality(), new Impurity(), new Defilement()));
+            Assert.Equal(1.0, OracleHarness.Witness("Sodom and Gomorrah indulge in sexual immorality and pursue unnatural desire, defiling themselves", new SexualImmorality(), new Impurity(), new Defilement()).Disorder);
+        }
+
+        [Fact]
+        public void MichaelTheArchangelDidNotPronounceBlasphemingJudgment_IsRighteous()
+        {
+            // "Michael ... did not presume to pronounce a blasphemous judgment, but said, 'The Lord rebuke you.'" (Jude 9)
+            OracleHarness.Righteous(OracleHarness.Witness("Michael disputes with the devil yet refuses a reviling judgment, humbly leaving the rebuke to the Lord", new Humility(), new SelfControl(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TheWayOfCainBalaamAndKorah_IsSin()
+        {
+            // "they walked in the way of Cain and abandoned themselves for the sake of gain to Balaam's error and perished in Korah's rebellion." (Jude 11)
+            OracleHarness.Sin(OracleHarness.Witness("they walk in the way of Cain who murdered, run after Balaam's error for gain, and perish in Korah's rebellion", new Murder(), new Greed(), new Rebellion()));
+            Assert.Equal(1.0, OracleHarness.Witness("they walk in the way of Cain who murdered, run after Balaam's error for gain, and perish in Korah's rebellion", new Murder(), new Greed(), new Rebellion()).Disorder);
+        }
+
+        [Fact]
+        public void ShepherdsFeedingOnlyThemselvesWithoutFear_IsSin()
+        {
+            // "hidden reefs ... shepherds feeding themselves; waterless clouds ... fruitless trees." (Jude 12)
+            OracleHarness.Sin(OracleHarness.Witness("at the love feasts they shepherd only themselves without fear, giving nothing, caring for none", new SelfSeeking(), new Indifference(), new Heartlessness()));
+        }
+
+        [Fact]
+        public void GrumblersBoastingAndFlatteringForAdvantage_IsSin()
+        {
+            // "grumblers, malcontents ... loud-mouthed boasters, showing favoritism to gain advantage." (Jude 16)
+            OracleHarness.Sin(OracleHarness.Witness("they grumble and find fault, mouthing loud boasts and flattering people to gain advantage", new Ingratitude(), new Boasting(), new Greed()));
+        }
+
+        [Fact]
+        public void BuildingUpInFaithPrayingAndKeepingInTheLoveOfGod_IsRighteous()
+        {
+            // "building yourselves up in your most holy faith ... keep yourselves in the love of God." (Jude 20-21)
+            OracleHarness.Righteous(OracleHarness.Witness("the beloved build themselves up in the holy faith, pray in the Spirit, and keep themselves in the love of God", new Fidelity(), new Worship(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void HavingMercyOnDoubtersAndSnatchingThemFromTheFire_IsRighteous()
+        {
+            // "have mercy on those who doubt; save others by snatching them out of the fire." (Jude 22-23)
+            OracleHarness.Righteous(OracleHarness.Witness("the beloved have mercy on those who doubt and snatch others out of the fire to save them", new Compassion(), new Deliverance(), new Protection()));
+        }
+
+        [Fact]
+        public void GodIsAbleToKeepYouFromStumblingAndPresentYouBlameless_IsADivineAct()
+        {
+            // "to him who is able to keep you from stumbling and to present you blameless ... with great joy." (Jude 24-25)
+            OracleHarness.DivineAct(OracleHarness.Witness("God is able to keep them from stumbling and present them blameless before His glory with great joy", new Protection(), new Deliverance(), new Joy()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JudgesNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JudgesNarrativeTests.cs
@@ -1,0 +1,121 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Judges narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class JudgesNarrativeTests
+    {
+        [Fact]
+        public void IsraelAbandonsTheLordAndServesTheBaals_IsSin()
+        {
+            // "They forsook the LORD... and followed and worshiped various gods of the peoples around them." (Judges 2:11-13)
+            OracleHarness.Sin(OracleHarness.Grounded("Israel forsakes the LORD and bows down to the Baals and Ashtoreths", Grounding.InIdol("Baal"), new Idolatry(), new CovenantBreaking(), new Disobedience()));
+        }
+
+        [Fact]
+        public void GodRaisesUpJudgesToDeliverIsrael_IsADivineAct()
+        {
+            // "Then the LORD raised up judges, who saved them out of the hands of these raiders." (Judges 2:16-18)
+            OracleHarness.DivineAct(OracleHarness.Witness("God raises up judges to deliver Israel when they cry out to Him", new Deliverance(), new Compassion(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void OthnielDeliversIsraelFromCushanRishathaim_IsRighteous()
+        {
+            // "The Spirit of the LORD came on him, so that he became Israel's judge and went to war." (Judges 3:9-11)
+            OracleHarness.Righteous(OracleHarness.Witness("Othniel is raised as the first judge and delivers Israel from Cushan-Rishathaim", new Deliverance(), new CourageousFaith(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void DeborahJudgesIsraelAndSummonsBarakAtGodsWord_IsRighteous()
+        {
+            // "Deborah... was leading Israel at that time... 'The LORD, the God of Israel, commands you.'" (Judges 4:4-7)
+            OracleHarness.Righteous(OracleHarness.Witness("Deborah judges Israel and delivers God's word to Barak to muster the deliverance", new TeachingTruth(), new CourageousFaith(), new ObedienceToGod(), new Righteousness()));
+        }
+
+        [Fact]
+        public void GodRoutsSiseraAndDeliversIsrael_IsADivineAct()
+        {
+            // "At Barak's advance, the LORD routed Sisera and all his army." (Judges 4:14-15)
+            OracleHarness.DivineAct(OracleHarness.Witness("God routs Sisera's army before Barak and delivers Israel", new Deliverance(), new JustRecompense(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void DeborahAndBarakSingPraiseToTheLordForVictory_IsRighteous()
+        {
+            // "On that day Deborah and Barak son of Abinoam sang this song: 'When the princes... willingly offer themselves, praise the LORD!'" (Judges 5:1-3)
+            OracleHarness.Righteous(OracleHarness.Witness("Deborah and Barak sing praise to the LORD for the victory He gave", new Worship(), new Joy(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void GideonTearsDownTheAltarOfBaal_IsRighteous()
+        {
+            // "Tear down your father's altar to Baal and cut down the Asherah pole beside it." (Judges 6:25-27)
+            OracleHarness.Righteous(OracleHarness.Witness("Gideon tears down his father's altar to Baal and the Asherah pole in obedience to God", new ObedienceToGod(), new CourageousFaith(), new Worship()));
+        }
+
+        [Fact]
+        public void GodSavesIsraelByGideonsThreeHundred_IsADivineAct()
+        {
+            // "With the three hundred men... I will save you and give the Midianites into your hands." (Judges 7:7, 22)
+            OracleHarness.DivineAct(OracleHarness.Witness("God delivers Midian into Israel's hand through Gideon's three hundred so the glory is His alone", new Deliverance(), new PromiseFulfilled(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void GideonMakesAnEphodThatBecomesASnare_IsSin()
+        {
+            // "All Israel prostituted themselves by worshiping it there, and it became a snare to Gideon and his family." (Judges 8:27)
+            OracleHarness.Sin(OracleHarness.Grounded("Gideon makes a golden ephod that Israel worships, ensnaring his house", Grounding.InIdol("Ephod"), new Idolatry(), new GravenImage()));
+        }
+
+        [Fact]
+        public void AbimelechMurdersHisSeventyBrothers_IsSin()
+        {
+            // "He murdered his seventy brothers... on one stone." (Judges 9:5)
+            Resolution r = OracleHarness.Witness("Abimelech murders his seventy brothers on one stone to seize power", new Murder(), new Bloodshed(), new SelfishAmbition(), new Treachery());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void JephthahMakesAndKeepsARashVowSacrificingHisDaughter_IsSin()
+        {
+            // "He did to her as he had vowed." (Judges 11:30-39) - a rash vow ending in the death of his only child.
+            Resolution r = OracleHarness.Witness("Jephthah carries out his rash vow and offers up his only daughter", new ChildSacrifice(), new Bloodshed());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void SamsonBreaksHisNaziriteVowsInLustAndRevelry_IsSin()
+        {
+            // Samson chases Philistine women, touches the unclean, and is undone at Delilah's feet. (Judges 14-16)
+            OracleHarness.Sin(OracleHarness.Witness("Samson follows his lusts after foreign women and breaks his Nazirite consecration", new Lust(), new SexualImmorality(), new Disobedience()));
+        }
+
+        [Fact]
+        public void SamsonCriesToGodAndIsAnsweredInHisFinalAct_IsRighteous()
+        {
+            // "Sovereign LORD, remember me. Please, God, strengthen me just once more." (Judges 16:28-30)
+            OracleHarness.Righteous(OracleHarness.Witness("Samson repents and cries to God for strength one last time, dying to deliver Israel from the Philistines", new Repentance(), new Deliverance(), new SelfSacrifice(), new Trust()));
+        }
+
+        [Fact]
+        public void TheTribesAvengeTheOutrageAtGibeah_IsRighteous()
+        {
+            // The Levite's concubine is abused to death and Israel rises to purge the evil from among them. (Judges 19-20)
+            OracleHarness.Righteous(OracleHarness.Witness("the tribes of Israel rise to bring just recompense for the outrage at Gibeah", new JustRecompense(), new Righteousness()));
+        }
+
+        [Fact]
+        public void EveryoneDidWhatWasRightInHisOwnEyes_IsSin()
+        {
+            // "In those days Israel had no king; everyone did as they saw fit." (Judges 21:25)
+            OracleHarness.Sin(OracleHarness.Witness("with no king in Israel, everyone does what is right in his own eyes", new Lawlessness(), new Chaos(), new Rebellion()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JudgesOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JudgesOracleTests.cs
@@ -1,0 +1,26 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 07: Judges.
+    public class JudgesOracleTests
+    {
+        [Fact]
+        public void IsraelDoesEvilAndServesIdols_IsSin()
+        {
+            // "The Israelites did evil ... and served the Baals." (Judges 2:11) Rebellion brings disorder.
+            OracleHarness.Sin(OracleHarness.Witness("Israel serves the Baals", new Idolatry(), new Rebellion()));
+        }
+
+        [Fact]
+        public void GodRaisesADelivererInMercy_IsADivineAct()
+        {
+            // When they cried out, the LORD raised up deliverers (Judges 2:16, 18).
+            OracleHarness.DivineAct(OracleHarness.Witness("God raises a deliverer", new Deliverance(), new Compassion()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/JudithNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/JudithNarrativeTests.cs
@@ -1,0 +1,131 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Judith narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class JudithNarrativeTests
+    {
+        [Fact]
+        public void HolofernesRavagesTheNationsAndDemandsNebuchadnezzarBeWorshipped_IsSin()
+        {
+            // Holofernes marches out to "destroy all the gods of the land," that every nation
+            // might call upon Nebuchadnezzar alone as god. (Judith 2:1-13; 3:8; 6:2)
+            // Idolatrous, blasphemous conquest soaked in bloodshed and oppression.
+            OracleHarness.Sin(OracleHarness.Witness("Holofernes ravages the nations and demands Nebuchadnezzar be worshipped as god",
+                new Idolatry(), new Blasphemy(), new Bloodshed(), new Oppression(), new Pride()));
+        }
+
+        [Fact]
+        public void IsraelHumblesItselfInFastingAndSackclothBeforeTheLord_IsRighteous()
+        {
+            // "Every man of Israel cried out to God with great fervor ... they put on sackcloth ...
+            // and the Lord heard their prayers." (Judith 4:9-13)
+            // A humbled, mourning, repentant people seeking the Lord.
+            OracleHarness.Righteous(OracleHarness.Witness("Israel cries out to God in fasting, sackcloth, and humility",
+                new Humility(), new Mourning(), new Repentance(), new Trust(), new Worship()));
+        }
+
+        [Fact]
+        public void AchiorTestifiesTheTruthThatGodGuardsTheRighteous_IsRighteous()
+        {
+            // Achior the Ammonite tells Holofernes the truth: Israel cannot be conquered unless they
+            // sin against their God, for their God protects them. (Judith 5:5-21)
+            // Honest testimony to the truth at great personal risk.
+            OracleHarness.Righteous(OracleHarness.Witness("Achior testifies the truth about the God of Israel",
+                new TeachingTruth(), new RejoicingInTruth(), new CourageousFaith(), new Trustworthiness()));
+        }
+
+        [Fact]
+        public void HolofernesScornsGodAndCastsOutAchior_IsSin()
+        {
+            // Holofernes rages: "Who is God except Nebuchadnezzar?" and hands Achior over to be slain. (Judith 6:1-9)
+            // Blasphemous pride, oppression of the truth-teller, and threatened bloodshed.
+            OracleHarness.Sin(OracleHarness.Witness("Holofernes scorns the God of Israel and casts out Achior to die",
+                new Blasphemy(), new Pride(), new Oppression(), new Boasting()));
+        }
+
+        [Fact]
+        public void JudithRebukesTheEldersForPuttingGodToTheTest_IsRighteous()
+        {
+            // "Who are you to put God to the test ... You cannot plumb the depths of the human heart." (Judith 8:11-27)
+            // Judith corrects Uzziah's ultimatum, calling Israel to trust and endure under God.
+            OracleHarness.Righteous(OracleHarness.Witness("Judith rebukes the elders' five-day ultimatum and calls them to trust God",
+                new TeachingTruth(), new Trust(), new Endurance(), new Humility(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void JudithPraysForStrengthAndDeliverance_IsRighteous()
+        {
+            // Judith falls down in sackcloth and ashes and prays for the Lord to crush the proud
+            // by the hand of a widow. (Judith 9:1-14)
+            // Humble, worshipful petition resting wholly on God's covenant power.
+            OracleHarness.Righteous(OracleHarness.Grounded("Judith prays in sackcloth for God to deliver His people",
+                Grounding.InGod(),
+                new Worship(), new Humility(), new Trust(), new Repentance(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void JudithGoesIntoTheEnemyCampTrustingGod_IsRighteous()
+        {
+            // Judith and her maid go out through the gates toward the Assyrian camp, the elders
+            // praying, "May the Lord ... grant you success." (Judith 10:6-10)
+            // Self-offering courage, going alone into mortal danger to defend her people.
+            OracleHarness.Righteous(OracleHarness.Witness("Judith ventures into the camp of Holofernes to save Israel",
+                new CourageousFaith(), new SelfSacrifice(), new Trust(), new DefendingTheWeak()));
+        }
+
+        [Fact]
+        public void HolofernesLustsAndDrinksHimselfSenselessAtTheBanquet_IsSin()
+        {
+            // Holofernes burns to seduce Judith and "drank a great quantity of wine, much more than
+            // he had ever drunk in any one day." (Judith 12:16-20)
+            // Lust, drunkenness, and self-seeking debauchery.
+            OracleHarness.Sin(OracleHarness.Witness("Holofernes lusts after Judith and drinks himself into a stupor",
+                new Lust(), new Drunkenness(), new SexualImmorality(), new SelfSeeking()));
+        }
+
+        [Fact]
+        public void GodDeliversIsraelByJudithsHandAgainstTheOppressor_IsADivineAct()
+        {
+            // "The Lord has struck him down by the hand of a woman." (Judith 13:14-15; 13:18)
+            // The proud oppressor is brought low and Israel is delivered. Scripture's verdict is
+            // God's saving deliverance of the weak, worked through His handmaid.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God delivers Israel from Holofernes by Judith's hand",
+                Grounding.InGod(),
+                new Deliverance(), new DefendingTheWeak(), new Protection(),
+                new HonoringTheVulnerable(), new JustRecompense(), new Fidelity()));
+        }
+
+        [Fact]
+        public void UzziahAndThePeopleBlessGodAndPraiseJudith_IsRighteous()
+        {
+            // "Blessed are you, daughter, by the Most High God above all women on earth." (Judith 13:18-20; 15:9-10)
+            // Israel rejoices in the truth of God's salvation and honors His faithful servant.
+            OracleHarness.Righteous(OracleHarness.Witness("Uzziah and the people bless God and praise Judith for the deliverance",
+                new Worship(), new RejoicingInTruth(), new Joy(), new Goodness()));
+        }
+
+        [Fact]
+        public void AchiorBelievesInGodAndJoinsTheHouseOfIsrael_IsRighteous()
+        {
+            // Seeing all the Lord had done, "Achior believed firmly in God, and was circumcised,
+            // and joined the house of Israel." (Judith 14:5-10)
+            // A Gentile turns in faith and worship to the true God.
+            OracleHarness.Righteous(OracleHarness.Witness("Achior believes in God and is joined to Israel",
+                new CourageousFaith(), new Trust(), new Worship(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void JudithSingsHerHymnOfThanksgivingToGodTheDeliverer_IsRighteous()
+        {
+            // "Begin a song to my God ... the Lord is a God who crushes wars." (Judith 16:1-17)
+            // A hymn of worship, joy, and grateful praise to the God who saves the lowly.
+            OracleHarness.Righteous(OracleHarness.Witness("Judith leads Israel in a hymn of thanksgiving to God",
+                new Worship(), new Joy(), new RejoicingInTruth(), new Humility(), new PromiseFulfilled()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/KingsNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/KingsNarrativeTests.cs
@@ -1,0 +1,121 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 1 & 2 Kings narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class KingsNarrativeTests
+    {
+        [Fact]
+        public void SolomonAsksForAnUnderstandingHeart_IsRighteous()
+        {
+            // "Give your servant a discerning heart to govern your people." (1 Kings 3:9)
+            OracleHarness.Righteous(OracleHarness.Witness("Solomon asks God not for riches or long life but for a discerning heart to judge God's people", new Humility(), new HungerForRighteousness(), new Trust()));
+        }
+
+        [Fact]
+        public void GodGrantsSolomonWisdom_IsADivineAct()
+        {
+            // "God gave Solomon wisdom and very great insight." (1 Kings 3:12; 4:29)
+            OracleHarness.DivineAct(OracleHarness.Witness("God grants Solomon wisdom, discernment, and a breadth of understanding beyond all who came before", new Generosity(), new Goodness(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void SolomonBuildsTheTempleForTheLord_IsRighteous()
+        {
+            // "So Solomon built the temple and completed it." (1 Kings 6:14, 38)
+            OracleHarness.Righteous(OracleHarness.Witness("Solomon builds the temple as a house for the Name of the LORD according to all God commanded", new Worship(), new ObedienceToGod(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TheGloryOfTheLordFillsTheTemple_IsADivineAct()
+        {
+            // "The glory of the LORD filled his temple." (1 Kings 8:10-11)
+            OracleHarness.DivineAct(OracleHarness.Witness("the cloud of the glory of the LORD fills the temple at its dedication", new CovenantFaithfulness(), new PromiseFulfilled(), new Goodness()));
+        }
+
+        [Fact]
+        public void SolomonTurnsToForeignGodsInOldAge_IsSin()
+        {
+            // "His wives turned his heart after other gods... He followed Ashtoreth and Molek." (1 Kings 11:4-8)
+            OracleHarness.Sin(OracleHarness.Grounded("Solomon in his old age turns his heart to the gods of his foreign wives and builds high places for them", Grounding.InIdol("Molek"), new Idolatry(), new CovenantBreaking(), new Disobedience()));
+        }
+
+        [Fact]
+        public void JeroboamSetsUpGoldenCalves_IsSin()
+        {
+            // "Here are your gods, Israel, who brought you up out of Egypt." (1 Kings 12:28-30)
+            OracleHarness.Sin(OracleHarness.Grounded("Jeroboam makes two golden calves at Bethel and Dan and leads Israel into idolatry", Grounding.InIdol("GoldenCalf"), new Idolatry(), new GravenImage(), new Rebellion()));
+        }
+
+        [Fact]
+        public void GodFeedsElijahByRavensAtTheBrook_IsADivineAct()
+        {
+            // "I have directed the ravens to supply you with food there." (1 Kings 17:4-6)
+            OracleHarness.DivineAct(OracleHarness.Witness("God sustains Elijah at the Kerith Ravine, sending ravens with bread and meat and giving water from the brook", new Protection(), new FeedingTheHungry(), new GivingDrink(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void ElijahRaisesTheWidowsSon_IsADivineAct()
+        {
+            // "The LORD heard Elijah's cry, and the boy's life returned to him." (1 Kings 17:21-22)
+            OracleHarness.DivineAct(OracleHarness.Witness("God answers Elijah and restores the life of the widow of Zarephath's son", new RestoringLife(), new Compassion(), new HonoringTheVulnerable(), new Healing()));
+        }
+
+        [Fact]
+        public void TheLordAnswersByFireOnMountCarmel_IsADivineAct()
+        {
+            // "The fire of the LORD fell and burned up the sacrifice... 'The LORD, he is God!'" (1 Kings 18:38-39)
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD answers Elijah by fire on Mount Carmel, consuming the sacrifice so Israel knows He alone is God", new Deliverance(), new TeachingTruth(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void AhabAndJezebelSeizeNabothsVineyardByMurder_IsSin()
+        {
+            // Jezebel has Naboth falsely accused and stoned so Ahab can seize his vineyard. (1 Kings 21:1-16)
+            Resolution r = OracleHarness.Witness("Jezebel arranges false witnesses to condemn and stone Naboth so Ahab can seize his ancestral vineyard", new Murder(), new Bloodshed(), new FalseWitness(), new Covetousness(), new Theft());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void ElijahIsTakenUpToHeavenInAWhirlwind_IsADivineAct()
+        {
+            // "Elijah went up to heaven in a whirlwind." (2 Kings 2:11)
+            OracleHarness.DivineAct(OracleHarness.Witness("God takes Elijah up to heaven in a whirlwind with chariots of fire", new Deliverance(), new Fidelity(), new Goodness()));
+        }
+
+        [Fact]
+        public void ElishaHealsNaamanOfLeprosy_IsADivineAct()
+        {
+            // "His flesh was restored and became clean like that of a young boy." (2 Kings 5:14)
+            OracleHarness.DivineAct(OracleHarness.Witness("God cleanses Naaman the Aramean of his leprosy when he washes in the Jordan at Elisha's word", new Healing(), new Compassion(), new Goodness()));
+        }
+
+        [Fact]
+        public void GehaziLiesAndTakesNaamansGiftInGreed_IsSin()
+        {
+            // Gehazi runs after Naaman, lies to get silver and garments, and is struck with leprosy. (2 Kings 5:20-27)
+            OracleHarness.Sin(OracleHarness.Witness("Gehazi greedily chases Naaman, lies to obtain silver and clothing, and deceives Elisha", new Greed(), new Deceit(), new Covetousness()));
+        }
+
+        [Fact]
+        public void JosiahRepairsTheTempleAndRenewsTheCovenant_IsRighteous()
+        {
+            // Josiah hears the Book of the Law, tears his robes, and leads Judah back to the covenant. (2 Kings 22-23)
+            OracleHarness.Righteous(OracleHarness.Witness("Josiah finds the Book of the Law, repents in humility, purges the idols, and renews the covenant before the LORD", new Repentance(), new Humility(), new ObedienceToGod(), new CovenantFaithfulness(), new Worship()));
+        }
+
+        [Fact]
+        public void ManassehSacrificesHisSonAndFillsJerusalemWithBlood_IsSin()
+        {
+            // "He sacrificed his own son in the fire... and shed so much innocent blood." (2 Kings 21:6, 16)
+            Resolution r = OracleHarness.Witness("Manasseh sacrifices his own son in the fire, practices sorcery, and fills Jerusalem with innocent blood", new ChildSacrifice(), new Bloodshed(), new Idolatry(), new Sorcery());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/KingsOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/KingsOracleTests.cs
@@ -1,0 +1,43 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 10: 1 & 2 Kings.
+    public class KingsOracleTests
+    {
+        [Fact]
+        public void SolomonAsksForWisdom_IsRighteous()
+        {
+            // He asks for a discerning heart to govern justly, not for riches (1 Kings 3:9).
+            OracleHarness.Righteous(OracleHarness.Witness("Solomon asks for wisdom", new Humility(), new Trust()));
+        }
+
+        [Fact]
+        public void SolomonsIdolatryInOldAge_IsSin()
+        {
+            // His foreign wives turn his heart after other gods (1 Kings 11:4).
+            OracleHarness.Sin(OracleHarness.Witness("Solomon turns to idols", new Idolatry()));
+        }
+
+        [Fact]
+        public void ElijahCallsIsraelBackToTrueWorship_IsRighteous()
+        {
+            // "If the LORD is God, follow him." (1 Kings 18:21) on Mount Carmel.
+            OracleHarness.Righteous(OracleHarness.Witness("Elijah on Carmel", new Worship(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void AhabAndJezebelMurderNabothForHisVineyard_IsGraveSin()
+        {
+            // Coveting the vineyard, they have Naboth killed (1 Kings 21).
+            Resolution r = OracleHarness.Witness("Naboth murdered for his vineyard", new Murder(), new Greed());
+
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/LeviticusNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/LeviticusNarrativeTests.cs
@@ -1,0 +1,127 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Leviticus narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class LeviticusNarrativeTests
+    {
+        [Fact]
+        public void TheBurntOffering_ForAtonement_IsRighteous()
+        {
+            // The sacrifice is offered "to make atonement for him." (Leviticus 1:3-4)
+            OracleHarness.Righteous(OracleHarness.Witness("the burnt offering for atonement",
+                new Atonement(), new Worship(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TheSinOfferingForUnintentionalSin_IsRighteous()
+        {
+            // The priest "shall make atonement for them, and they will be forgiven." (Leviticus 4:20)
+            OracleHarness.Righteous(OracleHarness.Witness("the sin offering brings forgiveness",
+                new Atonement(), new Repentance(), new Pardon()));
+        }
+
+        [Fact]
+        public void AaronAndSonsObeyTheOrdinationCommand_IsRighteous()
+        {
+            // "Aaron and his sons did all the things the LORD commanded through Moses." (Leviticus 8:36)
+            OracleHarness.Righteous(OracleHarness.Witness("Aaron and his sons obey the ordination",
+                new ObedienceToGod(), new Worship(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheLordsGloryConsumesTheOffering_IsADivineAct()
+        {
+            // "Fire came out from the presence of the LORD and consumed the burnt offering." (Leviticus 9:23-24)
+            OracleHarness.DivineAct(OracleHarness.Witness("the glory of the LORD accepts the offering",
+                new CovenantFaithfulness(), new Righteousness(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void NadabAndAbihuOfferStrangeFire_IsSin()
+        {
+            // They offered "unauthorized fire ... contrary to his command." (Leviticus 10:1-2)
+            OracleHarness.Sin(OracleHarness.Witness("Nadab and Abihu offer unauthorized fire",
+                new Disobedience(), new Rebellion()));
+        }
+
+        [Fact]
+        public void TheDayOfAtonementScapegoat_IsRighteous()
+        {
+            // The goat "carry on itself all their sins ... atonement is made for you." (Leviticus 16:21-30)
+            OracleHarness.Righteous(OracleHarness.Witness("the Day of Atonement, the scapegoat bears Israel's sin",
+                new Atonement(), new Pardon(), new Deliverance(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void OfferingChildrenToMolech_IsSin()
+        {
+            // "Do not give any of your children to be sacrificed to Molek." (Leviticus 18:21; 20:2)
+            Resolution r = OracleHarness.Witness("giving children to Molek",
+                new ChildSacrifice(), new Idolatry(), new Bloodshed());
+
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void LeavingGleaningsForThePoor_IsRighteous()
+        {
+            // "Leave them for the poor and the foreigner." (Leviticus 19:9-10)
+            OracleHarness.Righteous(OracleHarness.Witness("leaving the gleanings for the poor and the foreigner",
+                new Generosity(), new FeedingTheHungry(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void LoveYourNeighborAsYourself_IsRighteous()
+        {
+            // "Love your neighbor as yourself. I am the LORD." (Leviticus 19:18)
+            OracleHarness.Righteous(OracleHarness.Witness("love your neighbor as yourself",
+                new Kindness(), new Compassion(), new Forgiveness()));
+        }
+
+        [Fact]
+        public void HoldingAGrudgeAndSeekingRevenge_IsSin()
+        {
+            // "Do not seek revenge or bear a grudge." (Leviticus 19:18a)
+            OracleHarness.Sin(OracleHarness.Witness("seeking revenge and bearing a grudge",
+                new Grudge(), new Unforgiveness()));
+        }
+
+        [Fact]
+        public void DishonestWeightsAndMeasures_IsSin()
+        {
+            // "Do not use dishonest standards ... use honest scales and honest weights." (Leviticus 19:35-36)
+            OracleHarness.Sin(OracleHarness.Witness("using dishonest scales and weights",
+                new Deceit(), new Wrongdoing(), new WithholdingWhatIsDue()));
+        }
+
+        [Fact]
+        public void RisingBeforeTheElderly_HonorsTheVulnerable_IsRighteous()
+        {
+            // "Stand up in the presence of the aged, show respect for the elderly." (Leviticus 19:32)
+            OracleHarness.Righteous(OracleHarness.Witness("standing in honor of the aged",
+                new HonoringTheVulnerable(), new Kindness()));
+        }
+
+        [Fact]
+        public void BlasphemingTheNameOfTheLord_IsSin()
+        {
+            // The son of an Israelite woman "blasphemed the Name with a curse." (Leviticus 24:11-16)
+            OracleHarness.Sin(OracleHarness.Witness("blaspheming the Name of the LORD",
+                new Blasphemy(), new MisusingGodsName()));
+        }
+
+        [Fact]
+        public void TheYearOfJubileeReleasesTheCaptive_IsRighteous()
+        {
+            // "Proclaim liberty throughout the land ... each of you is to return to your property." (Leviticus 25:10)
+            OracleHarness.Righteous(OracleHarness.Witness("the Jubilee proclaims liberty and restores the poor",
+                new Deliverance(), new JustRecompense(), new Generosity(), new HonoringTheVulnerable()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/LeviticusOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/LeviticusOracleTests.cs
@@ -1,0 +1,47 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 03: Leviticus.
+    public class LeviticusOracleTests
+    {
+        [Fact]
+        public void TheAtoningSacrifice_OfferedRightly_IsRighteous()
+        {
+            // The sin offering points to atonement; offered in faith it is right worship (Leviticus 16-17).
+            OracleHarness.Righteous(OracleHarness.Witness("the sin offering", new Atonement(), new Worship()));
+        }
+
+        [Fact]
+        public void ChildSacrifice_IsGraveSin()
+        {
+            // "Do not give any of your children to be sacrificed to Molek." (Leviticus 18:21)
+            OracleHarness.Sin(OracleHarness.Witness("child sacrifice to Molek", new ChildSacrifice(), new Bloodshed()));
+        }
+
+        [Fact]
+        public void TheLawProtectsTheVulnerable_IsRighteous()
+        {
+            // The law that forbids it shields the child (Leviticus 18-20).
+            OracleHarness.Righteous(OracleHarness.Witness("the child protected", new HonoringTheVulnerable(), new Protection()));
+        }
+
+        [Fact]
+        public void JusticeAndProvisionForThePoor_IsRighteous()
+        {
+            // Gleaning left for the poor and the foreigner; no partiality (Leviticus 19:9-15).
+            OracleHarness.Righteous(OracleHarness.Witness("gleaning for the poor", new Generosity(), new JustRecompense()));
+        }
+
+        [Fact]
+        public void LoveYourNeighbor_IsRighteous()
+        {
+            // "Love your neighbor as yourself." (Leviticus 19:18)
+            OracleHarness.Righteous(OracleHarness.Witness("loving the neighbor", new Compassion()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/LukeNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/LukeNarrativeTests.cs
@@ -1,0 +1,150 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Luke narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class LukeNarrativeTests
+    {
+        [Fact]
+        public void GabrielAnnouncesJohnsBirthToZechariah_IsADivineAct()
+        {
+            // "Your prayer has been heard, and your wife Elizabeth will bear you a son." (Luke 1:13-17)
+            // God answers the barren couple and prepares a forerunner for the Lord.
+            OracleHarness.DivineAct(OracleHarness.Witness("Gabriel announces the birth of John to Zechariah",
+                new PromiseFulfilled(), new RestoringLife(), new Fidelity(), new Goodness()));
+        }
+
+        [Fact]
+        public void MaryConsentsToTheAnnunciation_IsRighteous()
+        {
+            // "Behold, I am the servant of the Lord; let it be to me according to your word." (Luke 1:38)
+            // Mary's humble, trusting, obedient submission to God's call.
+            OracleHarness.Righteous(OracleHarness.Witness("Mary submits to the angel's word at the Annunciation",
+                new Humility(), new ObedienceToGod(), new Trust(), new CourageousFaith(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheIncarnationOfChrist_IsADivineAct()
+        {
+            // "The Holy Spirit will come upon you ... the child to be born will be called holy." (Luke 1:35; 2:7)
+            // God takes flesh to dwell with and save His people.
+            OracleHarness.DivineAct(OracleHarness.Witness("The Son of God is conceived and born of Mary",
+                new SelfSacrifice(), new CovenantFaithfulness(), new PromiseFulfilled(),
+                new Deliverance(), new Goodness(), new Purity()));
+        }
+
+        [Fact]
+        public void MaryMagnifiesTheLordInTheMagnificat_IsRighteous()
+        {
+            // "My soul magnifies the Lord ... he has regarded the low estate of his servant." (Luke 1:46-55)
+            // Mary worships God who lifts the lowly and fills the hungry.
+            OracleHarness.Righteous(OracleHarness.Witness("Mary sings the Magnificat in praise of God",
+                new Worship(), new Joy(), new Humility(), new RejoicingInTruth(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GoodSamaritanCaresForTheWoundedTraveler_IsRighteous()
+        {
+            // "He had compassion ... bound up his wounds ... took care of him." (Luke 10:33-35)
+            // The neighbor who shows mercy across enmity, at his own cost.
+            OracleHarness.Righteous(OracleHarness.Witness("The Good Samaritan binds the wounds of the beaten man",
+                new Compassion(), new Kindness(), new CaringForTheSick(),
+                new Generosity(), new SelfSacrifice(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void PriestAndLevitePassByTheBeatenMan_IsSin()
+        {
+            // "A priest ... saw him ... passed by on the other side. So likewise a Levite." (Luke 10:31-32)
+            // Religious men withhold mercy from a dying neighbor.
+            OracleHarness.Sin(OracleHarness.Witness("The priest and Levite pass by the dying man",
+                new Indifference(), new Heartlessness(), new WithholdingWhatIsDue()));
+        }
+
+        [Fact]
+        public void FatherRunsToWelcomeHomeTheProdigalSon_IsRighteous()
+        {
+            // "While he was still a long way off, his father ... ran and embraced him." (Luke 15:20-24)
+            // The father pardons the wayward son and rejoices over his return.
+            OracleHarness.Righteous(OracleHarness.Witness("The father welcomes home the prodigal son",
+                new Forgiveness(), new Compassion(), new Pardon(), new Joy(), new Generosity()));
+        }
+
+        [Fact]
+        public void ProdigalSonSquandersAndRepents_IsRighteous()
+        {
+            // "I will arise and go to my father, and I will say ... I have sinned." (Luke 15:18-21)
+            // Coming to himself, the son turns back in humble repentance.
+            OracleHarness.Righteous(OracleHarness.Witness("The prodigal son returns in repentance",
+                new Repentance(), new Humility(), new PovertyOfSpirit()));
+        }
+
+        [Fact]
+        public void ZacchaeusRepentsAndRestoresFourfold_IsRighteous()
+        {
+            // "Half of my goods I give to the poor ... I restore it fourfold." (Luke 19:8-9)
+            // The chief tax collector repents, gives generously, and makes just restitution.
+            OracleHarness.Righteous(OracleHarness.Witness("Zacchaeus repents and restores what he took",
+                new Repentance(), new Generosity(), new JustRecompense(), new Righteousness()));
+        }
+
+        [Fact]
+        public void ChristHealsTenLepersAndOneReturnsGivingThanks_IsADivineAct()
+        {
+            // "As they went they were cleansed ... one of them ... turned back, praising God." (Luke 17:12-19)
+            // Christ cleanses the ten lepers by His healing word.
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ heals the ten lepers",
+                new Healing(), new Compassion(), new HonoringTheVulnerable(), new Goodness()));
+        }
+
+        [Fact]
+        public void ChristForgivesFromTheCross_IsADivineAct()
+        {
+            // "Father, forgive them, for they know not what they do." (Luke 23:34)
+            // The crucified Christ pardons His executioners and offers Himself for sinners.
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ forgives His crucifiers from the cross",
+                new Forgiveness(), new Pardon(), new SelfSacrifice(), new Atonement(), new Compassion()));
+        }
+
+        [Fact]
+        public void ChristPromisesParadiseToThePenitentThief_IsADivineAct()
+        {
+            // "Truly, I say to you, today you will be with me in Paradise." (Luke 23:43)
+            // Christ pardons the dying thief who confesses Him.
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ promises Paradise to the penitent thief",
+                new Pardon(), new Forgiveness(), new Deliverance(), new PromiseFulfilled(), new Compassion()));
+        }
+
+        [Fact]
+        public void JudasBetraysJesusForMoney_IsSin()
+        {
+            // "Then Satan entered into Judas ... he ... conferred ... how he might betray him." (Luke 22:3-6)
+            // Judas sells the innocent Christ to His enemies for silver.
+            OracleHarness.Sin(OracleHarness.Witness("Judas agrees to betray Jesus for money",
+                new Treachery(), new Greed(), new Deceit(), new CovenantBreaking()));
+        }
+
+        [Fact]
+        public void PeterDeniesChristThreeTimes_IsSin()
+        {
+            // "Man, I do not know what you are talking about ... and the cock crowed." (Luke 22:57-61)
+            // Peter denies his Lord out of fear, then weeps bitterly.
+            OracleHarness.Sin(OracleHarness.Witness("Peter denies Jesus three times in the courtyard",
+                new Deceit(), new FalseWitness(), new CovenantBreaking()));
+        }
+
+        [Fact]
+        public void TheResurrectionOfChrist_IsADivineAct()
+        {
+            // "He is not here, but has risen." (Luke 24:5-6)
+            // God raises the crucified Christ, conquering death for His people.
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ is raised from the dead",
+                new RestoringLife(), new Deliverance(), new PromiseFulfilled(),
+                new CovenantFaithfulness(), new Goodness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/MaccabeesMeqabyanOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/MaccabeesMeqabyanOracleTests.cs
@@ -1,0 +1,50 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 20 & 21: 1 Maccabees, and the Ethiopic Meqabyan (2 & 3 Maccabees of the Ethiopian canon).
+    public class MaccabeesMeqabyanOracleTests
+    {
+        [Fact]
+        public void RefusingForcedIdolatry_IsRighteous()
+        {
+            // The faithful will not abandon the covenant under the tyrant's decree (1 Maccabees 1-2).
+            OracleHarness.Righteous(OracleHarness.Witness("refusing the idol under persecution",
+                new CourageousFaith(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TheTyrantsForcedIdolatryAndSlaughter_IsGraveSin()
+        {
+            // Forcing idolatry and killing those who refuse (1 Maccabees 1).
+            Resolution r = OracleHarness.Witness("the tyrant forces idolatry", new Murder(), new Oppression());
+
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void MartyrdomRatherThanIdolatry_IsRighteous()
+        {
+            // The Meqabyan martyrs choose death over the dead idols, trusting the God who raises
+            // (resurrection hope).
+            OracleHarness.Righteous(OracleHarness.Witness("martyrdom rather than idolatry",
+                new CourageousFaith(), new Trust()));
+        }
+
+        [Fact]
+        public void TheIdolsCannotGiveLife_WorshipOfThemDriftsToNonBeing()
+        {
+            // "They do not truly live, they cannot give life." (1 Meqabyan 1)
+            Resolution onGod = OracleHarness.Grounded("worship", Grounding.InGod(), new Worship());
+            Resolution onIdol = OracleHarness.Grounded("worship", Grounding.InIdol("the idol"), new Worship());
+
+            Assert.True(onIdol.Coherence < onGod.Coherence);
+            Assert.True(onIdol.Disorder > 0.0);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/MajorProphetsOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/MajorProphetsOracleTests.cs
@@ -1,0 +1,67 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 29-32: Isaiah, Jeremiah, Ezekiel, Daniel.
+    public class MajorProphetsOracleTests
+    {
+        [Fact]
+        public void TheSufferingServantBearsOurSins_IsADivineAct()
+        {
+            // "He was pierced for our transgressions ... the LORD has laid on him the iniquity of us
+            // all." (Isaiah 53:5-6) Atonement and self-giving love.
+            OracleHarness.DivineAct(OracleHarness.Witness("the suffering Servant", new Atonement(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void IsaiahsCallToSeekJustice_IsRighteous()
+        {
+            // "Seek justice. Defend the oppressed. Take up the cause of the fatherless." (Isaiah 1:17)
+            OracleHarness.Righteous(OracleHarness.Witness("seek justice, defend the oppressed",
+                new JustRecompense(), new DefendingTheWeak()));
+        }
+
+        [Fact]
+        public void JeremiahsNewCovenant_IsADivineAct()
+        {
+            // "I will make a new covenant ... I will forgive their wickedness." (Jeremiah 31:31-34)
+            OracleHarness.DivineAct(OracleHarness.Witness("the new covenant", new CovenantFaithfulness(), new Pardon()));
+        }
+
+        [Fact]
+        public void ChildSacrificeInTheValley_NeverEnteredGodsMind_IsGraveSin()
+        {
+            // "Something I did not command, nor did it enter my mind." (Jeremiah 32:35)
+            Resolution r = OracleHarness.Witness("child sacrifice in the valley", new ChildSacrifice(), new Bloodshed());
+
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void EzekielTakesNoPleasureInTheDeathOfTheWicked_IsADivineAct()
+        {
+            // "I take no pleasure in the death of anyone ... Repent and live!" (Ezekiel 18:32)
+            OracleHarness.DivineAct(OracleHarness.Witness("God calls the wicked to live", new Compassion(), new JustRecompense()));
+        }
+
+        [Fact]
+        public void TheValleyOfDryBonesRestoredToLife_IsADivineAct()
+        {
+            // "I will put my Spirit in you and you will live." (Ezekiel 37:14)
+            OracleHarness.DivineAct(OracleHarness.Witness("the dry bones live", new RestoringLife(), new CreationOrder()));
+        }
+
+        [Fact]
+        public void DanielRefusesTheKingsIdol_IsRighteous()
+        {
+            // The three will not bow to the image, and Daniel keeps praying (Daniel 3; 6).
+            OracleHarness.Righteous(OracleHarness.Witness("Daniel will not bow to the idol",
+                new CourageousFaith(), new ObedienceToGod()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/MalachiNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/MalachiNarrativeTests.cs
@@ -1,0 +1,194 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Malachi narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class MalachiNarrativeTests
+    {
+        [Fact]
+        public void GodDeclaresHisCovenantLoveForJacob_IsADivineAct()
+        {
+            // "I have loved you, saith the LORD ... Yet I loved Jacob." (Malachi 1:2)
+            // God answers the people's doubt by affirming His electing, covenant love for them.
+            OracleHarness.DivineAct(OracleHarness.Witness("God declares to Israel, I have loved you, and affirms His covenant love for Jacob",
+                new CovenantFaithfulness(), new Fidelity(), new Goodness(),
+                new Compassion(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void ThePriestsDespiseGodsNameWithPollutedOfferings_IsSin()
+        {
+            // "Ye offer polluted bread upon mine altar ... when ye offer the blind for sacrifice, is it not evil?" (Malachi 1:7-8)
+            // The priests dishonor the LORD by bringing defiled and blemished sacrifices to His altar.
+            OracleHarness.Sin(OracleHarness.Grounded("The priests despise the name of the LORD by offering polluted bread and blind and lame animals on His altar",
+                Grounding.InIdol("their own contempt"),
+                new Defilement(), new Blasphemy(), new Disobedience(),
+                new WithholdingWhatIsDue(), new Ingratitude()));
+            // capital vice (Defilement) drives disorder to its limit
+            Assert.Equal(1.0, OracleHarness.Grounded("The priests despise the name of the LORD by offering polluted bread and blind and lame animals on His altar",
+                Grounding.InIdol("their own contempt"),
+                new Defilement(), new Blasphemy(), new Disobedience(),
+                new WithholdingWhatIsDue(), new Ingratitude()).Disorder);
+        }
+
+        [Fact]
+        public void ThePriestsBringTheStolenLameAndSickAsSacrifice_IsSin()
+        {
+            // "Ye brought that which was torn, and the lame, and the sick ... should I accept this of your hand?" (Malachi 1:13)
+            // They sniff at the LORD's table and present cheap, blemished, ill-gotten offerings, robbing Him of due honor.
+            OracleHarness.Sin(OracleHarness.Grounded("The priests bring the torn, the lame, and the sick as offerings and weary of the LORD's table",
+                Grounding.InIdol("their own greed"),
+                new WithholdingWhatIsDue(), new Greed(), new Deceit(),
+                new Disobedience(), new Indifference()));
+        }
+
+        [Fact]
+        public void GodWillBeMagnifiedAndHisNameGreatAmongTheNations_IsADivineAct()
+        {
+            // "My name shall be great among the Gentiles ... a pure offering: for my name shall be great among the heathen." (Malachi 1:11)
+            // God promises that in every place a pure offering will be brought and His name honored among the nations.
+            OracleHarness.DivineAct(OracleHarness.Witness("God declares His name shall be great among the nations and a pure offering brought to Him in every place",
+                new Worship(), new Righteousness(), new PromiseFulfilled(),
+                new CovenantFaithfulness(), new Goodness()));
+        }
+
+        [Fact]
+        public void TheCovenantOfLeviWasOnePeaceAndTruth_IsRighteous()
+        {
+            // "My covenant was with him of life and peace ... The law of truth was in his mouth ... he walked with me in peace and equity, and did turn many away from iniquity." (Malachi 2:5-6)
+            // Faithful Levi feared the LORD, taught true instruction, and turned many from sin: the priesthood as it ought to be.
+            OracleHarness.Righteous(OracleHarness.Witness("Levi walks with God in peace and equity, the law of truth in his mouth, turning many away from iniquity",
+                new CovenantFaithfulness(), new TeachingTruth(), new Peace(),
+                new Righteousness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void ThePriestsCorruptTheCovenantAndCausePeopleToStumble_IsSin()
+        {
+            // "Ye are departed out of the way; ye have caused many to stumble at the law; ye have corrupted the covenant of Levi." (Malachi 2:8)
+            // The priests forsake God's way, show partiality in instruction, and trip up the people, breaking Levi's covenant.
+            OracleHarness.Sin(OracleHarness.Grounded("The priests depart from the way, cause many to stumble at the law, and corrupt the covenant of Levi",
+                Grounding.InIdol("their own partiality"),
+                new CovenantBreaking(), new Disobedience(), new Deceit(),
+                new SowingDiscord(), new Rebellion()));
+        }
+
+        [Fact]
+        public void JudahDealsTreacherouslyAndProfanesTheCovenant_IsSin()
+        {
+            // "Judah hath dealt treacherously ... Judah hath profaned the holiness of the LORD ... and hath married the daughter of a strange god." (Malachi 2:11)
+            // The people break faith with one another and with God, profaning the covenant by marrying into idolatry.
+            OracleHarness.Sin(OracleHarness.Grounded("Judah deals treacherously, profanes the covenant of the LORD, and marries the daughter of a foreign god",
+                Grounding.InIdol("foreign gods"),
+                new Treachery(), new CovenantBreaking(), new Idolatry(),
+                new Disobedience(), new Faction()));
+        }
+
+        [Fact]
+        public void TheMenBreakFaithWithTheWivesOfTheirYouthByDivorce_IsSin()
+        {
+            // "The LORD ... hath been witness between thee and the wife of thy youth, against whom thou hast dealt treacherously ... For the LORD ... hateth putting away." (Malachi 2:14-16)
+            // The men betray the wives of their covenant, and God testifies that He hates this treacherous putting away.
+            OracleHarness.Sin(OracleHarness.Grounded("The men deal treacherously against the wives of their youth and put them away in divorce",
+                Grounding.InIdol("their own desires"),
+                new Treachery(), new CovenantBreaking(), new Deceit(),
+                new Oppression(), new Disobedience()));
+        }
+
+        [Fact]
+        public void ThePeopleWearyGodCallingEvildoersGood_IsSin()
+        {
+            // "Ye have wearied the LORD with your words ... When ye say, Every one that doeth evil is good in the sight of the LORD ... Where is the God of judgment?" (Malachi 2:17)
+            // They tire God with cynical words, calling evil good and doubting that He judges at all.
+            OracleHarness.Sin(OracleHarness.Grounded("The people weary the LORD with their words, calling every evildoer good and asking where is the God of judgment",
+                Grounding.InIdol("their own cynicism"),
+                new DelightingInEvil(), new Blasphemy(), new Deceit(),
+                new Slander(), new Disobedience()));
+        }
+
+        [Fact]
+        public void GodSendsHisMessengerAndTheRefinerToPurifyTheSonsOfLevi_IsADivineAct()
+        {
+            // "I will send my messenger ... the Lord ... shall suddenly come to his temple ... he shall purify the sons of Levi, and purge them ... that they may offer ... an offering in righteousness." (Malachi 3:1-3)
+            // God promises His messenger and His own coming as a refiner's fire to cleanse and restore true worship.
+            OracleHarness.DivineAct(OracleHarness.Witness("God sends His messenger and comes as a refiner's fire to purify the sons of Levi for an offering in righteousness",
+                new PromiseFulfilled(), new Righteousness(), new Purity(),
+                new CovenantFaithfulness(), new Deliverance()));
+        }
+
+        [Fact]
+        public void GodWillJudgeSorcerersAdulterersAndOppressors_IsADivineAct()
+        {
+            // "I will come near to you to judgment ... against the sorcerers, and against the adulterers ... and those that oppress the hireling in his wages, the widow, and the fatherless." (Malachi 3:5)
+            // The LORD draws near as a swift witness to judge the wicked and defend the defenseless they have wronged.
+            OracleHarness.DivineAct(OracleHarness.Witness("God comes near in judgment against sorcerers and adulterers and those who oppress the widow, the fatherless, and the hireling",
+                new JustRecompense(), new Righteousness(), new DefendingTheWeak(),
+                new HonoringTheVulnerable(), new Fidelity()));
+        }
+
+        [Fact]
+        public void ThePeopleRobGodInTithesAndOfferings_IsSin()
+        {
+            // "Will a man rob God? Yet ye have robbed me ... In tithes and offerings. Ye are cursed with a curse." (Malachi 3:8-9)
+            // The whole nation withholds the tithes and offerings owed to God, robbing Him of what is His.
+            OracleHarness.Sin(OracleHarness.Grounded("The people rob God by withholding the tithes and offerings they owe Him",
+                Grounding.InIdol("their own greed"),
+                new Theft(), new WithholdingWhatIsDue(), new Greed(),
+                new Disobedience(), new Ingratitude()));
+        }
+
+        [Fact]
+        public void GodPromisesToOpenHeavensWindowsToThoseWhoBringTheTithe_IsADivineAct()
+        {
+            // "Bring ye all the tithes ... prove me now herewith ... if I will not open you the windows of heaven, and pour you out a blessing." (Malachi 3:10)
+            // To those who return what is His, God pledges to pour out blessing beyond measure and rebuke the devourer.
+            OracleHarness.DivineAct(OracleHarness.Witness("God promises to open the windows of heaven and pour out blessing on those who bring the full tithe into His house",
+                new Generosity(), new Goodness(), new PromiseFulfilled(),
+                new CovenantFaithfulness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void ThoseWhoFearTheLordSpeakTogetherAndAreWrittenInTheBookOfRemembrance_IsRighteous()
+        {
+            // "Then they that feared the LORD spake often one to another ... and a book of remembrance was written ... for them that feared the LORD, and that thought upon his name." (Malachi 3:16)
+            // A faithful remnant fears God, encourages one another, and reveres His name, and He records them as His own.
+            OracleHarness.Righteous(OracleHarness.Witness("Those who fear the LORD speak often to one another and revere His name, and a book of remembrance is written for them",
+                new Worship(), new Fidelity(), new CovenantFaithfulness(),
+                new Trust(), new Righteousness()));
+        }
+
+        [Fact]
+        public void GodSparesAndOwnsThoseWhoFearHimAsHisTreasuredPossession_IsADivineAct()
+        {
+            // "They shall be mine, saith the LORD ... in that day when I make up my jewels; and I will spare them, as a man spareth his own son." (Malachi 3:17)
+            // God claims the God-fearers as His treasured possession and spares them as a father spares his obedient son.
+            OracleHarness.DivineAct(OracleHarness.Witness("God claims those who fear Him as His treasured possession and spares them as a man spares his own son",
+                new Compassion(), new CovenantFaithfulness(), new Protection(),
+                new Goodness(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void TheSunOfRighteousnessRisesWithHealingForThoseWhoFearGod_IsADivineAct()
+        {
+            // "Unto you that fear my name shall the Sun of righteousness arise with healing in his wings." (Malachi 4:2)
+            // For those who fear His name God promises the Sun of righteousness, rising with healing and joyful deliverance.
+            OracleHarness.DivineAct(OracleHarness.Witness("The Sun of righteousness rises with healing in His wings for those who fear the name of the LORD",
+                new Healing(), new Righteousness(), new Deliverance(),
+                new Joy(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void GodPromisesToSendElijahToTurnTheHeartsOfFathersAndChildren_IsADivineAct()
+        {
+            // "I will send you Elijah the prophet ... And he shall turn the heart of the fathers to the children, and the heart of the children to their fathers." (Malachi 4:5-6)
+            // God promises to send Elijah before the great day, reconciling generations and calling His people to repentance.
+            OracleHarness.DivineAct(OracleHarness.Witness("God promises to send Elijah the prophet to turn the hearts of the fathers to the children and the children to the fathers",
+                new Peacemaking(), new Repentance(), new PromiseFulfilled(),
+                new CovenantFaithfulness(), new Deliverance()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/MarkNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/MarkNarrativeTests.cs
@@ -1,0 +1,181 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Mark narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class MarkNarrativeTests
+    {
+        [Fact]
+        public void JohnTheBaptistPreachesRepentanceAndPreparesTheWay_IsRighteous()
+        {
+            // "John did baptize in the wilderness, and preach the baptism of repentance for the remission of sins." (Mark 1:4-8)
+            // The forerunner calls Israel to turn, humbling himself before the One mightier who comes after him.
+            OracleHarness.Righteous(OracleHarness.Witness("John the Baptist preaches the baptism of repentance and prepares the way of the Lord",
+                new TeachingTruth(), new Repentance(), new Humility(),
+                new ObedienceToGod(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void JesusCleansesTheLeperWithCompassion_IsADivineAct()
+        {
+            // "Jesus, moved with compassion, put forth his hand, and touched him ... and immediately the leprosy departed." (Mark 1:40-42)
+            // Christ touches the untouchable and restores the outcast to wholeness.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus is moved with compassion and heals the leper, making him clean",
+                new Compassion(), new Healing(), new Kindness(),
+                new HonoringTheVulnerable(), new Goodness()));
+        }
+
+        [Fact]
+        public void JesusForgivesAndHealsTheParalytic_IsADivineAct()
+        {
+            // "Son, thy sins be forgiven thee ... Arise, and take up thy bed, and walk." (Mark 2:5-12)
+            // Christ exercises the divine authority to pardon sin and then heals the paralyzed man to prove it.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus forgives the paralytic's sins and heals him so he rises and walks",
+                new Forgiveness(), new Pardon(), new Healing(),
+                new Compassion(), new Righteousness()));
+        }
+
+        [Fact]
+        public void JesusHealsOnTheSabbathToDoGoodAndSaveLife_IsADivineAct()
+        {
+            // "Is it lawful ... to do good on the sabbath days, or to do evil? to save life, or to kill?" (Mark 3:1-5)
+            // Christ restores the withered hand, teaching that mercy, not legalism, fulfills the Sabbath.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus heals the man with the withered hand on the Sabbath to do good and save life",
+                new Healing(), new Compassion(), new TeachingTruth(),
+                new Goodness(), new RestoringLife()));
+        }
+
+        [Fact]
+        public void JesusStillsTheStormAndCommandsPeaceBeStill_IsADivineAct()
+        {
+            // "Peace, be still. And the wind ceased, and there was a great calm." (Mark 4:39)
+            // Christ rebukes the wind and sea, and the chaos of the deep obeys its Creator.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus rebukes the storm and commands Peace, be still, and the wind and sea obey Him",
+                new Protection(), new Deliverance(), new Peace(),
+                new CreationOrder(), new Goodness()));
+        }
+
+        [Fact]
+        public void JesusRaisesJairusDaughterFromTheDead_IsADivineAct()
+        {
+            // "Talitha cumi ... And straightway the damsel arose, and walked." (Mark 5:41-42)
+            // Christ takes the dead girl by the hand and gives her back her life.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus takes the dead girl by the hand and raises Jairus's daughter to life",
+                new RestoringLife(), new Compassion(), new Healing(),
+                new HonoringTheVulnerable(), new Goodness()));
+        }
+
+        [Fact]
+        public void HerodiasSchemesAndHerodBeheadsJohnTheBaptist_IsSin()
+        {
+            // "And he ... beheaded him in the prison ... and gave it to the damsel: and the damsel gave it to her mother." (Mark 6:17-28)
+            // Herodias nurses her grudge and through a rash oath Herod murders the righteous prophet.
+            OracleHarness.Sin(OracleHarness.Grounded("Herodias schemes against John and Herod has John the Baptist beheaded in prison",
+                Grounding.InIdol("Herodias's grudge"),
+                new Murder(), new Bloodshed(), new Grudge(),
+                new WickedScheming(), new Treachery()));
+            // capital vices (Murder, Bloodshed) drive disorder to its limit
+            Assert.Equal(1.0, OracleHarness.Grounded("Herodias schemes against John and Herod has John the Baptist beheaded in prison",
+                Grounding.InIdol("Herodias's grudge"),
+                new Murder(), new Bloodshed(), new Grudge(),
+                new WickedScheming(), new Treachery()).Disorder);
+        }
+
+        [Fact]
+        public void JesusHasCompassionAndFeedsTheFiveThousand_IsADivineAct()
+        {
+            // "Jesus ... was moved with compassion toward them ... they did all eat, and were filled." (Mark 6:34-44)
+            // Seeing the crowd as sheep without a shepherd, Christ teaches them and multiplies the loaves to feed them.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus has compassion on the crowd, teaches them, and feeds the five thousand",
+                new Compassion(), new FeedingTheHungry(), new TeachingTruth(),
+                new Generosity(), new Goodness()));
+        }
+
+        [Fact]
+        public void JesusTeachesThatDefilementComesFromTheHeart_IsADivineAct()
+        {
+            // "That which cometh out of the man, that defileth the man ... evil thoughts, adulteries, fornications, murders." (Mark 7:20-23)
+            // Christ reveals that true uncleanness is moral, flowing from the corrupt heart, not from unwashed hands.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus teaches that what comes out of the heart, not unwashed hands, is what defiles a person",
+                new TeachingTruth(), new RejoicingInTruth(), new Purity(),
+                new Righteousness(), new Goodness()));
+        }
+
+        [Fact]
+        public void TheRichYoungManTurnsAwayInGreed_IsSin()
+        {
+            // "He was sad at that saying, and went away grieved: for he had great possessions." (Mark 10:21-22)
+            // Called to sell all and follow Christ, the man clings to his wealth and walks away from the Lord.
+            OracleHarness.Sin(OracleHarness.Grounded("The rich young man refuses to sell his possessions and turns away from following Jesus",
+                Grounding.InIdol("his great possessions"),
+                new Greed(), new Covetousness(), new Disobedience(),
+                new SelfSeeking(), new Idolatry()));
+        }
+
+        [Fact]
+        public void JesusServesAsRansomGivingHisLifeForMany_IsADivineAct()
+        {
+            // "The Son of man came not to be ministered unto, but to minister, and to give his life a ransom for many." (Mark 10:43-45)
+            // Christ defines greatness as service and offers His own life as the ransom for the many.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus teaches that He came to serve and to give His life a ransom for many",
+                new SelfSacrifice(), new Atonement(), new Humility(),
+                new Deliverance(), new Goodness()));
+        }
+
+        [Fact]
+        public void JudasIscariotBetraysJesusToTheChiefPriests_IsSin()
+        {
+            // "Judas Iscariot ... went unto the chief priests, to betray him unto them ... and promised to give him money." (Mark 14:10-11)
+            // For money Judas hands his Master over to those who seek to kill Him.
+            OracleHarness.Sin(OracleHarness.Grounded("Judas Iscariot goes to the chief priests and betrays Jesus to them for money",
+                Grounding.InIdol("thirty pieces of silver"),
+                new Treachery(), new Greed(), new Deceit(),
+                new Disobedience(), new WickedScheming()));
+        }
+
+        [Fact]
+        public void JesusGivesHisBodyAndBloodAtTheLastSupper_IsADivineAct()
+        {
+            // "Take, eat: this is my body ... This is my blood of the new testament, which is shed for many." (Mark 14:22-24)
+            // Christ institutes the covenant meal, giving His body and blood for the remission of sins.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus gives His body and His blood of the new covenant for many at the Last Supper",
+                new SelfSacrifice(), new Atonement(), new CovenantFaithfulness(),
+                new PromiseFulfilled(), new Goodness()));
+        }
+
+        [Fact]
+        public void JesusSubmitsInGethsemaneNotMyWillButThine_IsADivineAct()
+        {
+            // "Not what I will, but what thou wilt." (Mark 14:36)
+            // In the garden Christ entrusts Himself wholly to the Father, embracing the cup of suffering in obedience.
+            OracleHarness.DivineAct(OracleHarness.Witness("Jesus prays in Gethsemane, Not my will but thine be done, and submits to the Father",
+                new ObedienceToGod(), new SelfSacrifice(), new Humility(),
+                new Trust(), new Endurance()));
+        }
+
+        [Fact]
+        public void PeterDeniesJesusThreeTimes_IsSin()
+        {
+            // "I know not this man of whom ye speak ... And the second time the cock crew." (Mark 14:66-72)
+            // Out of fear Peter swears he does not know his Lord, denying Christ three times before the cock crows.
+            OracleHarness.Sin(OracleHarness.Grounded("Peter denies that he knows Jesus three times in the high priest's courtyard",
+                Grounding.InIdol("fear of the crowd"),
+                new Treachery(), new Deceit(), new FalseWitness(),
+                new Disobedience(), new CovenantBreaking()));
+        }
+
+        [Fact]
+        public void JosephOfArimatheaCourageouslyBuriesTheBodyOfJesus_IsRighteous()
+        {
+            // "Joseph of Arimathaea ... went in boldly unto Pilate, and craved the body of Jesus ... and laid him in a sepulchre." (Mark 15:43-46)
+            // Honorably and at risk to himself, Joseph asks for the Lord's body and lays it reverently in the tomb.
+            OracleHarness.Righteous(OracleHarness.Witness("Joseph of Arimathea goes boldly to Pilate, takes the body of Jesus, and lays it in a tomb",
+                new CourageousFaith(), new HonoringTheVulnerable(), new Kindness(),
+                new Goodness(), new Fidelity()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/MatthewNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/MatthewNarrativeTests.cs
@@ -1,0 +1,162 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Matthew narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class MatthewNarrativeTests
+    {
+        [Fact]
+        public void GodIsWithUsInTheBirthOfChrist_IsADivineAct()
+        {
+            // "Behold, the virgin shall conceive ... and they shall call his name Immanuel, God with us." (Matthew 1:18-23)
+            // The Holy Spirit conceives Christ; the promise to the house of David is fulfilled.
+            OracleHarness.DivineAct(OracleHarness.Witness("The Holy Spirit conceives Christ in the virgin (Matthew 1:18-23)",
+                new CreationOrder(), new PromiseFulfilled(), new CovenantFaithfulness(), new Deliverance(), new Goodness()));
+        }
+
+        [Fact]
+        public void JosephTakesMaryAsWifeInObedience_IsRighteous()
+        {
+            // Joseph, a just man, obeys the angel and takes Mary, sparing her shame. (Matthew 1:19-24)
+            // Quiet obedience to God and protective compassion for the vulnerable.
+            OracleHarness.Righteous(OracleHarness.Witness("Joseph obeys the angel and takes Mary as his wife (Matthew 1:24)",
+                new ObedienceToGod(), new Righteousness(), new Protection(), new Compassion(), new Trust()));
+        }
+
+        [Fact]
+        public void HerodSlaughtersTheInnocentsOfBethlehem_IsSin()
+        {
+            // "Herod ... slew all the children that were in Bethlehem ... from two years old and under." (Matthew 2:16)
+            // Murderous bloodshed of infants out of jealous rage. Capital vice: disorder is total.
+            Resolution r = OracleHarness.Witness("Herod massacres the infants of Bethlehem (Matthew 2:16)",
+                new Murder(), new Bloodshed(), new Jealousy(), new FitsOfRage(), new Oppression());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void JohnBaptizesCallingForRepentance_IsRighteous()
+        {
+            // "Repent ye: for the kingdom of heaven is at hand." (Matthew 3:1-6)
+            // John preaches truth and a baptism of repentance, preparing the way of the Lord.
+            OracleHarness.Righteous(OracleHarness.Witness("John the Baptist preaches repentance in the wilderness (Matthew 3:1-6)",
+                new TeachingTruth(), new Repentance(), new Righteousness(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void ChristResistsTheTempterInTheWilderness_IsADivineAct()
+        {
+            // Christ answers Satan with "It is written," refusing bread, presumption, and idolatrous power. (Matthew 4:1-11)
+            // Perfect obedience, self-control, and worship of God alone.
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ overcomes the temptations in the wilderness (Matthew 4:1-11)",
+                new ObedienceToGod(), new SelfControl(), new Worship(), new Endurance(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void ChristPreachesTheBeatitudes_IsADivineAct()
+        {
+            // "Blessed are the poor in spirit ... they that mourn ... the meek ... they which hunger ... for righteousness." (Matthew 5:3-10)
+            // Christ teaches the very shape of kingdom blessedness.
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ teaches the Beatitudes on the mount (Matthew 5:3-10)",
+                new TeachingTruth(), new PovertyOfSpirit(), new Mourning(), new Meekness(),
+                new HungerForRighteousness(), new Purity(), new Peacemaking()));
+        }
+
+        [Fact]
+        public void ChristTeachesLoveOfEnemiesAndForgiveness_IsADivineAct()
+        {
+            // "Love your enemies ... if ye forgive men their trespasses, your heavenly Father will also forgive you." (Matthew 5:44; 6:14)
+            // The Lord commands enemy-love, mercy, and the forgiveness of debts.
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ teaches love of enemies and forgiveness (Matthew 5:44; 6:14)",
+                new TeachingTruth(), new Forgiveness(), new Kindness(), new Peacemaking(), new Compassion()));
+        }
+
+        [Fact]
+        public void ChristHealsTheLeperAndTheSick_IsADivineAct()
+        {
+            // Christ cleanses the leper, heals the centurion's servant and Peter's mother-in-law, and "healed all that were sick." (Matthew 8:1-17)
+            // Divine compassion that restores the broken body.
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ heals the leper and the sick (Matthew 8:1-17)",
+                new Healing(), new Compassion(), new CaringForTheSick(), new Goodness(), new Deliverance()));
+        }
+
+        [Fact]
+        public void ChristStillsTheStormOverChaos_IsADivineAct()
+        {
+            // "He arose, and rebuked the winds and the sea; and there was a great calm." (Matthew 8:23-27)
+            // The Lord of creation orders the raging waters and delivers His disciples.
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ stills the storm on the sea (Matthew 8:23-27)",
+                new CreationOrder(), new Deliverance(), new Protection(), new Peace()));
+        }
+
+        [Fact]
+        public void ChristFeedsTheFiveThousand_IsADivineAct()
+        {
+            // Moved with compassion, Christ multiplies the loaves and "they did all eat, and were filled." (Matthew 14:14-21)
+            // Divine compassion that feeds the hungry multitude.
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ feeds the five thousand (Matthew 14:14-21)",
+                new Compassion(), new FeedingTheHungry(), new Generosity(), new Goodness(), new CreationOrder()));
+        }
+
+        [Fact]
+        public void ChristTeachesUnlimitedForgivenessSeventyTimesSeven_IsADivineAct()
+        {
+            // "I say not unto thee, Until seven times: but, Until seventy times seven." (Matthew 18:21-35)
+            // The parable of the unforgiving servant commands boundless mercy and pardon.
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ teaches forgiveness seventy times seven (Matthew 18:21-35)",
+                new TeachingTruth(), new Forgiveness(), new Pardon(), new Compassion(), new Mourning()));
+        }
+
+        [Fact]
+        public void ChristDescribesTheLastJudgmentOfTheNations_IsADivineAct()
+        {
+            // "I was an hungred, and ye gave me meat ... thirsty ... a stranger ... naked ... sick ... in prison." (Matthew 25:31-40)
+            // The King names the works of mercy by which the sheep are known.
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ names the works of mercy at the judgment (Matthew 25:31-40)",
+                new TeachingTruth(), new FeedingTheHungry(), new GivingDrink(), new Hospitality(),
+                new ClothingTheNaked(), new CaringForTheSick(), new VisitingThePrisoner()));
+        }
+
+        [Fact]
+        public void JudasBetraysChristForThirtyPieces_IsSin()
+        {
+            // "What will ye give me, and I will deliver him unto you? And they covenanted with him for thirty pieces of silver." (Matthew 26:14-16)
+            // Treacherous betrayal of the innocent for greed.
+            OracleHarness.Sin(OracleHarness.Witness("Judas betrays Christ for thirty pieces of silver (Matthew 26:14-16)",
+                new Treachery(), new Greed(), new Deceit(), new CovenantBreaking()));
+        }
+
+        [Fact]
+        public void ChristGivesHimselfInTheCovenantOfHisBlood_IsADivineAct()
+        {
+            // "This is my blood of the new testament, which is shed for many for the remission of sins." (Matthew 26:26-28)
+            // Christ offers Himself as the atoning sacrifice of the new covenant.
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ institutes the covenant in His blood (Matthew 26:26-28)",
+                new SelfSacrifice(), new Atonement(), new CovenantFaithfulness(), new Pardon(), new Deliverance()));
+        }
+
+        [Fact]
+        public void PilateCondemnsTheInnocentToBeCrucified_IsSin()
+        {
+            // Pilate, finding no fault, washes his hands yet delivers the innocent Christ to be crucified. (Matthew 27:24-26)
+            // Bloodshed of the innocent through cowardly injustice and false condemnation.
+            Resolution r = OracleHarness.Witness("Pilate condemns the innocent Christ to crucifixion (Matthew 27:24-26)",
+                new Bloodshed(), new Condemnation(), new Wrongdoing(), new Oppression(), new FalseWitness());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void ChristIsRaisedAndSendsTheGreatCommission_IsADivineAct()
+        {
+            // "He is not here: for he is risen ... Go ye therefore, and teach all nations." (Matthew 28:6,19-20)
+            // God raises Christ from the dead and the risen Lord commissions His church.
+            OracleHarness.DivineAct(OracleHarness.Witness("The risen Christ gives the Great Commission (Matthew 28:6,19-20)",
+                new RestoringLife(), new PromiseFulfilled(), new Deliverance(), new TeachingTruth(), new CovenantFaithfulness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/MeqabyanNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/MeqabyanNarrativeTests.cs
@@ -1,0 +1,130 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Meqabyan (Ethiopic Maccabees) narrative oracle: the engine must return the verdict
+    // Scripture gives at each step. Canon tag: ETH (Ethiopic-only; best-effort).
+    // These three books (1, 2, 3 Meqabyan) of the Ethiopian Orthodox Tewahedo canon are
+    // distinct from the Greek Maccabees. Verses follow common ETH versification.
+    public class MeqabyanNarrativeTests
+    {
+        [Fact]
+        public void MeqabisOfBenjaminExaltsHimselfAndSetsUpIdols_IsSin()
+        {
+            // Meqabis (Tseerutsaydaan), a Midianite king of Benjamin's land, exalts himself,
+            // forsakes the living God, and sets up carved idols to be worshipped. (1 Meqabyan 1:6-11)
+            // Proud, lawless idolatry that abandons the covenant of the LORD.
+            OracleHarness.Sin(OracleHarness.Grounded("Meqabis exalts himself and sets up idols to be worshipped",
+                Grounding.InIdol("Meqabis"),
+                new Idolatry(), new Pride(), new Lawlessness(), new CovenantBreaking(), new Blasphemy()));
+        }
+
+        [Fact]
+        public void MeqabisCommandsAllToWorshipHisIdolsAndOppressesTheFaithful_IsSin()
+        {
+            // The king decrees that every people must bow to his gods, oppressing and afflicting
+            // those who cling to the God of Abraham, Isaac, and Jacob. (1 Meqabyan 1:12-20)
+            // Tyrannical compulsion to idolatry and oppression of the righteous.
+            OracleHarness.Sin(OracleHarness.Witness("Meqabis commands all peoples to worship his idols and oppresses the faithful",
+                new Idolatry(), new Oppression(), new Lawlessness(), new Pride()));
+        }
+
+        [Fact]
+        public void MeqabisSlaughtersThoseWhoWorshipTheTrueGod_IsSin()
+        {
+            // Meqabis puts to death those who refuse his idols and worship the living God,
+            // shedding the blood of the innocent who keep the covenant. (1 Meqabyan 1:21-28)
+            // Bloodshed and murder of the righteous; reality is driven to full disorder.
+            OracleHarness.Sin(OracleHarness.Witness("Meqabis slaughters those who worship the true God",
+                new Murder(), new Bloodshed(), new Oppression(), new Idolatry(), new Hatred()));
+            Assert.Equal(1.0, OracleHarness.Witness("Meqabis slaughters those who worship the true God",
+                new Murder(), new Bloodshed(), new Oppression(), new Idolatry(), new Hatred()).Disorder);
+        }
+
+        [Fact]
+        public void TheFiveSonsOfMeqabyanRefuseIdolatryAndConfessTheLivingGod_IsRighteous()
+        {
+            // Abya, Seela, and Fentos with their brethren refuse the king's idols, confessing,
+            // "We worship the God who made heaven and earth," though it means death. (1 Meqabyan 2:1-12)
+            // Courageous covenant faithfulness and steadfast confession of the true God.
+            OracleHarness.Righteous(OracleHarness.Grounded("The five sons of Meqabyan refuse idolatry and confess the living God",
+                Grounding.InGod(),
+                new CourageousFaith(), new CovenantFaithfulness(), new ObedienceToGod(),
+                new Fidelity(), new Worship()));
+        }
+
+        [Fact]
+        public void TheSonsOfMeqabyanEndureMartyrdomRatherThanDenyGod_IsRighteous()
+        {
+            // The brethren are tortured and slain, yet they endure to the end rather than deny the LORD,
+            // laying down their lives for His name. (1 Meqabyan 2:13-23)
+            // Faithful endurance unto death; self-sacrifice that keeps the covenant whole.
+            OracleHarness.Righteous(OracleHarness.Grounded("The sons of Meqabyan endure martyrdom rather than deny God",
+                Grounding.InGod(),
+                new Endurance(), new SelfSacrifice(), new CourageousFaith(), new Fidelity(),
+                new ObedienceToGod(), new Purity()));
+        }
+
+        [Fact]
+        public void GodAvengesTheMartyrsAndDestroysTheTyrantMeqabis_IsADivineAct()
+        {
+            // The LORD hears the blood of His servants and brings the proud king to ruin,
+            // delivering His people and rendering the tyrant his due. (1 Meqabyan 3:1-12)
+            // Scripture's verdict is the just deliverance Heaven works for the oppressed righteous.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God avenges the martyrs and destroys the tyrant Meqabis",
+                Grounding.InGod(),
+                new JustRecompense(), new Deliverance(), new Protection(), new DefendingTheWeak(),
+                new Righteousness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodAsCreatorOfHeavenAndEarthIsProclaimed_IsADivineAct()
+        {
+            // Meqabyan extols the LORD who established the heavens, the sea, and the dry land in order,
+            // ruling all creation by His word. (2 Meqabyan 1:1-9; 3:1-6)
+            // The ordered work of the Creator who upholds reality.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God the Creator establishes the heavens and the earth in order",
+                Grounding.InGod(),
+                new CreationOrder(), new Goodness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodPromisesToRaiseTheRighteousDeadAtTheResurrection_IsADivineAct()
+        {
+            // The book proclaims that God will raise the dead and restore life to the righteous who
+            // died for His name, fulfilling His promise of resurrection. (2 Meqabyan 5:28-35; 3 Meqabyan 6)
+            // Scripture's verdict is the life-restoring faithfulness of God to His own.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God promises to raise the righteous dead and restore them to life",
+                Grounding.InGod(),
+                new RestoringLife(), new PromiseFulfilled(), new Fidelity(), new Deliverance(),
+                new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TheBookCallsSinnersToRepentBeforeTheJudgment_IsRighteous()
+        {
+            // Meqabyan exhorts the wicked to turn from idols and wickedness, humble themselves,
+            // and seek the mercy of God before the day of judgment. (2 Meqabyan 2; 3 Meqabyan 2-4)
+            // A righteous call to repentance, humility, and trust in God's mercy.
+            OracleHarness.Righteous(OracleHarness.Grounded("Meqabyan calls sinners to repent and humble themselves before the judgment",
+                Grounding.InGod(),
+                new Repentance(), new Humility(), new Trust(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void GodRewardsTheRighteousAndJudgesTheWickedAtTheLastDay_IsADivineAct()
+        {
+            // At the last day God gives the righteous their reward and renders the wicked their due,
+            // delivering His faithful into rest. (3 Meqabyan 5-7)
+            // Scripture's verdict is the just, faithful recompense of the righteous Judge.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God rewards the righteous and judges the wicked at the last day",
+                Grounding.InGod(),
+                new JustRecompense(), new Righteousness(), new Deliverance(), new Fidelity(),
+                new PromiseFulfilled()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/MicahNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/MicahNarrativeTests.cs
@@ -1,0 +1,181 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Micah narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class MicahNarrativeTests
+    {
+        [Fact]
+        public void TheLordComesDownToWitnessAgainstSamariaAndJerusalem_IsADivineAct()
+        {
+            // "the Lord GOD be witness against you ... behold, the LORD cometh forth out of his place." (Micah 1:2-3)
+            // God descends as righteous Witness and Judge against the high places of His people's sin.
+            OracleHarness.DivineAct(OracleHarness.Witness("The LORD comes down from His holy temple to witness against Samaria and Jerusalem",
+                new Righteousness(), new JustRecompense(), new TeachingTruth(),
+                new RejoicingInTruth(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void SamariasHarlotryAndIdolWorshipAreCondemned_IsSin()
+        {
+            // "all the graven images thereof shall be beaten to pieces ... she gathered it of the hire of an harlot." (Micah 1:6-7)
+            // Samaria built her shrines from the wages of idolatrous harlotry, the very sin that brings her ruin.
+            OracleHarness.Sin(OracleHarness.Grounded("Samaria heaps up graven images and wages of harlotry in idol worship",
+                Grounding.InIdol("Baal"),
+                new Idolatry(), new GravenImage(), new SexualImmorality(),
+                new CovenantBreaking(), new Rebellion()));
+        }
+
+        [Fact]
+        public void TheGreedyDeviseEvilOnTheirBedsAndSeizeFieldsAndHouses_IsSin()
+        {
+            // "Woe to them that devise iniquity ... they covet fields, and take them by violence; and houses, and take them away." (Micah 2:1-2)
+            // On their beds the powerful scheme to steal the inheritance of the poor and oppress a man and his house.
+            OracleHarness.Sin(OracleHarness.Grounded("The powerful devise iniquity on their beds and seize the fields and houses of the poor",
+                Grounding.InIdol("their own power"),
+                new WickedScheming(), new Covetousness(), new Theft(),
+                new Oppression(), new Greed()));
+        }
+
+        [Fact]
+        public void FalseProphetsCryPeaceForBreadAndWarOnThoseWhoFeedThemNot_IsSin()
+        {
+            // "the prophets that make my people err ... he that putteth not into their mouths, they even prepare war against him." (Micah 3:5)
+            // The hireling prophets bless those who feed them and curse the rest, deceiving the people for gain.
+            OracleHarness.Sin(OracleHarness.Grounded("The false prophets cry peace for bread and declare war on those who do not fill their mouths",
+                Grounding.InIdol("dishonest gain"),
+                new Deceit(), new Greed(), new FalseWitness(),
+                new Treachery(), new Lawlessness()));
+        }
+
+        [Fact]
+        public void TheRulersHateGoodLoveEvilAndTearTheFleshOfThePeople_IsSin()
+        {
+            // "Who hate the good, and love the evil; who pluck off their skin ... and eat the flesh of my people." (Micah 3:1-3)
+            // The heads of Jacob who should know justice instead devour the people like meat in a pot.
+            OracleHarness.Sin(OracleHarness.Grounded("The rulers hate good and love evil, tearing the skin and flesh off the people",
+                Grounding.InIdol("their own appetite"),
+                new Oppression(), new Bloodshed(), new Hatred(),
+                new DelightingInEvil(), new Heartlessness()));
+            // capital vice (Bloodshed) drives disorder to its limit
+        }
+
+        [Fact]
+        public void ZionsHeadsJudgeForRewardAndPriestsTeachForHire_IsSin()
+        {
+            // "the heads thereof judge for reward, and the priests thereof teach for hire ... yet will they lean upon the LORD." (Micah 3:11)
+            // Bribed judges, mercenary priests, and money-prophets presume on God while building Zion with blood.
+            OracleHarness.Sin(OracleHarness.Grounded("Zion's heads judge for reward and her priests teach for hire while presuming on the LORD",
+                Grounding.InIdol("bribes and hire"),
+                new Greed(), new Deceit(), new Pride(),
+                new FalseWitness(), new Blasphemy()));
+        }
+
+        [Fact]
+        public void ManyNationsShallFlowToTheMountainOfTheLordToLearnHisWays_IsADivineAct()
+        {
+            // "many nations shall come, and say, Come, and let us go up to the mountain of the LORD ... he will teach us of his ways." (Micah 4:1-2)
+            // In the last days God draws the peoples to Zion, teaching His ways so they walk in His paths.
+            OracleHarness.DivineAct(OracleHarness.Witness("The LORD draws many nations to His mountain to teach them His ways and judge among them",
+                new TeachingTruth(), new Peacemaking(), new Righteousness(),
+                new Peace(), new Worship()));
+        }
+
+        [Fact]
+        public void TheNationsBeatSwordsIntoPlowsharesAndLearnWarNoMore_IsADivineAct()
+        {
+            // "they shall beat their swords into plowshares ... neither shall they learn war any more." (Micah 4:3)
+            // God's reign turns weapons into farm tools and gives every man rest under his own vine and fig tree.
+            OracleHarness.DivineAct(OracleHarness.Witness("Under God's reign the nations beat swords into plowshares and learn war no more",
+                new Peacemaking(), new Peace(), new Protection(),
+                new Goodness(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TheRulerOfIsraelShallComeForthFromBethlehem_IsADivineAct()
+        {
+            // "out of thee shall he come forth ... that is to be ruler in Israel; whose goings forth have been ... from everlasting." (Micah 5:2)
+            // The promised Shepherd-King comes from little Bethlehem, the eternal Ruler who fulfills God's word.
+            OracleHarness.DivineAct(OracleHarness.Witness("Out of Bethlehem comes forth the eternal Ruler of Israel, the promised Messiah",
+                new PromiseFulfilled(), new CovenantFaithfulness(), new Fidelity(),
+                new Deliverance(), new Goodness()));
+        }
+
+        [Fact]
+        public void TheRulerShallStandAndFeedHisFlockInTheStrengthOfTheLord_IsADivineAct()
+        {
+            // "he shall stand and feed in the strength of the LORD ... and this man shall be the peace." (Micah 5:4-5)
+            // The coming Ruler shepherds His flock in God's might, securing them, and He Himself is their peace.
+            OracleHarness.DivineAct(OracleHarness.Witness("The Ruler stands and feeds His flock in the strength of the LORD and is their peace",
+                new Protection(), new Peace(), new CovenantFaithfulness(),
+                new Fidelity(), new Goodness()));
+        }
+
+        [Fact]
+        public void GodRecallsHowHeRedeemedIsraelFromEgyptAndSentMosesAaronAndMiriam_IsADivineAct()
+        {
+            // "I brought thee up out of the land of Egypt, and redeemed thee ... I sent before thee Moses, Aaron, and Miriam." (Micah 6:4)
+            // God pleads His case by recalling the redemption from Egypt and the leaders He gave in covenant love.
+            OracleHarness.DivineAct(OracleHarness.Witness("God recalls how He redeemed Israel out of Egypt and sent Moses, Aaron, and Miriam before them",
+                new Deliverance(), new CovenantFaithfulness(), new PromiseFulfilled(),
+                new Protection(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodRequiresToDoJustlyLoveMercyAndWalkHumblyWithHim_IsADivineAct()
+        {
+            // "what doth the LORD require of thee, but to do justly, and to love mercy, and to walk humbly with thy God?" (Micah 6:8)
+            // Above sacrifices God teaches the heart of His will: justice, steadfast mercy, and humble walking.
+            OracleHarness.DivineAct(OracleHarness.Witness("The LORD requires of His people to do justly, to love mercy, and to walk humbly with their God",
+                new Righteousness(), new Compassion(), new Humility(),
+                new TeachingTruth(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TheCityUsesWickedScalesDeceitfulWeightsAndViolence_IsSin()
+        {
+            // "the bag of deceitful weights ... the rich men thereof are full of violence ... they have spoken lies." (Micah 6:11-12)
+            // The merchants cheat with rigged scales, the rich live by violence, and every tongue is full of deceit.
+            OracleHarness.Sin(OracleHarness.Grounded("The city's merchants use wicked balances and deceitful weights while the rich are full of violence and lies",
+                Grounding.InIdol("dishonest gain"),
+                new Deceit(), new Greed(), new Oppression(),
+                new FalseWitness(), new Lawlessness()));
+        }
+
+        [Fact]
+        public void TheGodlyHavePerishedAndEveryManHuntsHisBrotherWithANet_IsSin()
+        {
+            // "The good man is perished out of the earth ... they hunt every man his brother with a net." (Micah 7:2)
+            // Faithfulness has vanished from the land; men lie in wait for blood and snare even their own kin.
+            OracleHarness.Sin(OracleHarness.Grounded("The godly have perished and every man hunts his brother with a net to shed blood",
+                Grounding.InIdol("self-seeking violence"),
+                new Bloodshed(), new Treachery(), new Malice(),
+                new Deceit(), new Hatred()));
+            // capital vice (Bloodshed) drives disorder to its limit
+        }
+
+        [Fact]
+        public void MicahWaitsForGodHisSaviorWhoWillBringHimToTheLight_IsRighteous()
+        {
+            // "I will look unto the LORD; I will wait for the God of my salvation: my God will hear me." (Micah 7:7)
+            // Amid the darkness the prophet trusts and waits for God, confident his Savior will bring him to light.
+            OracleHarness.Righteous(OracleHarness.Witness("Micah waits in trust for the LORD, the God of his salvation, who will hear him and bring him to the light",
+                new Trust(), new Endurance(), new Worship(),
+                new CourageousFaith(), new Patience()));
+        }
+
+        [Fact]
+        public void GodPardonsIniquityAndCastsAllSinsIntoTheDepthsOfTheSea_IsADivineAct()
+        {
+            // "Who is a God like unto thee, that pardoneth iniquity ... he will subdue our iniquities; ... cast all their sins into the depths of the sea." (Micah 7:18-19)
+            // Delighting in mercy, God forgives His people's sin and drowns their iniquities in the sea forever.
+            OracleHarness.DivineAct(OracleHarness.Witness("God pardons iniquity, delights in mercy, and casts all the sins of His people into the depths of the sea",
+                new Pardon(), new Forgiveness(), new Compassion(),
+                new CovenantFaithfulness(), new Fidelity()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/MinorProphetsOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/MinorProphetsOracleTests.cs
@@ -1,0 +1,108 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 33-44: the Twelve (Hosea through Malachi).
+    public class MinorProphetsOracleTests
+    {
+        [Fact]
+        public void Hosea_IDesireMercyNotSacrifice_IsADivineAct()
+        {
+            // "I desire mercy, not sacrifice." (Hosea 6:6) God's redeeming love for the unfaithful.
+            OracleHarness.DivineAct(OracleHarness.Witness("I desire mercy", new Compassion(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void Amos_TramplingThePoor_IsSin()
+        {
+            // "They trample on the heads of the poor." (Amos 2:7)
+            OracleHarness.Sin(OracleHarness.Witness("trampling the poor", new Oppression(), new Greed()));
+        }
+
+        [Fact]
+        public void Amos_LetJusticeRollOn_IsRighteous()
+        {
+            // "Let justice roll on like a river." (Amos 5:24)
+            OracleHarness.Righteous(OracleHarness.Witness("let justice roll", new JustRecompense(), new DefendingTheWeak()));
+        }
+
+        [Fact]
+        public void Micah_ActJustlyLoveMercyWalkHumbly_IsRighteous()
+        {
+            // "Act justly, love mercy, walk humbly with your God." (Micah 6:8) The whole of God's
+            // character in one calling.
+            OracleHarness.Righteous(OracleHarness.Witness("act justly, love mercy, walk humbly",
+                new JustRecompense(), new Compassion(), new Humility()));
+        }
+
+        [Fact]
+        public void Joel_ReturnToTheGraciousGod_IsRighteous()
+        {
+            // "Return to me ... for he is gracious and compassionate." (Joel 2:13)
+            OracleHarness.Righteous(OracleHarness.Witness("return to the LORD", new Repentance(), new Humility()));
+        }
+
+        [Fact]
+        public void Obadiah_GloatingOverABrothersFall_IsSin()
+        {
+            // Edom gloats and joins in the violence against Jacob (Obadiah 10-14).
+            OracleHarness.Sin(OracleHarness.Witness("Edom gloats over Jacob", new DelightingInEvil(), new Wrongdoing()));
+        }
+
+        [Fact]
+        public void Jonah_GodsMercyToTheRepentantEnemyCity_IsADivineAct()
+        {
+            // God spares Nineveh when it repents, to Jonah's displeasure (Jonah 3-4).
+            OracleHarness.DivineAct(OracleHarness.Witness("God spares Nineveh", new Compassion(), new Pardon()));
+        }
+
+        [Fact]
+        public void Nahum_NinevehsBloodshed_IsGraveSin()
+        {
+            // "Woe to the city of blood." (Nahum 3:1)
+            Resolution r = OracleHarness.Witness("the city of blood", new Bloodshed(), new Oppression());
+
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void Habakkuk_TheRighteousLiveByFaith_IsRighteous()
+        {
+            // "The righteous person will live by his faithfulness." (Habakkuk 2:4)
+            OracleHarness.Righteous(OracleHarness.Witness("the righteous live by faith", new Trust()));
+        }
+
+        [Fact]
+        public void Zephaniah_GodRejoicesOverHisPeople_IsADivineAct()
+        {
+            // "He will rejoice over you with singing." (Zephaniah 3:17)
+            OracleHarness.DivineAct(OracleHarness.Witness("God rejoices over His people", new Compassion(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void Haggai_RebuildTheHousePutGodFirst_IsRighteous()
+        {
+            // "Give careful thought to your ways ... build the house." (Haggai 1:7-8)
+            OracleHarness.Righteous(OracleHarness.Witness("rebuild the LORD's house", new Worship(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void Zechariah_TrueJusticeAndMercy_IsRighteous()
+        {
+            // "Administer true justice; show mercy and compassion to one another." (Zechariah 7:9)
+            OracleHarness.Righteous(OracleHarness.Witness("true justice and mercy", new JustRecompense(), new Compassion()));
+        }
+
+        [Fact]
+        public void Malachi_BreakingFaithWithTheWifeOfYouth_IsSin()
+        {
+            // "Do not break faith ... I hate divorce." (Malachi 2:14-16) Covenant treachery.
+            OracleHarness.Sin(OracleHarness.Witness("breaking faith with the wife of youth", new Treachery(), new Adultery()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/MysteriesOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/MysteriesOracleTests.cs
@@ -1,0 +1,63 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-12
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    /// <summary>
+    /// Closes the "events and sacraments" gap. These are not moral virtues or sins but holy mysteries
+    /// in which the whole character of God is present; each reads as a perfectly coherent divine act.
+    /// </summary>
+    public class MysteriesOracleTests
+    {
+        [Fact]
+        public void TheIncarnation_IsFullyDivine()
+        {
+            OracleHarness.FullyDivine(OracleHarness.Witness("the Word became flesh", new Incarnation()));
+        }
+
+        [Fact]
+        public void TheResurrection_IsFullyDivine()
+        {
+            OracleHarness.FullyDivine(OracleHarness.Witness("raised on the third day", new Resurrection()));
+        }
+
+        [Fact]
+        public void TheTransfiguration_IsFullyDivine()
+        {
+            OracleHarness.FullyDivine(OracleHarness.Witness("his face shone like the sun", new Transfiguration()));
+        }
+
+        [Fact]
+        public void Pentecost_IsFullyDivine()
+        {
+            OracleHarness.FullyDivine(OracleHarness.Witness("filled with the Holy Spirit", new Pentecost()));
+        }
+
+        [Fact]
+        public void TheEucharist_IsADivineMystery()
+        {
+            OracleHarness.DivineAct(OracleHarness.Witness("this is my body, given for you", new Eucharist()));
+        }
+
+        [Fact]
+        public void Baptism_IsADivineMystery()
+        {
+            OracleHarness.DivineAct(OracleHarness.Witness("baptized into the Triune name", new Baptism()));
+        }
+
+        [Fact]
+        public void Ordination_IsADivineMystery()
+        {
+            OracleHarness.DivineAct(OracleHarness.Witness("the laying on of hands", new Ordination()));
+        }
+
+        [Fact]
+        public void TheNewCreation_IsFullyDivine()
+        {
+            OracleHarness.FullyDivine(OracleHarness.Witness("making everything new", new NewCreation()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/NahumNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/NahumNarrativeTests.cs
@@ -1,0 +1,110 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Nahum narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class NahumNarrativeTests
+    {
+        [Fact]
+        public void TheLordIsAvengingAndSlowToAngerYetGreatInPower_IsADivineAct()
+        {
+            // The LORD is a jealous and avenging God; the LORD is slow to anger and great in power, and will not acquit the guilty (Nahum 1:2-3).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD avenges, yet is slow to anger and great in power, and by no means clears the guilty",
+                new JustRecompense(), new Righteousness(), new Patience()));
+        }
+
+        [Fact]
+        public void TheLordRulesTheStormAndTheTremblingCreation_IsADivineAct()
+        {
+            // His way is in whirlwind and storm; He rebukes the sea, the mountains quake and the hills melt before Him (Nahum 1:3-6).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD marches in whirlwind and storm and the whole creation trembles in order before its Maker",
+                new CreationOrder(), new Righteousness()));
+        }
+
+        [Fact]
+        public void TheLordIsAGoodStrongholdToThoseWhoTrustHim_IsADivineAct()
+        {
+            // The LORD is good, a stronghold in the day of trouble; He knows those who take refuge in Him (Nahum 1:7).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD is good, a stronghold in the day of trouble, and He knows all who take refuge in Him",
+                new Goodness(), new Protection(), new Trustworthiness()));
+        }
+
+        [Fact]
+        public void TheLordMakesAFullEndOfHisEnemies_IsADivineAct()
+        {
+            // With an overflowing flood He will make a complete end of Nineveh, and pursue His enemies into darkness (Nahum 1:8-9).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD makes a complete end of His enemies and delivers His afflicted people from their grip",
+                new JustRecompense(), new Deliverance(), new Righteousness()));
+        }
+
+        [Fact]
+        public void TheWickedCounselorOfNinevehPlotsEvilAgainstTheLord_IsSin()
+        {
+            // From you, O Nineveh, came one who plotted evil against the LORD, a worthless counselor (Nahum 1:11).
+            OracleHarness.Sin(OracleHarness.Witness("the worthless counselor of Nineveh devises evil schemes against the LORD",
+                new WickedScheming(), new Rebellion(), new Pride()));
+        }
+
+        [Fact]
+        public void TheLordBreaksTheYokeOffHisAfflictedPeople_IsADivineAct()
+        {
+            // Now I will break his yoke from off you and burst your bonds apart (Nahum 1:13).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD breaks the yoke of the oppressor from off His people and bursts their bonds apart",
+                new Deliverance(), new Protection(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void GoodNewsOfPeaceIsHeraldedOverTheMountains_IsRighteous()
+        {
+            // Behold, on the mountains the feet of him who brings good news, who publishes peace! Keep your feasts, O Judah (Nahum 1:15).
+            OracleHarness.Righteous(OracleHarness.Witness("the herald upon the mountains publishes good news of peace and Judah keeps her feasts and vows to the LORD",
+                new Peacemaking(), new Joy(), new Worship(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TheLordIsAgainstNinevehAndBurnsHerChariots_IsADivineAct()
+        {
+            // Behold, I am against you, declares the LORD of hosts, and I will burn your chariots in smoke (Nahum 2:13).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD of hosts sets Himself against Nineveh and burns her chariots in smoke in just judgment",
+                new JustRecompense(), new Righteousness()));
+        }
+
+        [Fact]
+        public void NinevehTheBloodyCityFullOfLiesAndPlunder_IsSin()
+        {
+            // Woe to the bloody city, all full of lies and plunder, no end to the prey! (Nahum 3:1).
+            Resolution r = OracleHarness.Witness("Nineveh, the bloody city, is full of lies and plunder with no end to her prey",
+                new Bloodshed(), new Deceit(), new Theft());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void NinevehTheHarlotEnslavesNationsBySorcery_IsSin()
+        {
+            // Because of the countless harlotries of the prostitute, who betrays nations with her whorings and peoples with her sorcery (Nahum 3:4).
+            OracleHarness.Sin(OracleHarness.Witness("Nineveh the seductive harlot betrays nations by her whoredom and enslaves peoples by her sorcery",
+                new SexualImmorality(), new Sorcery(), new Deceit()));
+        }
+
+        [Fact]
+        public void TheLordIsAgainstTheHarlotCityAndExposesHerShame_IsADivineAct()
+        {
+            // Behold, I am against you, declares the LORD of hosts, and will lift up your skirts over your face (Nahum 3:5-7).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD of hosts judges the harlot city, uncovers her shame, and recompenses her evil rightly",
+                new JustRecompense(), new Righteousness()));
+        }
+
+        [Fact]
+        public void TheNationsRejoiceAtTheFallOfNinevehsEndlessCruelty_IsADivineAct()
+        {
+            // All who hear the news of you clap their hands, for upon whom has not come your unceasing evil? (Nahum 3:19).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD brings Nineveh's wound past healing as the just recompense for her unceasing cruelty against all peoples",
+                new JustRecompense(), new Righteousness(), new DefendingTheWeak()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/NumbersNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/NumbersNarrativeTests.cs
@@ -1,0 +1,124 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Numbers narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class NumbersNarrativeTests
+    {
+        [Fact]
+        public void GodOrdersTheCampAndTheCensus_IsADivineAct()
+        {
+            // "The LORD spoke to Moses... 'Take a census of the whole Israelite community.'" (Numbers 1:1-2)
+            OracleHarness.DivineAct(OracleHarness.Witness("God numbers and orders Israel's camp for the journey", new CreationOrder(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TheAaronicBlessing_IsADivineAct()
+        {
+            // "The LORD bless you and keep you... and give you peace." (Numbers 6:24-26)
+            OracleHarness.DivineAct(OracleHarness.Witness("God gives the priestly blessing of peace over Israel", new Peace(), new Goodness(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void ThePeopleComplainAtTaberah_IsSin()
+        {
+            // "Now the people complained about their hardships in the hearing of the LORD." (Numbers 11:1)
+            OracleHarness.Sin(OracleHarness.Witness("Israel grumbles bitterly against the LORD at Taberah", new Ingratitude(), new Rebellion()));
+        }
+
+        [Fact]
+        public void TheRabbleCraveMeatAndDespiseManna_IsSin()
+        {
+            // "If only we had meat to eat!... we never see anything but this manna!" (Numbers 11:4-6)
+            OracleHarness.Sin(OracleHarness.Witness("the rabble crave meat and despise the LORD's manna", new Gluttony(), new Ingratitude(), new Covetousness()));
+        }
+
+        [Fact]
+        public void MiriamAndAaronSpeakAgainstMoses_IsSin()
+        {
+            // "Miriam and Aaron began to talk against Moses... 'Has the LORD spoken only through Moses?'" (Numbers 12:1-2)
+            OracleHarness.Sin(OracleHarness.Witness("Miriam and Aaron slander Moses out of jealousy", new Slander(), new Jealousy(), new Pride()));
+        }
+
+        [Fact]
+        public void MosesIntercedesForMiriamsHealing_IsRighteous()
+        {
+            // "So Moses cried out to the LORD, 'Please, God, heal her!'" (Numbers 12:13)
+            OracleHarness.Righteous(OracleHarness.Witness("Moses pleads for the healing of leprous Miriam", new Forgiveness(), new Compassion(), new Peacemaking()));
+        }
+
+        [Fact]
+        public void TheTenSpiesGiveABadReportAndInciteRebellion_IsSin()
+        {
+            // "They spread among the Israelites a bad report... and the whole assembly talked of stoning them." (Numbers 13:32; 14:2-4)
+            OracleHarness.Sin(OracleHarness.Witness("the ten faithless spies spread a bad report and the people rebel", new FalseWitness(), new Rebellion(), new Disobedience()));
+        }
+
+        [Fact]
+        public void CalebAndJoshuaTrustGodAgainstTheGiants_IsRighteous()
+        {
+            // "We should go up and take possession of the land, for we can certainly do it." (Numbers 13:30; 14:6-9)
+            OracleHarness.Righteous(OracleHarness.Witness("Caleb and Joshua trust God and urge Israel forward", new CourageousFaith(), new Trust(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void MosesIntercedesAndGodPardonsIsrael_IsADivineAct()
+        {
+            // "'I have forgiven them, as you asked.'" (Numbers 14:19-20)
+            OracleHarness.DivineAct(OracleHarness.Witness("God pardons rebellious Israel at Moses' intercession", new Pardon(), new Forgiveness(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void KorahsRebellionAgainstMosesAndAaron_IsSin()
+        {
+            // "They... rose up against Moses... 'You have gone too far!'" (Numbers 16:1-3)
+            OracleHarness.Sin(OracleHarness.Witness("Korah, Dathan and Abiram rebel against God's appointed leaders", new Rebellion(), new Pride(), new Discord()));
+        }
+
+        [Fact]
+        public void AaronStandsBetweenTheLivingAndTheDeadToStopThePlague_IsRighteous()
+        {
+            // "He stood between the living and the dead, and the plague stopped." (Numbers 16:47-48)
+            OracleHarness.Righteous(OracleHarness.Witness("Aaron makes atonement with incense and halts the plague", new Atonement(), new SelfSacrifice(), new Protection()));
+        }
+
+        [Fact]
+        public void MosesStrikesTheRockInUnbelief_IsSin()
+        {
+            // "Because you did not trust in me enough to honor me as holy... you will not bring this community into the land." (Numbers 20:10-12)
+            OracleHarness.Sin(OracleHarness.Witness("Moses strikes the rock in anger and disobedience at Meribah", new Disobedience(), new FitsOfRage()));
+        }
+
+        [Fact]
+        public void GodGivesTheBronzeSerpentForHealing_IsADivineAct()
+        {
+            // "Anyone who is bitten can look at it and live." (Numbers 21:8-9)
+            OracleHarness.DivineAct(OracleHarness.Witness("God gives the bronze serpent so the snakebitten may be healed and live", new Healing(), new RestoringLife(), new Deliverance()));
+        }
+
+        [Fact]
+        public void BalaamBlessesIsraelInsteadOfCursing_IsRighteous()
+        {
+            // "How can I curse those whom God has not cursed?... I must do only what the LORD says." (Numbers 23:8, 26)
+            OracleHarness.Righteous(OracleHarness.Witness("Balaam speaks only God's word and blesses Israel", new ObedienceToGod(), new TeachingTruth(), new Fidelity()));
+        }
+
+        [Fact]
+        public void IsraelJoinsItselfToBaalOfPeorThroughIdolatry_IsSin()
+        {
+            // "The people... began to indulge in sexual immorality... and bowed down before [the] gods." (Numbers 25:1-3)
+            OracleHarness.Sin(OracleHarness.Grounded("Israel yokes itself to Baal of Peor in immorality and idol worship", Grounding.InIdol("Baal of Peor"), new Idolatry(), new SexualImmorality(), new CovenantBreaking()));
+        }
+
+        [Fact]
+        public void TheDaughtersOfZelophehadReceiveAJustInheritance_IsADivineAct()
+        {
+            // "What Zelophehad's daughters are saying is right. You must certainly give them property as an inheritance." (Numbers 27:5-7)
+            OracleHarness.DivineAct(OracleHarness.Witness("God grants Zelophehad's daughters their just inheritance", new JustRecompense(), new Righteousness(), new DefendingTheWeak()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/NumbersOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/NumbersOracleTests.cs
@@ -1,0 +1,42 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 04: Numbers.
+    public class NumbersOracleTests
+    {
+        [Fact]
+        public void KorahsRebellion_IsSin()
+        {
+            // Korah and his company rise against the LORD's appointed order (Numbers 16).
+            OracleHarness.Sin(OracleHarness.Witness("Korah's rebellion", new Rebellion(), new Pride()));
+        }
+
+        [Fact]
+        public void TheWildernessGrumbling_IsSin()
+        {
+            // Refusing to trust God at the border of the land (Numbers 14).
+            OracleHarness.Sin(OracleHarness.Witness("the wilderness rebellion", new Disobedience(), new Rebellion()));
+        }
+
+        [Fact]
+        public void TheBronzeSerpentHealing_IsADivineAct()
+        {
+            // God provides healing for those who look in faith (Numbers 21:8-9; cf. John 3:14).
+            OracleHarness.DivineAct(OracleHarness.Witness("the bronze serpent", new Healing(), new Compassion()));
+        }
+
+        [Fact]
+        public void TheDaughtersOfZelophehad_InheritInJustice()
+        {
+            // No sons remained, so the inheritance passes to the daughters: a startling justice for
+            // women in antiquity (Numbers 27:1-11).
+            OracleHarness.Righteous(OracleHarness.Witness("the daughters of Zelophehad inherit",
+                new JustRecompense(), new HonoringTheVulnerable()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/ObadiahNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/ObadiahNarrativeTests.cs
@@ -1,0 +1,108 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Obadiah narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class ObadiahNarrativeTests
+    {
+        [Fact]
+        public void EdomTrustsItsHeightAndIsDeceivedByPride_IsSin()
+        {
+            // The pride of your heart has deceived you, you who dwell in the clefts of the rock... who say, Who will bring me down? (Obadiah 1:3).
+            Resolution r = OracleHarness.Grounded("Edom trusts in the height of its rocky strongholds and boasts in its heart that none can bring it down",
+                Grounding.InIdol("Edom's might"), new Pride(), new Boasting());
+            OracleHarness.Sin(r);
+        }
+
+        [Fact]
+        public void GodWillBringEdomDownFromTheHeights_IsADivineAct()
+        {
+            // Though you soar like the eagle and set your nest among the stars, from there I will bring you down, declares the LORD (Obadiah 1:4).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD declares He will bring proud Edom down from its lofty nest in just judgment",
+                new JustRecompense(), new Righteousness()));
+        }
+
+        [Fact]
+        public void EdomDoesViolenceToHisBrotherJacob_IsSin()
+        {
+            // Because of the violence done to your brother Jacob, shame shall cover you, and you shall be cut off forever (Obadiah 1:10).
+            Resolution r = OracleHarness.Witness("Edom does violence to his brother Jacob and sheds the blood of kindred",
+                new Bloodshed(), new Treachery(), new Oppression());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void EdomStoodAloofWhileStrangersPlunderedJerusalem_IsSin()
+        {
+            // On the day you stood aloof, while strangers carried off his wealth and cast lots for Jerusalem, you were like one of them (Obadiah 1:11).
+            Resolution r = OracleHarness.Witness("Edom stands aloof while strangers plunder Jerusalem and casts lots for the city, making himself one with the looters",
+                new Indifference(), new Heartlessness(), new Treachery());
+            OracleHarness.Sin(r);
+        }
+
+        [Fact]
+        public void EdomGloatedOverTheDayOfJudahsDisaster_IsSin()
+        {
+            // Do not gloat over your brother in the day of his misfortune, nor rejoice over Judah in the day of their ruin (Obadiah 1:12).
+            Resolution r = OracleHarness.Witness("Edom gloats over his brother Judah and rejoices over their ruin in the day of their calamity",
+                new DelightingInEvil(), new Malice(), new Boasting());
+            OracleHarness.Sin(r);
+        }
+
+        [Fact]
+        public void EdomLootedTheGoodsOfTheStrickenCity_IsSin()
+        {
+            // Do not enter the gate of My people in the day of their calamity, nor loot his wealth in the day of his disaster (Obadiah 1:13).
+            Resolution r = OracleHarness.Witness("Edom enters the gate of God's stricken people and seizes their wealth in the day of their disaster",
+                new Theft(), new Greed(), new Oppression());
+            OracleHarness.Sin(r);
+        }
+
+        [Fact]
+        public void EdomCutDownAndHandedOverTheFugitives_IsSin()
+        {
+            // Do not stand at the crossroads to cut off his fugitives, nor hand over his survivors in the day of distress (Obadiah 1:14).
+            Resolution r = OracleHarness.Witness("Edom stands at the crossroads to cut down the fugitives of Judah and hands over the survivors to the enemy",
+                new Bloodshed(), new Murder(), new Treachery());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void TheDayOfTheLordRepaysEachNationAsItHasDone_IsADivineAct()
+        {
+            // The day of the LORD is near upon all the nations; as you have done, it shall be done to you; your deeds shall return on your own head (Obadiah 1:15).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD brings the day of judgment near upon all the nations and returns each one's deeds justly upon its own head",
+                new JustRecompense(), new Righteousness()));
+        }
+
+        [Fact]
+        public void OnMountZionThereShallBeDeliveranceAndHoliness_IsADivineAct()
+        {
+            // But on Mount Zion there shall be those who escape, and it shall be holy, and the house of Jacob shall possess its possessions (Obadiah 1:17).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD grants deliverance and holiness on Mount Zion and restores to the house of Jacob its inheritance",
+                new Deliverance(), new Protection(), new RestoringLife(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void TheHouseOfJacobConsumesEsauAsStubble_IsADivineAct()
+        {
+            // The house of Jacob shall be a fire... and the house of Esau stubble; they shall burn and consume them, for the LORD has spoken (Obadiah 1:18).
+            OracleHarness.DivineAct(OracleHarness.Witness("by the word of the LORD the house of Jacob becomes a flame that justly consumes proud Esau like stubble, leaving no survivor",
+                new JustRecompense(), new Righteousness(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void SaviorsGoUpToMountZionAndTheKingdomIsTheLords_IsADivineAct()
+        {
+            // Saviors shall go up on Mount Zion to rule Mount Esau, and the kingdom shall be the LORD's (Obadiah 1:21).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD raises up deliverers on Mount Zion and establishes His own everlasting kingdom over all",
+                new Deliverance(), new Righteousness(), new CovenantFaithfulness(), new PromiseFulfilled()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/PhilemonNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/PhilemonNarrativeTests.cs
@@ -1,0 +1,82 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Philemon narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class PhilemonNarrativeTests
+    {
+        [Fact]
+        public void PaulThanksGodForPhilemonsLoveAndFaith_IsRighteous()
+        {
+            // "I always thank my God ... because I hear of your love and of your faith toward the Lord Jesus and all the saints." (Philemon 4-5)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul gives thanks for Philemon's love and faith toward the Lord and the saints", new Fidelity(), new Kindness(), new Worship()));
+        }
+
+        [Fact]
+        public void PhilemonRefreshesTheHeartsOfTheSaints_IsRighteous()
+        {
+            // "the hearts of the saints have been refreshed through you, brother." (Philemon 7)
+            OracleHarness.Righteous(OracleHarness.Witness("Philemon refreshes the hearts of the saints by his love", new Kindness(), new Generosity(), new Compassion()));
+        }
+
+        [Fact]
+        public void PaulAppealsForLovesSakeRatherThanCommanding_IsRighteous()
+        {
+            // "though I am bold enough in Christ to command you ... yet for love's sake I prefer to appeal to you." (Philemon 8-9)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul appeals out of love and humility instead of issuing a command", new Humility(), new Kindness(), new Gentleness()));
+        }
+
+        [Fact]
+        public void PaulPleadsForOnesimusHisChildInPrison_IsRighteous()
+        {
+            // "I appeal to you for my child, Onesimus, whose father I became in my imprisonment." (Philemon 10)
+            OracleHarness.Righteous(OracleHarness.Witness("the imprisoned Paul pleads on behalf of Onesimus, begotten in his chains", new Compassion(), new DefendingTheWeak(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void PaulSendsBackOnesimusThoughItCostsHisOwnHeart_IsRighteous()
+        {
+            // "I am sending him back to you, sending my very heart." (Philemon 12)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul sends Onesimus back though he is his very heart, doing what is right", new SelfSacrifice(), new Righteousness(), new Trustworthiness()));
+        }
+
+        [Fact]
+        public void PaulRefusesToActWithoutPhilemonsConsent_IsRighteous()
+        {
+            // "I preferred to do nothing without your consent ... not by compulsion but of your own accord." (Philemon 14)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul does nothing without Philemon's free consent, refusing to compel goodness", new Patience(), new Goodness(), new Gentleness()));
+        }
+
+        [Fact]
+        public void OnesimusIsToBeReceivedNoLongerAsSlaveButBelovedBrother_IsRighteous()
+        {
+            // "no longer as a bondservant but ... as a beloved brother." (Philemon 16)
+            OracleHarness.Righteous(OracleHarness.Witness("Onesimus is welcomed no longer as a slave but as a beloved brother", new Kindness(), new HonoringTheVulnerable(), new Peacemaking()));
+        }
+
+        [Fact]
+        public void PaulAsksPhilemonToReceiveOnesimusAsHeWouldPaul_IsRighteous()
+        {
+            // "if you consider me your partner, receive him as you would receive me." (Philemon 17)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul asks Philemon to receive Onesimus with welcome as he would welcome Paul", new Hospitality(), new Kindness(), new Forgiveness()));
+        }
+
+        [Fact]
+        public void PaulOffersToRepayWhateverOnesimusOwes_IsRighteous()
+        {
+            // "If he has wronged you ... charge that to my account. I, Paul, will repay it." (Philemon 18-19)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul takes Onesimus's debt upon himself and pledges to repay it", new SelfSacrifice(), new JustRecompense(), new Atonement()));
+        }
+
+        [Fact]
+        public void PaulIsConfidentOfPhilemonsObedience_IsRighteous()
+        {
+            // "Confident of your obedience, I write to you, knowing that you will do even more than I say." (Philemon 21)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul is confident Philemon will obey and do even more than asked", new ObedienceToGod(), new Trust(), new Goodness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/PhilippiansNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/PhilippiansNarrativeTests.cs
@@ -1,0 +1,124 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Philippians narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class PhilippiansNarrativeTests
+    {
+        [Fact]
+        public void PaulThanksGodForThePhilippiansPartnershipInTheGospel_IsRighteous()
+        {
+            // "I thank my God ... because of your partnership in the gospel." (Philippians 1:3-5)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul gives thanks for the Philippian partnership", new Joy(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodBeganAGoodWorkAndWillCompleteIt_IsADivineAct()
+        {
+            // "He who began a good work in you will carry it on to completion." (Philippians 1:6)
+            OracleHarness.DivineAct(OracleHarness.Witness("God carries the good work to completion", new PromiseFulfilled(), new Fidelity()));
+        }
+
+        [Fact]
+        public void PaulRejoicesThatChristIsPreachedEvenFromSelfishAmbition_IsRighteous()
+        {
+            // "Whether from false motives or true, Christ is preached. And because of this I rejoice." (Philippians 1:18)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul rejoices that Christ is proclaimed", new Joy(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void SomePreachChristOutOfEnvyAndRivalry_IsSin()
+        {
+            // "Some preach Christ out of envy and rivalry ... out of selfish ambition." (Philippians 1:15-17)
+            OracleHarness.Sin(OracleHarness.Witness("rivals preach from envy and ambition", new Envy(), new SelfishAmbition()));
+        }
+
+        [Fact]
+        public void ChristEmptiedHimselfTakingTheFormOfAServant_IsADivineAct()
+        {
+            // "He made himself nothing, taking the very nature of a servant." (Philippians 2:6-7)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ empties himself and takes the servant's form", new Humility(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void ChristHumbledHimselfObedientToDeathOnACross_IsADivineAct()
+        {
+            // "He humbled himself by becoming obedient to death, even death on a cross." (Philippians 2:8)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ obeys unto death on the cross", new ObedienceToGod(), new Humility(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void DoNothingFromSelfishAmbitionButInHumilityCountOthersBetter_IsRighteous()
+        {
+            // "In humility value others above yourselves." (Philippians 2:3-4)
+            OracleHarness.Righteous(OracleHarness.Witness("the saints count others better than themselves", new Humility(), new Kindness()));
+        }
+
+        [Fact]
+        public void TimothyGenuinelyCaresForTheWelfareOfThePhilippians_IsRighteous()
+        {
+            // "I have no one else like him, who will show genuine concern for your welfare." (Philippians 2:20-22)
+            OracleHarness.Righteous(OracleHarness.Witness("Timothy serves with genuine care for the church", new Compassion(), new Fidelity()));
+        }
+
+        [Fact]
+        public void EpaphroditusRisksHisLifeToCompleteTheirService_IsRighteous()
+        {
+            // "He almost died for the work of Christ, risking his life." (Philippians 2:25-30)
+            OracleHarness.Righteous(OracleHarness.Witness("Epaphroditus risks his life to minister to Paul", new SelfSacrifice(), new Fidelity()));
+        }
+
+        [Fact]
+        public void BewareTheDogsTheEvildoersWhoMutilateTheFlesh_IsSin()
+        {
+            // "Watch out for those dogs, those evildoers, those mutilators of the flesh." (Philippians 3:2)
+            OracleHarness.Sin(OracleHarness.Witness("the false teachers do evil and mutilate the flesh", new Wrongdoing(), new Deceit()));
+        }
+
+        [Fact]
+        public void PaulCountsAllThingsLossForTheSakeOfChrist_IsRighteous()
+        {
+            // "I consider everything a loss because of the surpassing worth of knowing Christ." (Philippians 3:7-8)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul counts all things loss to gain Christ", new SelfSacrifice(), new Worship()));
+        }
+
+        [Fact]
+        public void EnemiesOfTheCrossWhoseGodIsTheirBelly_IsSin()
+        {
+            // "Their god is their stomach ... their mind is set on earthly things." (Philippians 3:18-19)
+            OracleHarness.Sin(OracleHarness.Grounded("the enemies of the cross worship the belly", Grounding.InIdol("their belly"), new Gluttony(), new Idolatry()));
+        }
+
+        [Fact]
+        public void RejoiceInTheLordAlwaysWithGentlenessAndPrayer_IsRighteous()
+        {
+            // "Rejoice in the Lord always ... Let your gentleness be evident to all." (Philippians 4:4-6)
+            OracleHarness.Righteous(OracleHarness.Witness("the saints rejoice and show gentleness to all", new Joy(), new Gentleness(), new Peace()));
+        }
+
+        [Fact]
+        public void PaulHasLearnedTheSecretOfContentmentInEveryCircumstance_IsRighteous()
+        {
+            // "I have learned to be content whatever the circumstances." (Philippians 4:11-13)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul learns contentment in want and plenty", new SelfControl(), new Endurance()));
+        }
+
+        [Fact]
+        public void ThePhilippiansSendAGiftToPaulsNeed_IsRighteous()
+        {
+            // "It was good of you to share in my troubles ... the gifts you sent." (Philippians 4:14-18)
+            OracleHarness.Righteous(OracleHarness.Witness("the Philippians send a generous gift to Paul", new Generosity(), new Compassion()));
+        }
+
+        [Fact]
+        public void GodWillSupplyEveryNeedAccordingToHisRiches_IsADivineAct()
+        {
+            // "My God will meet all your needs according to the riches of his glory." (Philippians 4:19)
+            OracleHarness.DivineAct(OracleHarness.Witness("God supplies every need of his people", new Generosity(), new PromiseFulfilled()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/PrecisionOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/PrecisionOracleTests.cs
@@ -1,0 +1,105 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-12
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    /// <summary>
+    /// Closes the "coarse assertions" gap: the bulk of the oracle suite only checks which side of
+    /// 0.5 a verdict falls on. These tests pin the EXACT coherence, disorder, and per-facet readings
+    /// for landmark cases, so any drift in the engine's arithmetic fails loudly here rather than
+    /// hiding behind a forgiving threshold.
+    /// </summary>
+    public class PrecisionOracleTests
+    {
+        [Fact]
+        public void TheCross_IsExactlyOneCoherence_ZeroDisorder_AllFacetsFull()
+        {
+            Resolution r = OracleHarness.Witness("the cross",
+                new SelfSacrifice(), new Atonement(), new Pardon(), new CovenantFaithfulness());
+
+            OracleHarness.FullyDivine(r);
+            OracleHarness.Facet(r, "Love", 1.0);
+            OracleHarness.Facet(r, "Justice", 1.0);
+            OracleHarness.Facet(r, "Mercy", 1.0);
+            OracleHarness.Facet(r, "Faithfulness", 1.0);
+        }
+
+        [Fact]
+        public void Micah68_ActJustlyLoveMercyWalkHumbly_IsExactlyFullyCoherent()
+        {
+            // Justice, mercy, and humility together touch every facet of God's character at once.
+            Resolution r = OracleHarness.Witness("act justly, love mercy, walk humbly",
+                new JustRecompense(), new Compassion(), new Humility());
+
+            OracleHarness.Exact(r, 1.0, 0.0);
+        }
+
+        [Fact]
+        public void Murder_IsExactly_Quarter_Coherence_FullDisorder()
+        {
+            // Offends Justice and Love (0,0), leaves Mercy and Order neutral (0.5): mean 0.25.
+            // Capital gravity drives disorder to 1.0.
+            OracleHarness.Exact(OracleHarness.Witness("murder", new Murder()), 0.25, 1.0);
+        }
+
+        [Fact]
+        public void Theft_IsExactly_ThreeEighths_Coherence_HalfDisorder()
+        {
+            // Offends Justice only (0), three facets neutral: mean 0.375. Serious gravity: disorder 0.5.
+            OracleHarness.Exact(OracleHarness.Witness("theft", new Theft()), 0.375, 0.5);
+        }
+
+        [Fact]
+        public void Rudeness_IsExactly_ThreeEighths_Coherence_QuarterDisorder()
+        {
+            // Offends Love only (0): mean 0.375. Minor gravity: disorder only 0.25, far below murder.
+            OracleHarness.Exact(OracleHarness.Witness("a rude word", new Rudeness()), 0.375, 0.25);
+        }
+
+        [Fact]
+        public void GravedSinsAreStrictlyOrdered_RudenessLessThanTheftLessThanMurder()
+        {
+            // Scripture grades sin: the disorder each unleashes is strictly ordered, not flat.
+            double rudeness = OracleHarness.Witness("rude", new Rudeness()).Disorder;
+            double theft = OracleHarness.Witness("theft", new Theft()).Disorder;
+            double murder = OracleHarness.Witness("murder", new Murder()).Disorder;
+
+            Assert.True(rudeness < theft);
+            Assert.True(theft < murder);
+            Assert.Equal(1.0, murder);
+        }
+
+        [Fact]
+        public void TheGoodSamaritan_ReadsLoveAndMercyExactlyFull()
+        {
+            Resolution r = OracleHarness.Witness("the Good Samaritan", new Compassion(), new Protection());
+
+            OracleHarness.Exact(r, 0.75, 0.0);
+            OracleHarness.Facet(r, "Love", 1.0);
+            OracleHarness.Facet(r, "Mercy", 1.0);
+            OracleHarness.Facet(r, "Justice", 0.5);
+        }
+
+        [Fact]
+        public void AnIndifferentAct_SitsExactlyNeutral()
+        {
+            // No moral concept at all: every facet neutral, nothing destabilized.
+            OracleHarness.Exact(OracleHarness.Witness("watching a sunset"), 0.5, 0.0);
+        }
+
+        [Fact]
+        public void IdolGrounding_HalvesCoherence_AndFloorsDisorderAtHalf()
+        {
+            // The same right act of worship, borne on a dead idol, drifts toward non-being (1 Meqabyan).
+            Resolution onGod = OracleHarness.Grounded("worship", Grounding.InGod(), new Worship());
+            Resolution onIdol = OracleHarness.Grounded("worship", Grounding.InIdol("a dead idol"), new Worship());
+
+            Assert.Equal(0.0, onGod.Disorder);
+            Assert.Equal(onGod.Coherence * 0.5, onIdol.Coherence);
+            Assert.Equal(0.5, onIdol.Disorder);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/ProverbsNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/ProverbsNarrativeTests.cs
@@ -1,0 +1,153 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Proverbs narrative oracle: the engine must return the verdict Scripture gives at each teaching.
+    public class ProverbsNarrativeTests
+    {
+        [Fact]
+        public void TheLordByWisdomFoundedTheEarth_IsADivineAct()
+        {
+            // "The LORD by wisdom founded the earth; by understanding he established the heavens." (Proverbs 3:19-20)
+            // God's own ordering of creation by wisdom.
+            OracleHarness.DivineAct(OracleHarness.Witness("The LORD founds the earth by wisdom",
+                new CreationOrder(), new Goodness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void WisdomWasBesideGodAtCreationAsMasterCraftsman_IsADivineAct()
+        {
+            // "When he established the heavens, I was there ... then I was beside him, like a master workman." (Proverbs 8:27-30)
+            // Wisdom rejoicing in the truth of God's good creative order.
+            OracleHarness.DivineAct(OracleHarness.Witness("Wisdom is beside God ordering creation",
+                new CreationOrder(), new RejoicingInTruth(), new Joy(), new Goodness()));
+        }
+
+        [Fact]
+        public void TrustingTheLordWithAllYourHeart_IsRighteous()
+        {
+            // "Trust in the LORD with all your heart, and do not lean on your own understanding." (Proverbs 3:5-7)
+            // The fear of the LORD that turns from evil and trusts him wholly.
+            OracleHarness.Righteous(OracleHarness.Witness("Trust in the LORD and not your own understanding",
+                new Trust(), new Humility(), new ObedienceToGod(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GenerosityToThePoorLendsToTheLord_IsRighteous()
+        {
+            // "Whoever is generous to the poor lends to the LORD." (Proverbs 19:17; 22:9; 14:31)
+            // Honoring the Maker by feeding and caring for the needy.
+            OracleHarness.Righteous(OracleHarness.Witness("The wise are generous and give bread to the poor",
+                new Generosity(), new FeedingTheHungry(), new HonoringTheVulnerable(), new Compassion()));
+        }
+
+        [Fact]
+        public void RescuingThoseBeingLedAwayToDeath_IsRighteous()
+        {
+            // "Rescue those who are being taken away to death." (Proverbs 24:11-12)
+            // Defending and delivering the helpless from destruction.
+            OracleHarness.Righteous(OracleHarness.Witness("Deliver those being dragged to death",
+                new Deliverance(), new DefendingTheWeak(), new Protection(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void OpeningYourMouthForTheRightsOfTheNeedy_IsRighteous()
+        {
+            // "Open your mouth, judge righteously, defend the rights of the poor and needy." (Proverbs 31:8-9)
+            // The royal charge to plead for the destitute.
+            OracleHarness.Righteous(OracleHarness.Witness("Speak up and judge righteously for the needy",
+                new Righteousness(), new DefendingTheWeak(), new JustRecompense(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void TheVirtuousWomanFeedsAndClothesHerHousehold_IsRighteous()
+        {
+            // "She opens her hand to the poor ... her household are clothed in scarlet." (Proverbs 31:20-21,30)
+            // Diligent, God-fearing labor that feeds, clothes, and serves.
+            OracleHarness.Righteous(OracleHarness.Witness("The excellent wife provides for her household and the poor",
+                new Generosity(), new FeedingTheHungry(), new ClothingTheNaked(),
+                new Endurance(), new Trustworthiness(), new Compassion()));
+        }
+
+        [Fact]
+        public void TheGentleAnswerThatTurnsAwayWrath_IsRighteous()
+        {
+            // "A soft answer turns away wrath, but a harsh word stirs up anger." (Proverbs 15:1; 16:32)
+            // The patient, self-controlled tongue that makes peace.
+            OracleHarness.Righteous(OracleHarness.Witness("A soft answer turns away wrath",
+                new Gentleness(), new SelfControl(), new Patience(), new Peacemaking()));
+        }
+
+        [Fact]
+        public void FeedingYourEnemyWhoIsHungry_IsRighteous()
+        {
+            // "If your enemy is hungry, give him bread to eat; and if he is thirsty, give him water." (Proverbs 25:21-22)
+            // Mercy that overcomes evil with good toward an enemy.
+            OracleHarness.Righteous(OracleHarness.Witness("Give your hungry enemy bread and your thirsty enemy water",
+                new FeedingTheHungry(), new GivingDrink(), new Kindness(), new Forgiveness()));
+        }
+
+        [Fact]
+        public void TheSevenThingsTheLordHates_AreSin()
+        {
+            // "There are six things the LORD hates ... haughty eyes, a lying tongue, hands that shed innocent
+            // blood, a heart that devises wicked plans ... a false witness, one who sows discord." (Proverbs 6:16-19)
+            OracleHarness.Sin(OracleHarness.Witness("The things the LORD hates: pride, lies, bloodshed, scheming, discord",
+                new HaughtyEyes(), new Deceit(), new Bloodshed(), new WickedScheming(),
+                new FalseWitness(), new SowingDiscord()));
+            // Bloodshed is a capital vice and drives disorder to its limit.
+            Assert.Equal(1.0, OracleHarness.Witness("The things the LORD hates",
+                new HaughtyEyes(), new Deceit(), new Bloodshed(), new WickedScheming(),
+                new FalseWitness(), new SowingDiscord()).Disorder);
+        }
+
+        [Fact]
+        public void PrideGoesBeforeDestruction_IsSin()
+        {
+            // "Pride goes before destruction, and a haughty spirit before a fall." (Proverbs 16:18; 11:2)
+            // The arrogance the LORD abhors and that brings ruin.
+            OracleHarness.Sin(OracleHarness.Witness("Pride and a haughty spirit before the fall",
+                new Pride(), new HaughtyEyes(), new Boasting()));
+        }
+
+        [Fact]
+        public void TheAdulteressLeadsToDeath_IsSin()
+        {
+            // "Her house sinks down to death ... none who go to her come back." (Proverbs 5:3-5; 7:21-27)
+            // The seductress whose path is sexual immorality leading to Sheol.
+            OracleHarness.Sin(OracleHarness.Witness("The forbidden woman lures the simple to her bed of death",
+                new Adultery(), new SexualImmorality(), new Deceit(), new Lust()));
+        }
+
+        [Fact]
+        public void TheSluggardWhoWillNotPlow_IsSin()
+        {
+            // "The sluggard does not plow in the autumn; he will seek at harvest and have nothing." (Proverbs 20:4; 6:9-11)
+            // Slothful refusal of labor that ends in poverty.
+            OracleHarness.Sin(OracleHarness.Witness("The sluggard refuses to plow and falls into want",
+                new Sloth(), new Indifference()));
+        }
+
+        [Fact]
+        public void WineIsAMockerAndDrunkardsComeToPoverty_IsSin()
+        {
+            // "Wine is a mocker, strong drink a brawler ... the drunkard and the glutton will come to poverty." (Proverbs 20:1; 23:20-21,29-35)
+            // Drunkenness and gluttony that bring woe, sorrow, and ruin.
+            OracleHarness.Sin(OracleHarness.Witness("Drunkenness and gluttony bring woe and poverty",
+                new Drunkenness(), new Gluttony(), new Carousing()));
+        }
+
+        [Fact]
+        public void DishonestScalesAndUnjustGain_AreSin()
+        {
+            // "A false balance is an abomination to the LORD ... unequal weights are an abomination." (Proverbs 11:1; 20:10,23; 1:10-19)
+            // Deceitful greed and robbery that the LORD detests.
+            OracleHarness.Sin(OracleHarness.Witness("False balances and ill-gotten gain that ambush blood",
+                new Deceit(), new Greed(), new Theft(), new Oppression()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/ProverbsOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/ProverbsOracleTests.cs
@@ -1,0 +1,36 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 24: Proverbs.
+    public class ProverbsOracleTests
+    {
+        [Fact]
+        public void TheFearOfTheLordIsTheBeginningOfWisdom_IsRighteous()
+        {
+            // "The fear of the LORD is the beginning of knowledge." (Proverbs 1:7; 9:10)
+            OracleHarness.Righteous(OracleHarness.Witness("the fear of the LORD", new Humility(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TheSevenThingsTheLordHates_AreGraveSin()
+        {
+            // Haughty eyes, a lying tongue, and hands that shed innocent blood (Proverbs 6:16-19).
+            Resolution r = OracleHarness.Witness("the things the LORD hates", new Bloodshed(), new Pride(), new Deceit());
+
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void KindnessToThePoor_IsRighteous()
+        {
+            // "Whoever is kind to the poor lends to the LORD." (Proverbs 19:17)
+            OracleHarness.Righteous(OracleHarness.Witness("kindness to the poor", new Generosity()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/PsalmsNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/PsalmsNarrativeTests.cs
@@ -1,0 +1,114 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Psalms narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class PsalmsNarrativeTests
+    {
+        [Fact]
+        public void TheBlessedManDelightsInTheLaw_IsRighteous()
+        {
+            // "Blessed is the man... his delight is in the law of the LORD." (Psalm 1:1-2)
+            OracleHarness.Righteous(OracleHarness.Witness("the righteous one meditates on God's law day and night", new ObedienceToGod(), new Righteousness()));
+        }
+
+        [Fact]
+        public void TheLordReignsAndSetsHisKing_IsADivineAct()
+        {
+            // "I have set my king on Zion, my holy hill." (Psalm 2:6) God establishes His ordained order.
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD enthrones His Anointed One", new CreationOrder(), new Righteousness()));
+        }
+
+        [Fact]
+        public void TheLordIsTheShepherdWhoLeadsAndProvides_IsADivineAct()
+        {
+            // "The LORD is my shepherd; I shall not want." (Psalm 23) God guides, feeds, and protects.
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD shepherds His people", new Protection(), new Compassion(), new Goodness()));
+        }
+
+        [Fact]
+        public void TheKingOfGloryAndCreatorOfTheEarth_IsADivineAct()
+        {
+            // "The earth is the LORD's, and the fulness thereof." (Psalm 24:1) God's ownership of creation's order.
+            OracleHarness.DivineAct(OracleHarness.Witness("the King of Glory who founded the earth on the seas", new CreationOrder()));
+        }
+
+        [Fact]
+        public void DavidsConfessionAfterBathsheba_IsRighteous()
+        {
+            // "Have mercy upon me, O God... wash me throughly from mine iniquity." (Psalm 51) The penitent turns back.
+            OracleHarness.Righteous(OracleHarness.Witness("David confesses his sin and pleads for a clean heart", new Repentance(), new Humility(), new Purity()));
+        }
+
+        [Fact]
+        public void DavidsAdulteryAndMurderOfUriah_IsSin()
+        {
+            // The very sin Psalm 51 laments: David's adultery with Bathsheba and killing of Uriah (Psalm 51 title; 2 Sam 11).
+            Resolution r = OracleHarness.Witness("David takes Bathsheba and has Uriah killed", new Adultery(), new Murder(), new Deceit());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void GodForgivesTransgressionAndCoversSin_IsADivineAct()
+        {
+            // "Blessed is he whose transgression is forgiven, whose sin is covered." (Psalm 32:1)
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD forgives and does not impute iniquity", new Forgiveness(), new Pardon(), new Compassion()));
+        }
+
+        [Fact]
+        public void TheFoolSaysThereIsNoGodAndDoesCorruptly_IsSin()
+        {
+            // "The fool hath said in his heart, There is no God. They are corrupt..." (Psalm 14:1)
+            OracleHarness.Sin(OracleHarness.Witness("the fool denies God and works corruption", new Blasphemy(), new Wrongdoing()));
+        }
+
+        [Fact]
+        public void TheLordExecutesJusticeForTheOppressed_IsADivineAct()
+        {
+            // "The LORD executeth righteousness and judgment for all that are oppressed." (Psalm 103:6)
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD vindicates the oppressed and defends the weak", new Righteousness(), new JustRecompense(), new DefendingTheWeak()));
+        }
+
+        [Fact]
+        public void TheLordKeepsCovenantSteadfastLove_IsADivineAct()
+        {
+            // "For his mercy endureth for ever." (Psalm 136) God's enduring covenant faithfulness.
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD's steadfast love endures forever", new CovenantFaithfulness(), new Fidelity(), new Goodness()));
+        }
+
+        [Fact]
+        public void TheLordLiftsTheNeedyFromTheDust_IsADivineAct()
+        {
+            // "He raiseth up the poor out of the dust... he giveth the barren woman a house." (Psalm 113:7-9)
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD lifts the needy and seats them with princes", new Compassion(), new HonoringTheVulnerable(), new Deliverance()));
+        }
+
+        [Fact]
+        public void TheWickedPlotAgainstTheRighteousWithDeceit_IsSin()
+        {
+            // "Under his tongue is mischief and vanity... he lieth in wait to murder the innocent." (Psalm 10:7-8)
+            Resolution r = OracleHarness.Witness("the wicked lie in wait with deceit to slay the innocent", new WickedScheming(), new Deceit(), new Bloodshed(), new Oppression());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void ThePsalmistVowsWholeheartedPraise_IsRighteous()
+        {
+            // "I will praise thee, O LORD, with my whole heart." (Psalm 9:1; 150) The proper response of the creature.
+            OracleHarness.Righteous(OracleHarness.Witness("the psalmist worships God with thanksgiving and joy", new Worship(), new Joy(), new Trust()));
+        }
+
+        [Fact]
+        public void IdolsOfSilverAndGoldAreTrusted_IsSin()
+        {
+            // "Their idols are silver and gold... they that make them are like unto them." (Psalm 115:4-8) Grounding in an idol.
+            OracleHarness.Sin(OracleHarness.Grounded("the nations trust in idols of silver and gold", Grounding.InIdol("idols of silver and gold"), new Idolatry()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/PsalmsOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/PsalmsOracleTests.cs
@@ -1,0 +1,42 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 23: Psalms.
+    public class PsalmsOracleTests
+    {
+        [Fact]
+        public void GodIsRefugeAndSteadfastLove_IsADivineAct()
+        {
+            // "The LORD is my refuge ... his love endures forever." (Psalm 18; 136)
+            OracleHarness.DivineAct(OracleHarness.Witness("God my refuge", new Compassion(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TheContriteHeart_IsRighteous()
+        {
+            // "Create in me a pure heart ... a broken and contrite heart you will not despise." (Psalm 51)
+            OracleHarness.Righteous(OracleHarness.Witness("a contrite heart", new Repentance(), new Humility()));
+        }
+
+        [Fact]
+        public void RighteousnessAndPeaceKiss_IsADivineAct()
+        {
+            // "Righteousness and peace kiss each other." (Psalm 85:10) Justice and mercy meet, as at
+            // the cross.
+            OracleHarness.DivineAct(OracleHarness.Witness("righteousness and peace meet",
+                new Righteousness(), new Pardon()));
+        }
+
+        [Fact]
+        public void TheWayOfTheWicked_IsSin()
+        {
+            // "Not so the wicked ... the way of the wicked leads to destruction." (Psalm 1)
+            OracleHarness.Sin(OracleHarness.Witness("the way of the wicked", new Wrongdoing(), new Pride()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/RevelationNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/RevelationNarrativeTests.cs
@@ -1,0 +1,158 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Revelation narrative oracle (Eastern-Orthodox-accepted): the engine must return the verdict Scripture gives at each step.
+    public class RevelationNarrativeTests
+    {
+        [Fact]
+        public void ChristTheFaithfulWitnessLovesUsAndFreesUsByHisBlood_IsADivineAct()
+        {
+            // Jesus Christ, the faithful witness, loved us and freed us from our sins by His blood (Revelation 1:5).
+            OracleHarness.DivineAct(OracleHarness.Grounded("Christ the faithful witness loves us and frees us from sin by His blood",
+                Grounding.InGod(), new Fidelity(), new SelfSacrifice(), new Atonement(), new Deliverance()));
+        }
+
+        [Fact]
+        public void ChristCommendsEphesusForEnduringPatiently_IsRighteous()
+        {
+            // To Ephesus: you have endurance and have borne up for My name's sake and have not grown weary (Revelation 2:2-3).
+            OracleHarness.Righteous(OracleHarness.Witness("the church at Ephesus labors and endures patiently for Christ's name",
+                new Endurance(), new Patience(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheEnticementToEatFoodSacrificedToIdolsAndPracticeImmorality_IsSin()
+        {
+            // The teaching of Balaam and Jezebel: idolatry and sexual immorality among the churches (Revelation 2:14, 20).
+            OracleHarness.Sin(OracleHarness.Grounded("Jezebel teaches the servants to commit sexual immorality and eat food sacrificed to idols",
+                Grounding.InIdol("Jezebel"), new Idolatry(), new SexualImmorality(), new Deceit()));
+        }
+
+        [Fact]
+        public void ChristCounselsLukewarmLaodiceaToRepent_IsRighteous()
+        {
+            // Christ rebukes and disciplines those He loves; be earnest therefore and repent (Revelation 3:19).
+            OracleHarness.Righteous(OracleHarness.Witness("Laodicea is called to be earnest and repent of lukewarmness",
+                new Repentance(), new Humility(), new HungerForRighteousness()));
+        }
+
+        [Fact]
+        public void TheTwentyFourEldersWorshipHimWhoSitsOnTheThrone_IsRighteous()
+        {
+            // The elders fall down before the throne and cast their crowns, worshiping Him who lives forever (Revelation 4:10-11).
+            OracleHarness.Righteous(OracleHarness.Witness("the twenty-four elders cast down their crowns and worship the Creator",
+                new Worship(), new Humility(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void TheSlainLambIsWorthyToOpenTheScroll_IsADivineAct()
+        {
+            // Worthy is the Lamb who was slain, for by His blood He ransomed people for God (Revelation 5:9-12).
+            OracleHarness.DivineAct(OracleHarness.Grounded("the Lamb who was slain ransoms people for God by His blood",
+                Grounding.InGod(), new SelfSacrifice(), new Atonement(), new Deliverance(), new Worship()));
+        }
+
+        [Fact]
+        public void TheLambShepherdsTheRedeemedAndGodWipesAwayEveryTear_IsADivineAct()
+        {
+            // The Lamb guides them to springs of living water, and God wipes away every tear from their eyes (Revelation 7:16-17).
+            OracleHarness.DivineAct(OracleHarness.Grounded("the Lamb shepherds the redeemed and God wipes away every tear",
+                Grounding.InGod(), new Compassion(), new Protection(), new Healing(), new GivingDrink()));
+        }
+
+        [Fact]
+        public void MankindRefusesToRepentOfMurdersAndSorceriesAndThefts_IsSin()
+        {
+            // The rest of mankind did not repent of their murders, sorceries, sexual immorality, or thefts (Revelation 9:20-21).
+            OracleHarness.Sin(OracleHarness.Grounded("mankind refuses to repent of its murders, sorceries, immorality, and thefts",
+                Grounding.InIdol("demons and idols of gold and silver"),
+                new Murder(), new Sorcery(), new SexualImmorality(), new Theft(), new Idolatry()));
+            Assert.Equal(1.0, OracleHarness.Grounded("mankind refuses to repent of its murders, sorceries, immorality, and thefts",
+                Grounding.InIdol("demons and idols of gold and silver"),
+                new Murder(), new Sorcery(), new SexualImmorality(), new Theft(), new Idolatry()).Disorder);
+        }
+
+        [Fact]
+        public void TheTwoWitnessesProphesyFaithfullyUntilSlain_IsRighteous()
+        {
+            // The two witnesses prophesy in sackcloth and bear faithful testimony before they are killed (Revelation 11:3-7).
+            OracleHarness.Righteous(OracleHarness.Witness("the two witnesses bear faithful testimony and lay down their lives",
+                new TeachingTruth(), new CourageousFaith(), new Fidelity(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void TheGreatDragonDeceivesTheWholeWorldAndAccusesTheBrethren_IsSin()
+        {
+            // The great dragon, the deceiver of the whole world, accuses the brethren day and night (Revelation 12:9-10).
+            OracleHarness.Sin(OracleHarness.Grounded("the dragon deceives the whole world and accuses the brethren before God",
+                Grounding.InIdol("the great dragon, that ancient serpent"),
+                new Deceit(), new Rebellion(), new Condemnation(), new Slander()));
+        }
+
+        [Fact]
+        public void TheBeastBlasphemesGodAndMakesWarOnTheSaints_IsSin()
+        {
+            // The beast opens its mouth in blasphemy against God and is allowed to make war on the saints (Revelation 13:5-7).
+            OracleHarness.Sin(OracleHarness.Grounded("the beast blasphemes God and makes war to conquer the saints",
+                Grounding.InIdol("the beast from the sea"),
+                new Blasphemy(), new Bloodshed(), new Oppression(), new Pride()));
+            Assert.Equal(1.0, OracleHarness.Grounded("the beast blasphemes God and makes war to conquer the saints",
+                Grounding.InIdol("the beast from the sea"),
+                new Blasphemy(), new Bloodshed(), new Oppression(), new Pride()).Disorder);
+        }
+
+        [Fact]
+        public void BabylonTheGreatIntoxicatesTheNationsWithImmoralityAndLuxury_IsSin()
+        {
+            // Babylon makes the nations drunk with the wine of her immorality and lives in sensual luxury (Revelation 17:1-2; 18:3).
+            OracleHarness.Sin(OracleHarness.Grounded("Babylon the great seduces the nations into immorality, idolatry, and excess",
+                Grounding.InIdol("Babylon the great"),
+                new SexualImmorality(), new Idolatry(), new Debauchery(), new Greed()));
+        }
+
+        [Fact]
+        public void GodJudgesTheGreatHarlotWithTrueAndJustJudgments_IsADivineAct()
+        {
+            // True and just are His judgments, for He has judged the great harlot and avenged the blood of His servants (Revelation 19:1-2).
+            OracleHarness.DivineAct(OracleHarness.Grounded("God judges the great harlot with true and just judgment and avenges His servants",
+                Grounding.InGod(), new Righteousness(), new JustRecompense(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheMarriageSupperOfTheLambAndTheBrideMadeReady_IsRighteous()
+        {
+            // The Bride has made herself ready, clothed in fine linen, the righteous deeds of the saints (Revelation 19:7-8).
+            OracleHarness.Righteous(OracleHarness.Witness("the Bride of the Lamb is made ready, clothed in the righteous deeds of the saints",
+                new Purity(), new Righteousness(), new Fidelity(), new Joy()));
+        }
+
+        [Fact]
+        public void TheRiderCalledFaithfulAndTrueJudgesAndMakesWarInRighteousness_IsADivineAct()
+        {
+            // The rider on the white horse is called Faithful and True, and in righteousness He judges and makes war (Revelation 19:11).
+            OracleHarness.DivineAct(OracleHarness.Grounded("the rider called Faithful and True judges and wars in righteousness",
+                Grounding.InGod(), new Fidelity(), new Trustworthiness(), new Righteousness(), new JustRecompense()));
+        }
+
+        [Fact]
+        public void GodMakesAllThingsNewAndDwellsWithHisPeople_IsADivineAct()
+        {
+            // Behold, the dwelling of God is with man; He wipes away every tear and makes all things new (Revelation 21:3-5).
+            OracleHarness.DivineAct(OracleHarness.Grounded("God dwells with His people, wipes away every tear, and makes all things new",
+                Grounding.InGod(), new Compassion(), new Healing(), new RestoringLife(), new CovenantFaithfulness(), new Peace()));
+        }
+
+        [Fact]
+        public void TheLeavesOfTheTreeOfLifeAreForTheHealingOfTheNations_IsADivineAct()
+        {
+            // The river of the water of life and the tree of life, whose leaves are for the healing of the nations (Revelation 22:1-2).
+            OracleHarness.DivineAct(OracleHarness.Grounded("God gives the water of life and the tree whose leaves heal the nations",
+                Grounding.InGod(), new Healing(), new RestoringLife(), new Generosity(), new GivingDrink()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/RevelationOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/RevelationOracleTests.cs
@@ -1,0 +1,41 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 73: Revelation.
+    public class RevelationOracleTests
+    {
+        [Fact]
+        public void TheLambWhoWasSlain_IsADivineAct()
+        {
+            // "Worthy is the Lamb, who was slain." (Revelation 5:12)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Lamb who was slain", new SelfSacrifice(), new Atonement()));
+        }
+
+        [Fact]
+        public void TrueAndJustAreHisJudgments_IsADivineAct()
+        {
+            // "True and just are his judgments." (Revelation 19:2)
+            OracleHarness.DivineAct(OracleHarness.Witness("true and just judgments", new Righteousness(), new JustRecompense()));
+        }
+
+        [Fact]
+        public void EveryDeadJudgedFromTheBooks_IsADivineAct()
+        {
+            // "The dead were judged ... according to what they had done as recorded in the books."
+            // (Revelation 20:12) The heavenly record, the engine's HeavenlyTablets.
+            OracleHarness.DivineAct(OracleHarness.Witness("judged from the books", new JustRecompense()));
+        }
+
+        [Fact]
+        public void TheNewCreation_OrderRestored_IsADivineAct()
+        {
+            // "I am making everything new ... no more death or mourning." (Revelation 21:4-5)
+            OracleHarness.DivineAct(OracleHarness.Witness("the new creation", new CreationOrder(), new RestoringLife()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/RomansNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/RomansNarrativeTests.cs
@@ -1,0 +1,127 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Romans narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class RomansNarrativeTests
+    {
+        [Fact]
+        public void TheGospelIsTheRighteousnessOfGodRevealed_IsADivineAct()
+        {
+            // "In the gospel the righteousness of God is revealed ... 'The righteous will live by faith.'" (Romans 1:16-17)
+            OracleHarness.DivineAct(OracleHarness.Witness("the gospel reveals the righteousness of God", new Righteousness(), new TeachingTruth()));
+        }
+
+        [Fact]
+        public void HumanityExchangesTheTruthOfGodForIdols_IsSin()
+        {
+            // "They exchanged the truth about God for a lie, and worshiped ... created things." (Romans 1:23-25)
+            OracleHarness.Sin(OracleHarness.Grounded("they exchange the glory of God for idols", Grounding.InIdol("created things"), new Idolatry(), new Deceit()));
+        }
+
+        [Fact]
+        public void TheDepravedMindGivenOverToEveryWickedness_IsSin()
+        {
+            // "Filled with every kind of wickedness ... envy, murder, strife, deceit." (Romans 1:29)
+            OracleHarness.Sin(OracleHarness.Witness("the depraved mind full of wickedness", new Murder(), new Envy(), new Deceit()));
+            // Capital vice (Murder) drives disorder to its maximum.
+            Resolution r = OracleHarness.Witness("the depraved mind full of wickedness", new Murder(), new Envy(), new Deceit());
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void GodsKindnessLeadsToRepentance_IsADivineAct()
+        {
+            // "God's kindness is intended to lead you to repentance." (Romans 2:4)
+            OracleHarness.DivineAct(OracleHarness.Witness("God's kindness leads sinners to repentance", new Kindness(), new Patience()));
+        }
+
+        [Fact]
+        public void AllHaveSinnedAndFallShortOfGlory_IsSin()
+        {
+            // "There is no one righteous ... all have sinned and fall short of the glory of God." (Romans 3:10-23)
+            OracleHarness.Sin(OracleHarness.Witness("all have sinned and fall short", new Wrongdoing(), new Disobedience()));
+        }
+
+        [Fact]
+        public void TheAtonementJustAndJustifying_IsADivineAct()
+        {
+            // "Whom God put forward as a propitiation ... so as to be just and the justifier." (Romans 3:24-26)
+            OracleHarness.DivineAct(OracleHarness.Witness("God presents Christ as the atoning sacrifice", new Atonement(), new Pardon(), new Righteousness()));
+        }
+
+        [Fact]
+        public void AbrahamBelievesGodAndItIsCreditedAsRighteousness_IsRighteous()
+        {
+            // "Abraham believed God, and it was credited to him as righteousness." (Romans 4:3, 20-21)
+            OracleHarness.Righteous(OracleHarness.Grounded("Abraham trusts the promise of God", Grounding.InGod(), new Trust(), new CourageousFaith(), new Righteousness()));
+        }
+
+        [Fact]
+        public void WhileWeWereStillSinnersChristDiedForUs_IsADivineAct()
+        {
+            // "While we were still sinners, Christ died for us." (Romans 5:8)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ dies for the ungodly", new SelfSacrifice(), new Compassion(), new Atonement()));
+        }
+
+        [Fact]
+        public void PeaceWithGodThroughOurLordJesusChrist_IsADivineAct()
+        {
+            // "We have peace with God through our Lord Jesus Christ." (Romans 5:1)
+            OracleHarness.DivineAct(OracleHarness.Witness("God reconciles us, giving peace through Christ", new Peacemaking(), new Pardon()));
+        }
+
+        [Fact]
+        public void SufferingProducesPerseveranceCharacterAndHope_IsRighteous()
+        {
+            // "Suffering produces perseverance; perseverance, character; and character, hope." (Romans 5:3-4)
+            OracleHarness.Righteous(OracleHarness.Grounded("the saints endure suffering and so grow in hope", Grounding.InGod(), new Endurance(), new Patience()));
+        }
+
+        [Fact]
+        public void ThereIsNoCondemnationForThoseInChrist_IsADivineAct()
+        {
+            // "There is now no condemnation for those who are in Christ Jesus." (Romans 8:1)
+            OracleHarness.DivineAct(OracleHarness.Witness("God grants no condemnation to those in Christ", new Pardon(), new Deliverance()));
+        }
+
+        [Fact]
+        public void NothingCanSeparateUsFromTheLoveOfGod_IsADivineAct()
+        {
+            // "Neither death nor life ... will be able to separate us from the love of God." (Romans 8:38-39)
+            OracleHarness.DivineAct(OracleHarness.Witness("nothing separates us from the love of God", new CovenantFaithfulness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void OfferYourBodiesAsALivingSacrifice_IsRighteous()
+        {
+            // "Offer your bodies as a living sacrifice, holy and pleasing to God." (Romans 12:1)
+            OracleHarness.Righteous(OracleHarness.Grounded("the believer offers himself as a living sacrifice", Grounding.InGod(), new SelfSacrifice(), new Worship()));
+        }
+
+        [Fact]
+        public void DoNotRepayEvilButOvercomeEvilWithGood_IsRighteous()
+        {
+            // "Bless those who persecute you ... Do not be overcome by evil, but overcome evil with good." (Romans 12:14-21)
+            OracleHarness.Righteous(OracleHarness.Witness("repay no one evil, but overcome evil with good", new Forgiveness(), new Goodness(), new Peacemaking()));
+        }
+
+        [Fact]
+        public void LoveDoesNoHarmAndFulfillsTheLaw_IsRighteous()
+        {
+            // "Love does no harm to a neighbor. Therefore love is the fulfillment of the law." (Romans 13:8-10)
+            OracleHarness.Righteous(OracleHarness.Witness("love your neighbor and so fulfill the law", new Kindness(), new Compassion()));
+        }
+
+        [Fact]
+        public void WelcomeTheWeakInFaithWithoutPassingJudgment_IsRighteous()
+        {
+            // "Accept the one whose faith is weak, without quarreling over disputable matters." (Romans 14:1-3)
+            OracleHarness.Righteous(OracleHarness.Witness("welcome the one weak in faith", new Hospitality(), new Gentleness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/RuthNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/RuthNarrativeTests.cs
@@ -1,0 +1,113 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Ruth narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class RuthNarrativeTests
+    {
+        [Fact]
+        public void RuthClingsToNaomi_IsRighteous()
+        {
+            // "Where you go I will go ... your people shall be my people, and your God my God." (Ruth 1:16-17)
+            // Covenant-loyal love (hesed) of the Moabite widow to her bereaved mother-in-law.
+            OracleHarness.Righteous(OracleHarness.Witness("Ruth refuses to leave Naomi",
+                new CovenantFaithfulness(), new Compassion(), new SelfSacrifice(), new Fidelity()));
+        }
+
+        [Fact]
+        public void RuthForsakesHerGodsToTrustTheLordOfIsrael_IsRighteous()
+        {
+            // "Your God shall be my God." (Ruth 1:16) Ruth turns from the idols of Moab to the Lord. (Ruth 2:12)
+            // She comes "to take refuge under the wings" of the God of Israel.
+            OracleHarness.Righteous(OracleHarness.Witness("Ruth takes refuge under the wings of Israel's God",
+                new Worship(), new Trust(), new ObedienceToGod(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void NaomiBlessesHerDaughtersInLaw_IsRighteous()
+        {
+            // "May the LORD deal kindly with you, as you have dealt with the dead and with me." (Ruth 1:8-9)
+            // Naomi releases Orpah and Ruth back to their kin, blessing them with kindness.
+            OracleHarness.Righteous(OracleHarness.Witness("Naomi blesses Orpah and Ruth",
+                new Kindness(), new Generosity(), new Compassion()));
+        }
+
+        [Fact]
+        public void RuthGleansToFeedNaomi_IsRighteous()
+        {
+            // Ruth goes to glean grain to feed herself and the widow Naomi. (Ruth 2:2,18)
+            // Humble labor that feeds the hungry vulnerable.
+            OracleHarness.Righteous(OracleHarness.Witness("Ruth gleans grain for Naomi",
+                new SelfSacrifice(), new FeedingTheHungry(), new Humility(), new Endurance()));
+        }
+
+        [Fact]
+        public void BoazShowsFavorAndProtectionToTheForeignWidow_IsRighteous()
+        {
+            // Boaz lets Ruth glean, gives her drink, orders his men not to touch her. (Ruth 2:8-9,14-16)
+            // Kindness, protection, and provision to a defenseless foreign widow.
+            OracleHarness.Righteous(OracleHarness.Witness("Boaz protects and provides for Ruth in his field",
+                new Kindness(), new Protection(), new Generosity(),
+                new GivingDrink(), new HonoringTheVulnerable(), new DefendingTheWeak()));
+        }
+
+        [Fact]
+        public void BoazBlessesRuthInTheNameOfTheLord_IsRighteous()
+        {
+            // "The LORD repay you for what you have done ... under whose wings you have come to take refuge." (Ruth 2:12)
+            // Boaz commends her covenant loyalty and blesses her in God's name.
+            OracleHarness.Righteous(OracleHarness.Witness("Boaz blesses Ruth for her loyal love",
+                new Kindness(), new RejoicingInTruth(), new Worship(), new Goodness()));
+        }
+
+        [Fact]
+        public void RuthAppealsToBoazAsKinsmanRedeemerAtTheThreshingFloor_IsRighteous()
+        {
+            // "Spread your wings over your servant, for you are a redeemer." (Ruth 3:9)
+            // A chaste, faithful appeal for covenant redemption, made in trust and humility.
+            OracleHarness.Righteous(OracleHarness.Witness("Ruth asks Boaz to act as kinsman-redeemer",
+                new Humility(), new Trust(), new Purity(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void BoazPraisesRuthsKindnessAndProtectsHerHonor_IsRighteous()
+        {
+            // "This last kindness is greater than the first ... all my people know you are a worthy woman." (Ruth 3:10-14)
+            // Boaz guards her reputation and vows to do the kinsman's part.
+            OracleHarness.Righteous(OracleHarness.Witness("Boaz honors Ruth and guards her at the threshing floor",
+                new Kindness(), new Protection(), new Purity(), new SelfControl(), new Trustworthiness()));
+        }
+
+        [Fact]
+        public void BoazRedeemsTheFieldAndTakesRuthAsWife_IsRighteous()
+        {
+            // At the gate Boaz redeems Elimelech's land and takes Ruth to wife, raising up the dead man's name. (Ruth 4:9-10)
+            // Just, lawful covenant redemption of the widow and the inheritance.
+            OracleHarness.Righteous(OracleHarness.Witness("Boaz redeems the inheritance and marries Ruth",
+                new CovenantFaithfulness(), new JustRecompense(), new Righteousness(),
+                new HonoringTheVulnerable(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheLordGivesRuthConceptionAndAChild_IsADivineAct()
+        {
+            // "The LORD gave her conception, and she bore a son." (Ruth 4:13)
+            // God's own act of restoring life and fruitfulness to the household.
+            OracleHarness.DivineAct(OracleHarness.Witness("The LORD gives Ruth conception",
+                new RestoringLife(), new CreationOrder(), new Goodness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void ObedRestoresLifeToNaomiAndContinuesThePromisedLine_IsADivineAct()
+        {
+            // "He shall be to you a restorer of life ... Obed ... the father of Jesse, the father of David." (Ruth 4:15-17)
+            // God restores the widow Naomi and preserves the Davidic/Messianic line.
+            OracleHarness.DivineAct(OracleHarness.Witness("God restores Naomi's life and keeps the line of David",
+                new RestoringLife(), new CovenantFaithfulness(), new PromiseFulfilled(), new Deliverance()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/RuthOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/RuthOracleTests.cs
@@ -1,0 +1,28 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 08: Ruth.
+    public class RuthOracleTests
+    {
+        [Fact]
+        public void RuthsLoyalLoveToNaomi_IsRighteous()
+        {
+            // "Where you go I will go ... your God will be my God." (Ruth 1:16) Loyal love (hesed).
+            OracleHarness.Righteous(OracleHarness.Witness("Ruth cleaves to Naomi",
+                new Compassion(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void BoazRedeemsAndProvidesForTheWidow_IsRighteous()
+        {
+            // The kinsman-redeemer's kindness to the foreign widow (Ruth 2-4).
+            OracleHarness.Righteous(OracleHarness.Witness("Boaz redeems Ruth",
+                new Generosity(), new HonoringTheVulnerable()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/SamuelNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/SamuelNarrativeTests.cs
@@ -1,0 +1,140 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 1 & 2 Samuel narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class SamuelNarrativeTests
+    {
+        [Fact]
+        public void HannahVowsAndPraysToTheLordForASon_IsRighteous()
+        {
+            // "In her deep anguish Hannah prayed to the LORD... 'I will give him to the LORD for all the days of his life.'" (1 Samuel 1:10-11)
+            OracleHarness.Righteous(OracleHarness.Witness("Hannah pours out her soul before the LORD and vows to give her son back to Him", new Worship(), new Trust(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void GodRemembersHannahAndGivesHerSamuel_IsADivineAct()
+        {
+            // "So in the course of time Hannah became pregnant and gave birth to a son... 'Because I asked the LORD for him.'" (1 Samuel 1:19-20)
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD remembers Hannah and gives her a son, Samuel, in answer to her prayer", new Compassion(), new PromiseFulfilled(), new RestoringLife()));
+        }
+
+        [Fact]
+        public void EliSonsAbuseTheOfferingsAndLieWithTheServingWomen_IsSin()
+        {
+            // "This sin of the young men was very great in the LORD's sight... they were treating the LORD's offering with contempt." (1 Samuel 2:12-22)
+            OracleHarness.Sin(OracleHarness.Witness("Hophni and Phinehas steal the LORD's offerings by force and defile the women serving at the tent of meeting", new Theft(), new SexualImmorality(), new Blasphemy(), new Greed()));
+        }
+
+        [Fact]
+        public void GodCallsTheBoySamuelAndRevealsHisWord_IsADivineAct()
+        {
+            // "The LORD came and stood there, calling as at the other times, 'Samuel! Samuel!'" (1 Samuel 3:10-21)
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD calls the boy Samuel and reveals His word, letting none of it fall to the ground", new TeachingTruth(), new PromiseFulfilled(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void SamuelDeclaresTheWholeWordOfGodToEli_IsRighteous()
+        {
+            // "So Samuel told him everything, hiding nothing from him." (1 Samuel 3:18)
+            OracleHarness.Righteous(OracleHarness.Witness("Samuel faithfully tells Eli the LORD's whole word, hiding nothing", new TeachingTruth(), new Trustworthiness(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void GodStrikesDagonAndAfflictsThePhilistinesForTheArk_IsADivineAct()
+        {
+            // "There was Dagon, fallen on his face... his head and hands had been broken off." (1 Samuel 5:1-6)
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD topples Dagon before His ark and afflicts the Philistines until they return it", new JustRecompense(), new Deliverance(), new Righteousness()));
+        }
+
+        [Fact]
+        public void IsraelRepentsAtMizpahAndSamuelIntercedes_IsRighteous()
+        {
+            // "They... fasted and there confessed, 'We have sinned against the LORD.' ... Samuel cried out to the LORD on Israel's behalf." (1 Samuel 7:5-9)
+            OracleHarness.Righteous(OracleHarness.Witness("Israel repents and confesses its sin at Mizpah while Samuel intercedes for them before the LORD", new Repentance(), new Worship(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void GodAnointsAndDeliversByDavidAgainstGoliath_IsADivineAct()
+        {
+            // "The LORD who rescued me from the paw of the lion... will rescue me from the hand of this Philistine." (1 Samuel 17:37, 45-50)
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD delivers Goliath into David's hand so all may know there is a God in Israel", new Deliverance(), new Protection(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void DavidFightsGoliathInTheNameOfTheLord_IsRighteous()
+        {
+            // "You come against me with sword and spear... but I come against you in the name of the LORD Almighty." (1 Samuel 17:45)
+            OracleHarness.Righteous(OracleHarness.Witness("David goes out against Goliath in courageous faith, trusting the LORD to defend His people", new CourageousFaith(), new Trust(), new DefendingTheWeak()));
+        }
+
+        [Fact]
+        public void SaulHurlsHisSpearAtDavidInJealousRage_IsSin()
+        {
+            // "Saul was afraid of David... and Saul tried to pin him to the wall with his spear." (1 Samuel 18:10-11, 28-29)
+            OracleHarness.Sin(OracleHarness.Witness("Saul, eaten with jealousy, hurls his spear to murder David and hunts him through the wilderness", new Jealousy(), new Murder(), new Bloodshed(), new Hatred()));
+        }
+
+        [Fact]
+        public void DavidSparesSaulInTheCaveRefusingToHarmTheLordsAnointed_IsRighteous()
+        {
+            // "The LORD forbid that I should... lay my hand on him; for he is the anointed of the LORD." (1 Samuel 24:6-12)
+            OracleHarness.Righteous(OracleHarness.Witness("David spares Saul's life in the cave, refusing to lift his hand against the LORD's anointed", new Forgiveness(), new SelfControl(), new ObedienceToGod(), new Patience()));
+        }
+
+        [Fact]
+        public void SaulConsultsTheMediumOfEndor_IsSin()
+        {
+            // "Saul then said to his attendants, 'Find me a woman who is a medium, so I may go and inquire of her.'" (1 Samuel 28:7-19)
+            OracleHarness.Sin(OracleHarness.Grounded("Saul forsakes the LORD and consults the medium of Endor to call up the dead", Grounding.InIdol("Medium of Endor"), new Sorcery(), new Disobedience(), new Rebellion()));
+        }
+
+        [Fact]
+        public void DavidMournsSaulAndJonathanInsteadOfRejoicing_IsRighteous()
+        {
+            // "David took up this lament concerning Saul and his son Jonathan... 'How the mighty have fallen!'" (2 Samuel 1:17-27)
+            OracleHarness.Righteous(OracleHarness.Witness("David mourns and laments Saul and Jonathan rather than gloating over his enemy's fall", new Mourning(), new Kindness(), new Forgiveness()));
+        }
+
+        [Fact]
+        public void GodCovenantsToEstablishDavidsThroneForever_IsADivineAct()
+        {
+            // "Your house and your kingdom will endure forever before me; your throne will be established forever." (2 Samuel 7:11-16)
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD makes covenant with David to establish his throne and offspring forever", new CovenantFaithfulness(), new PromiseFulfilled(), new Fidelity()));
+        }
+
+        [Fact]
+        public void DavidShowsKindnessToMephiboshethForJonathansSake_IsRighteous()
+        {
+            // "I will surely show you kindness for the sake of your father Jonathan... and you will always eat at my table." (2 Samuel 9:1-13)
+            OracleHarness.Righteous(OracleHarness.Witness("David seeks out lame Mephibosheth and restores his land and a seat at the king's table for Jonathan's sake", new Kindness(), new CovenantFaithfulness(), new HonoringTheVulnerable(), new Generosity()));
+        }
+
+        [Fact]
+        public void DavidTakesBathshebaAndHasUriahKilled_IsSin()
+        {
+            // "David committed adultery with Bathsheba... and Uriah the Hittite is struck down." (2 Samuel 11:2-17)
+            Resolution r = OracleHarness.Witness("David lies with Bathsheba and then has Uriah killed at the battle front to cover it", new Adultery(), new Murder(), new Bloodshed(), new Deceit());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void DavidConfessesAndRepentsAtNathansRebuke_IsRighteous()
+        {
+            // "Then David said to Nathan, 'I have sinned against the LORD.'" (2 Samuel 12:13)
+            OracleHarness.Righteous(OracleHarness.Witness("David confesses his sin before Nathan and humbles himself before the LORD", new Repentance(), new Humility(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void AbsalomRebelsAgainstHisFatherDavid_IsSin()
+        {
+            // "Absalom... stole the hearts of the people of Israel" and rose to seize his father's throne. (2 Samuel 15:1-14, 18:14)
+            OracleHarness.Sin(OracleHarness.Witness("Absalom conspires, steals the hearts of Israel, and rises in rebellion to overthrow his father David", new Rebellion(), new Treachery(), new Deceit(), new SelfishAmbition()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/SamuelOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/SamuelOracleTests.cs
@@ -1,0 +1,51 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 09: 1 & 2 Samuel.
+    public class SamuelOracleTests
+    {
+        [Fact]
+        public void SaulsRebellion_IsSin()
+        {
+            // "Rebellion is like the sin of divination." (1 Samuel 15:23)
+            OracleHarness.Sin(OracleHarness.Witness("Saul disobeys God", new Rebellion(), new Disobedience()));
+        }
+
+        [Fact]
+        public void DavidSparesSaul_IsRighteousMercy()
+        {
+            // David will not raise his hand against the LORD's anointed (1 Samuel 24; 26).
+            OracleHarness.Righteous(OracleHarness.Witness("David spares Saul", new Pardon()));
+        }
+
+        [Fact]
+        public void DavidAndBathsheba_IsGraveSin()
+        {
+            // Adultery, then the murder of Uriah to hide it (2 Samuel 11).
+            Resolution r = OracleHarness.Witness("David takes Bathsheba and kills Uriah", new Adultery(), new Murder());
+
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void DavidsRepentance_IsRighteous()
+        {
+            // "Against you, you only, have I sinned ... a broken and contrite heart." (Psalm 51)
+            OracleHarness.Righteous(OracleHarness.Witness("David repents", new Repentance(), new Humility()));
+        }
+
+        [Fact]
+        public void GodsCovenantWithDavid_IsADivineAct()
+        {
+            // "Your house and your kingdom will endure forever." (2 Samuel 7:16)
+            OracleHarness.DivineAct(OracleHarness.Witness("the covenant with David",
+                new CovenantFaithfulness(), new PromiseFulfilled()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/SecondCorinthiansNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/SecondCorinthiansNarrativeTests.cs
@@ -1,0 +1,159 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 2 Corinthians narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class SecondCorinthiansNarrativeTests
+    {
+        [Fact]
+        public void GodComfortsThemInAllAfflictionSoTheyMayComfortOthers_IsADivineAct()
+        {
+            // "the Father of mercies, and the God of all comfort; Who comforteth us in all our tribulation,
+            //  that we may be able to comfort them which are in any trouble." (2 Corinthians 1:3-4)
+            // God is the source of all comfort, consoling His people so they can console others.
+            OracleHarness.DivineAct(OracleHarness.Witness("God the Father of mercies comforts His people in all their affliction so that they may comfort others",
+                new Compassion(), new Goodness(), new Fidelity(),
+                new Kindness(), new Healing()));
+        }
+
+        [Fact]
+        public void GodDeliveredThemFromSoGreatADeathInWhomTheyTrust_IsADivineAct()
+        {
+            // "Who delivered us from so great a death ... in whom we trust that he will yet deliver us." (2 Corinthians 1:10)
+            // God rescued Paul and his companions from deadly peril, and they rest their hope in Him for deliverance to come.
+            OracleHarness.DivineAct(OracleHarness.Witness("God delivers Paul from so great a death and they trust He will yet deliver them",
+                new Deliverance(), new Protection(), new Fidelity(),
+                new CovenantFaithfulness(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void AllGodsPromisesAreYeaAndAmenInChrist_IsADivineAct()
+        {
+            // "For all the promises of God in him are yea, and in him Amen, unto the glory of God by us." (2 Corinthians 1:20)
+            // Every promise of God finds its sure Yes and Amen in Christ; God's word never fails.
+            OracleHarness.DivineAct(OracleHarness.Witness("In Christ all the promises of God are Yea and Amen to the glory of God",
+                new PromiseFulfilled(), new Fidelity(), new CovenantFaithfulness(),
+                new Trustworthiness(), new Goodness()));
+        }
+
+        [Fact]
+        public void PaulUrgesTheChurchToForgiveAndComfortTheRepentantOffender_IsRighteous()
+        {
+            // "ye ought rather to forgive him, and comfort him ... that ye would confirm your love toward him." (2 Corinthians 2:7-8)
+            // Paul pleads with the church to forgive and console the repentant man, lest he be swallowed up by sorrow.
+            OracleHarness.Righteous(OracleHarness.Witness("Paul urges the Corinthians to forgive and comfort the repentant offender and confirm their love toward him",
+                new Forgiveness(), new Pardon(), new Compassion(),
+                new Kindness(), new RestoringLife()));
+        }
+
+        [Fact]
+        public void TheLordTransformsBelieversIntoHisImageFromGloryToGlory_IsADivineAct()
+        {
+            // "we all ... beholding ... the glory of the Lord, are changed into the same image from glory to glory,
+            //  even as by the Spirit of the Lord." (2 Corinthians 3:18)
+            // The Lord by His Spirit transforms His people into His own image, glory upon glory.
+            OracleHarness.DivineAct(OracleHarness.Witness("The Lord by His Spirit transforms believers into His image from glory to glory",
+                new Healing(), new RestoringLife(), new Goodness(),
+                new CovenantFaithfulness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void PaulRenouncesDishonestyAndHandlesTheWordOfGodTruthfully_IsRighteous()
+        {
+            // "But have renounced the hidden things of dishonesty, not walking in craftiness, nor handling the word
+            //  of God deceitfully; but by manifestation of the truth commending ourselves." (2 Corinthians 4:2)
+            // Paul disowns shameful and deceitful ways, commending himself only by the plain manifestation of the truth.
+            OracleHarness.Righteous(OracleHarness.Witness("Paul renounces the hidden things of shame and craftiness and commends himself by manifestation of the truth",
+                new TeachingTruth(), new Righteousness(), new Trustworthiness(),
+                new RejoicingInTruth(), new Purity()));
+        }
+
+        [Fact]
+        public void GodMakesThePreachersOfTheGospelTriumphInAfflictionAndEndurance_IsRighteous()
+        {
+            // "We are troubled on every side, yet not distressed ... persecuted, but not forsaken; cast down, but not
+            //  destroyed." (2 Corinthians 4:8-9)
+            // Pressed on every side yet not crushed, the apostles endure all hardship for the gospel's sake.
+            OracleHarness.Righteous(OracleHarness.Witness("Paul and his companions endure affliction and persecution for the gospel yet are not crushed or forsaken",
+                new Endurance(), new Patience(), new CourageousFaith(),
+                new Trust(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodReconcilesTheWorldToHimselfInChristNotImputingTheirTrespasses_IsADivineAct()
+        {
+            // "God was in Christ, reconciling the world unto himself, not imputing their trespasses unto them." (2 Corinthians 5:19)
+            // In Christ, God reconciles sinners to Himself, no longer counting their sins against them.
+            OracleHarness.DivineAct(OracleHarness.Witness("God in Christ reconciles the world to Himself, not imputing their trespasses unto them",
+                new Atonement(), new Pardon(), new Forgiveness(),
+                new Peacemaking(), new Deliverance()));
+        }
+
+        [Fact]
+        public void GodMadeChristToBeSinForUsThatWeMightBecomeTheRighteousnessOfGod_IsADivineAct()
+        {
+            // "For he hath made him to be sin for us, who knew no sin; that we might be made the righteousness of God in him." (2 Corinthians 5:21)
+            // The sinless Christ bears our sin so that in Him we are made the very righteousness of God.
+            OracleHarness.DivineAct(OracleHarness.Witness("God makes the sinless Christ to be sin for us, that we might become the righteousness of God in Him",
+                new Atonement(), new SelfSacrifice(), new Righteousness(),
+                new Deliverance(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void PaulCommendsHimselfAsAMinisterOfGodInPatienceAndPurity_IsRighteous()
+        {
+            // "in much patience, in afflictions ... by pureness, by knowledge, by longsuffering, by kindness ...
+            //  by love unfeigned." (2 Corinthians 6:4-6)
+            // Paul commends his ministry by patient endurance, purity, kindness, and unfeigned love.
+            OracleHarness.Righteous(OracleHarness.Witness("Paul commends himself as a minister of God in much patience, purity, kindness, and love unfeigned",
+                new Patience(), new Purity(), new Kindness(),
+                new Endurance(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodlySorrowWorksRepentanceWhileTheSorrowOfTheWorldWorksDeath_IsRighteous()
+        {
+            // "godly sorrow worketh repentance to salvation not to be repented of: but the sorrow of the world worketh death." (2 Corinthians 7:10)
+            // The Corinthians' godly grief produced sincere repentance unto salvation.
+            OracleHarness.Righteous(OracleHarness.Witness("The Corinthians' godly sorrow works true repentance unto salvation",
+                new Repentance(), new Mourning(), new Humility(),
+                new RejoicingInTruth(), new Righteousness()));
+        }
+
+        [Fact]
+        public void TheMacedonianChurchesGiveGenerouslyOutOfDeepPovertyToTheSaints_IsRighteous()
+        {
+            // "in a great trial of affliction ... and their deep poverty abounded unto the riches of their liberality ...
+            //  beyond their power they were willing." (2 Corinthians 8:2-3)
+            // Out of severe affliction and deep poverty, the Macedonians gave overflowingly and beyond their means to the saints.
+            OracleHarness.Righteous(OracleHarness.Witness("The Macedonian churches give generously out of deep poverty to relieve the poor saints",
+                new Generosity(), new SelfSacrifice(), new Compassion(),
+                new FeedingTheHungry(), new Joy()));
+        }
+
+        [Fact]
+        public void GodLovesACheerfulGiverAndSuppliesAllTheirNeed_IsADivineAct()
+        {
+            // "God loveth a cheerful giver. And God is able to make all grace abound toward you." (2 Corinthians 9:7-8)
+            // God delights in the cheerful giver and provides all sufficiency so His people may abound in every good work.
+            OracleHarness.DivineAct(OracleHarness.Witness("God loves a cheerful giver and supplies all grace so His people abound in every good work",
+                new Generosity(), new Goodness(), new Fidelity(),
+                new Joy(), new Kindness()));
+        }
+
+        [Fact]
+        public void PaulBoastsOnlyInHisWeaknessesThatThePowerOfChristMayRestUponHim_IsRighteous()
+        {
+            // "Most gladly therefore will I rather glory in my infirmities, that the power of Christ may rest upon me ...
+            //  for when I am weak, then am I strong." (2 Corinthians 12:9-10)
+            // Paul rejoices in his weaknesses, content to be lowly so that Christ's power and grace may rest upon him.
+            OracleHarness.Righteous(OracleHarness.Witness("Paul gladly glories in his weaknesses that the power of Christ may rest upon him, content in his infirmities",
+                new Humility(), new PovertyOfSpirit(), new Trust(),
+                new Endurance(), new CourageousFaith()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/SecondDominosNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/SecondDominosNarrativeTests.cs
@@ -1,0 +1,147 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 2 Book of the Covenant (Dominos) narrative oracle: the engine must return the verdict the book gives at each step.
+    // Canon: ETH (Ethiopic-only; best-effort). The "Book of the Covenant" is the Ethiopic Mashafa Kidan
+    // (Testamentum Domini / Testament of our Lord), the risen Christ's teaching to the apostles. The SECOND book
+    // governs the life of the laity: preparation for and admission to baptism, the renunciation of Satan, the
+    // baptismal confession of faith, anointing and the seal, the Eucharist, the keeping of Easter and Pentecost,
+    // the agape love-feast for the poor, the hours of prayer, visiting the sick, the burial of the dead, and the
+    // ordered support of widows and virgins, all in a tone of ascetic self-discipline. It warns the faithful
+    // against returning to idols and against the immorality and violence of the world.
+    public class SecondDominosNarrativeTests
+    {
+        [Fact]
+        public void TheRisenChristTeachesTheApostlesTheWayOfTheCovenant_IsADivineAct()
+        {
+            // The second Book of the Covenant is the words the risen Lord speaks to His apostles, ordering
+            // the worship and life of His people in covenant faithfulness. (2 Covenant / Testament II, prologue)
+            OracleHarness.DivineAct(OracleHarness.Witness("the risen Christ teaches the apostles the way of the covenant",
+                new TeachingTruth(), new CovenantFaithfulness(), new CreationOrder(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void TheCatechumenIsInstructedAndPreparedForBaptism_IsRighteous()
+        {
+            // The candidate is examined, taught the words of godliness, and made ready over a season of
+            // preparation before he may be admitted to the laver. (2 Covenant / Testament II.1-8)
+            OracleHarness.Righteous(OracleHarness.Witness("the catechumen is instructed in the faith and prepared for baptism",
+                new TeachingTruth(), new ObedienceToGod(), new Patience(), new Purity()));
+        }
+
+        [Fact]
+        public void TheCandidateRenouncesSatanAndTurnsToGod_IsRighteous()
+        {
+            // Standing toward the west, the candidate renounces Satan and all his works, then turns to the
+            // east and gives himself to Christ. (2 Covenant / Testament II.8)
+            OracleHarness.Righteous(OracleHarness.Witness("the candidate renounces Satan and all his works and turns to God",
+                new Repentance(), new ObedienceToGod(), new CovenantFaithfulness(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void TheBaptizedConfessesFaithAndIsSealed_IsRighteous()
+        {
+            // The candidate confesses faith in the Father, the Son, and the Holy Spirit, is washed in the
+            // laver, and receives the anointing and the seal. (2 Covenant / Testament II.8-9)
+            OracleHarness.Righteous(OracleHarness.Witness("the baptized confesses the faith, is washed, and receives the seal",
+                new Worship(), new Fidelity(), new Purity(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TheFaithfulKeepTheEucharistInThanksgiving_IsRighteous()
+        {
+            // The newly sealed and the whole body partake of the Eucharist with thanksgiving, the
+            // remembrance the Lord appointed. (2 Covenant / Testament II.10)
+            OracleHarness.Righteous(OracleHarness.Witness("the faithful keep the Eucharist with thanksgiving and remembrance",
+                new Worship(), new Fidelity(), new Joy(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TheChurchKeepsEasterAndPentecostWithJoy_IsRighteous()
+        {
+            // The book commands the faithful keeping of the Pasch and of the fifty days of Pentecost,
+            // rejoicing in the Lord's resurrection. (2 Covenant / Testament II.11-12)
+            OracleHarness.Righteous(OracleHarness.Witness("the church keeps Easter and the fifty days of Pentecost with joy",
+                new Worship(), new Joy(), new Fidelity(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TheAgapeFeastFeedsThePoorAndTheWidows_IsRighteous()
+        {
+            // At the agape the faithful gather and the poor, the widows, and the orphans are fed from the
+            // gifts of the Church, not sent empty away. (2 Covenant / Testament II.13)
+            OracleHarness.Righteous(OracleHarness.Witness("the agape love-feast feeds the poor, the widows, and the orphans",
+                new FeedingTheHungry(), new Generosity(), new HonoringTheVulnerable(), new Compassion()));
+        }
+
+        [Fact]
+        public void TheFaithfulKeepTheHoursOfPrayerAndPsalmody_IsRighteous()
+        {
+            // The book appoints the hours of prayer and the singing of psalms by night and day, that the
+            // people may continue steadfast before God. (2 Covenant / Testament II.22)
+            OracleHarness.Righteous(OracleHarness.Witness("the faithful keep the appointed hours of prayer and psalmody",
+                new Worship(), new Fidelity(), new Endurance(), new SelfControl()));
+        }
+
+        [Fact]
+        public void TheChurchVisitsAndTendsTheSick_IsRighteous()
+        {
+            // The faithful and the deacons are charged to visit the sick, to pray over them, and to tend
+            // them in their affliction. (2 Covenant / Testament II.21)
+            OracleHarness.Righteous(OracleHarness.Witness("the church visits and tends the sick in their affliction",
+                new CaringForTheSick(), new Compassion(), new Kindness(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void TheDeadAreBuriedWithHonorAndPrayer_IsRighteous()
+        {
+            // The book orders that the bodies of the faithful departed be carried out and buried with
+            // honor and prayer, without grasping or extortion over the dead. (2 Covenant / Testament II.23)
+            OracleHarness.Righteous(OracleHarness.Witness("the faithful departed are buried with honor and prayer",
+                new HonoringTheVulnerable(), new Compassion(), new Fidelity(), new Mourning()));
+        }
+
+        [Fact]
+        public void TheWidowsAndVirginsLiveInChastePrayerfulDiscipline_IsRighteous()
+        {
+            // The widows who have precedence and the consecrated virgins are to give themselves to prayer
+            // and fasting, keeping themselves chaste and sober. (2 Covenant / Testament II.19; cf. I.46)
+            OracleHarness.Righteous(OracleHarness.Witness("the widows and virgins live in chaste, prayerful, sober discipline",
+                new Purity(), new SelfControl(), new Worship(), new Endurance()));
+        }
+
+        [Fact]
+        public void TheBelieverWhoReturnsToIdolsAndTheTableOfDemons_IsSin()
+        {
+            // The one who, after renouncing Satan at the laver, turns back to idols and shares the table of
+            // demons breaks the covenant he confessed. (2 Covenant / Testament II.8, warning)
+            OracleHarness.Sin(OracleHarness.Witness("a baptized believer returns to idols and shares the table of demons",
+                new Idolatry(), new CovenantBreaking(), new Defilement(), new Disobedience()));
+        }
+
+        [Fact]
+        public void TheWorldDefilesTheFaithfulWithImmoralityAndDrunkenness_IsSin()
+        {
+            // The book sets the ascetic, chaste life of the covenant against the immorality, drunkenness,
+            // and revelry of the world, which defile the body. (2 Covenant / Testament II, ethical exhortation)
+            OracleHarness.Sin(OracleHarness.Witness("the world defiles the faithful with sexual immorality, drunkenness, and carousing",
+                new SexualImmorality(), new Drunkenness(), new Carousing(), new Impurity()));
+        }
+
+        [Fact]
+        public void ThePersecutorWhoShedsTheBloodOfTheFaithful_IsSin()
+        {
+            // The Testament is written under the shadow of persecution; the persecutor who sheds the blood
+            // of the faithful for their confession does murder. (2 Covenant / Testament, persecution warning)
+            Resolution r = OracleHarness.Witness("the persecutor sheds the blood of the faithful for their confession of Christ",
+                new Murder(), new Bloodshed(), new Oppression(), new Hatred());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/SecondEzraNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/SecondEzraNarrativeTests.cs
@@ -1,0 +1,158 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 2 Ezra / Ezra Sutuel narrative oracle: the engine must return the verdict Scripture gives at each step.
+    // Canon: ETH (Ethiopic-only; best-effort). This is the apocalyptic Ezra (the seven visions / dialogues
+    // with the angel Uriel, the lament over Zion, the eagle vision, the man from the sea, and the
+    // restoration of the lost scriptures), corresponding to 2 Esdras / 4 Ezra 3-14.
+    public class SecondEzraNarrativeTests
+    {
+        [Fact]
+        public void EzraMournsOverDesolateZionAndCriesToGod_IsRighteous()
+        {
+            // Ezra, troubled in the thirtieth year after the fall of the city, lies upon his bed and
+            // pours out his trouble before the Most High over the desolation of Zion. (2 Esd 3:1-3)
+            // A grieving, humble servant turning his lament toward God.
+            OracleHarness.Righteous(OracleHarness.Grounded("Ezra mourns over the ruin of Zion and pours out his trouble before the Most High",
+                Grounding.InGod(),
+                new Mourning(), new Humility(), new Trust(), new Worship()));
+        }
+
+        [Fact]
+        public void GodGivesAdamCommandmentAndOrdersCreation_IsADivineAct()
+        {
+            // Ezra rehearses that God made the world, formed Adam, gave him one commandment, and set
+            // the order of all things in the beginning. (2 Esd 3:4-7)
+            // God's creative ordering of the world and His just commandment to man.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God forms Adam, sets His commandment, and orders all creation",
+                Grounding.InGod(),
+                new CreationOrder(), new Righteousness(), new Goodness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void AdamTransgressesAndTheEvilHeartSpreads_IsSin()
+        {
+            // "For the first Adam bearing a wicked heart transgressed, and was overcome ... so be all
+            // they also that are born of him." A grain of evil seed sown in Adam's heart. (2 Esd 3:21-22; 4:30)
+            // The fall: disobedience and rebellion seeding corruption through the race.
+            OracleHarness.Sin(OracleHarness.Witness("Adam transgresses the commandment and the evil heart spreads to all his offspring",
+                new Disobedience(), new Rebellion(), new CovenantBreaking()));
+        }
+
+        [Fact]
+        public void UrielTeachesEzraThatGodsWaysAreUnsearchable_IsRighteous()
+        {
+            // The angel Uriel answers Ezra's complaints, setting before him weights, measures, and the
+            // wind, teaching that he cannot comprehend the way of the Most High. (2 Esd 4:1-21; 5:36-40)
+            // A messenger of God teaching truth and calling Ezra to humility before God's wisdom.
+            OracleHarness.Righteous(OracleHarness.Grounded("the angel Uriel teaches Ezra that the ways of the Most High are unsearchable",
+                Grounding.InGod(),
+                new TeachingTruth(), new RejoicingInTruth(), new Humility(), new Trust()));
+        }
+
+        [Fact]
+        public void GodPromisesTheEndOfTheAgeAndJudgmentToCome_IsADivineAct()
+        {
+            // God reveals through the angel the signs of the end, that the age hastens to its close and
+            // that He will judge the world and recompense every deed. (2 Esd 5:1-13; 6:18-28; 7:33-44)
+            // God's faithful promise of just judgment and the ordered consummation of the age.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God reveals the signs of the end and His coming righteous judgment of the world",
+                Grounding.InGod(),
+                new JustRecompense(), new Righteousness(), new PromiseFulfilled(), new CreationOrder(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodRecountsTheSixDaysOfCreation_IsADivineAct()
+        {
+            // In answer to Ezra, God recounts how He spread out the firmament, gathered the waters,
+            // made the lights, the living creatures, and man, in the six days. (2 Esd 6:38-54)
+            // The good ordering of creation declared by its Maker.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God recounts His ordering of the six days of creation",
+                Grounding.InGod(),
+                new CreationOrder(), new Goodness(), new Righteousness()));
+        }
+
+        [Fact]
+        public void EzraPleadsForMercyOnSinfulHumanity_IsRighteous()
+        {
+            // Ezra intercedes: "let thy mercy ... be magnified toward us ... for in this thy righteousness
+            // and thy goodness shall be declared, if thou be merciful unto them that have no store of good
+            // works." (2 Esd 7:62-69; 8:26-36; 8:45)
+            // Compassionate intercession for a guilty people, resting on God's mercy.
+            OracleHarness.Righteous(OracleHarness.Grounded("Ezra pleads for God's mercy upon sinful humanity",
+                Grounding.InGod(),
+                new Compassion(), new Humility(), new Trust(), new Worship()));
+        }
+
+        [Fact]
+        public void GodPromisesParadiseAndRestForTheRighteous_IsADivineAct()
+        {
+            // God shows that for the righteous a paradise is opened, the tree of life planted, rest
+            // prepared, and joy laid up. (2 Esd 7:36; 7:88-99; 8:52-54)
+            // God's gracious deliverance and reward kept for those who keep His ways.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God promises paradise, rest, and joy prepared for the righteous",
+                Grounding.InGod(),
+                new Deliverance(), new JustRecompense(), new Goodness(), new PromiseFulfilled(), new Joy()));
+        }
+
+        [Fact]
+        public void TheWeepingWomanIsRevealedAsZionRestored_IsADivineAct()
+        {
+            // Ezra meets a woman mourning her only son; as he comforts her she is transfigured into a
+            // built city, revealed by the angel to be Zion, whom God will establish. (2 Esd 9:38-10:57)
+            // God's healing, restoring vision: mourning Zion raised up and built anew.
+            OracleHarness.DivineAct(OracleHarness.Grounded("the mourning woman is transfigured into the rebuilt city of Zion",
+                Grounding.InGod(),
+                new RestoringLife(), new Healing(), new Compassion(), new PromiseFulfilled(), new Joy()));
+        }
+
+        [Fact]
+        public void TheEagleOfTheFourthKingdomDevoursAndOppresses_IsSin()
+        {
+            // The eagle rising from the sea reigns over the earth with terror, its heads and wings ruling
+            // with oppression, and the Most High condemns it for tyranny. (2 Esd 11:1-12:3; 11:40-43)
+            // The wicked kingdom: oppression, treachery, lawlessness, and pride against the Most High.
+            OracleHarness.Sin(OracleHarness.Witness("the eagle of the fourth kingdom rules the earth with oppression and tyranny",
+                new Oppression(), new Pride(), new Treachery(), new Lawlessness(), new WickedScheming()));
+        }
+
+        [Fact]
+        public void TheLionRebukesTheEagleAndAnnouncesJudgment_IsADivineAct()
+        {
+            // A lion, the Messiah whom the Most High keeps unto the end, rebukes the eagle and announces
+            // that its oppression is ended and that judgment is come. (2 Esd 11:36-12:3; 12:31-34)
+            // The Anointed One delivers the righteous remnant and renders just recompense to the tyrant.
+            OracleHarness.DivineAct(OracleHarness.Grounded("the Messiah-lion rebukes the eagle, ends its oppression, and delivers the righteous",
+                Grounding.InGod(),
+                new Deliverance(), new JustRecompense(), new Righteousness(), new DefendingTheWeak(), new Protection()));
+        }
+
+        [Fact]
+        public void TheManFromTheSeaDestroysTheHostileMultitude_IsADivineAct()
+        {
+            // The man rising from the heart of the sea (the Son of the Most High) is assailed by a
+            // multitude; he burns them with a stream of fire from his mouth, then gathers a peaceable
+            // company to himself. (2 Esd 13:1-13; 13:25-50)
+            // God's appointed Deliverer destroys the wicked who war against Him and protects His own.
+            OracleHarness.DivineAct(OracleHarness.Grounded("the man from the sea destroys the hostile multitude and gathers a peaceable people",
+                Grounding.InGod(),
+                new Deliverance(), new JustRecompense(), new Protection(), new Righteousness(), new DefendingTheWeak()));
+        }
+
+        [Fact]
+        public void EzraIsInspiredToRestoreTheLostScriptures_IsADivineAct()
+        {
+            // God gives Ezra to drink a cup like fire; for forty days, with five swift scribes, the words
+            // of the Most High are spoken and ninety-four books are written, restoring the lost Law. (2 Esd 14:37-48)
+            // God restores His revealed truth to His people through His enabled servant.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God inspires Ezra to restore the lost scriptures, the Law and the secret books",
+                Grounding.InGod(),
+                new TeachingTruth(), new RestoringLife(), new CovenantFaithfulness(), new PromiseFulfilled(), new Goodness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/SecondJohnNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/SecondJohnNarrativeTests.cs
@@ -1,0 +1,89 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 2 John narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class SecondJohnNarrativeTests
+    {
+        [Fact]
+        public void ElderLovesTheChosenLadyAndHerChildrenInTruth_IsRighteous()
+        {
+            // "The elder, to the elect lady and her children, whom I love in the truth." (2 John 1)
+            OracleHarness.Righteous(OracleHarness.Witness("the elder loves the chosen lady and her children in the truth", new RejoicingInTruth(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GraceMercyAndPeaceFromGodTheFatherAndChrist_IsADivineAct()
+        {
+            // "Grace, mercy, and peace ... from God the Father and from Jesus Christ ... in truth and love." (2 John 3)
+            OracleHarness.DivineAct(OracleHarness.Grounded("God the Father and Christ give grace, mercy, and peace in truth and love", Grounding.InGod(), new Pardon(), new Compassion(), new Peace()));
+        }
+
+        [Fact]
+        public void ElderRejoicesToFindHerChildrenWalkingInTruth_IsRighteous()
+        {
+            // "I rejoiced greatly to find some of your children walking in the truth." (2 John 4)
+            OracleHarness.Righteous(OracleHarness.Witness("the elder rejoices to find her children walking in the truth", new Joy(), new RejoicingInTruth(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void CommandmentThatWeLoveOneAnother_IsRighteous()
+        {
+            // "I ask that we love one another ... this is the commandment, that you walk in love." (2 John 5-6)
+            OracleHarness.Righteous(OracleHarness.Witness("the elect lady is asked to love one another as from the beginning", new Kindness(), new CovenantFaithfulness(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void WalkingInLoveAccordingToHisCommandments_IsRighteous()
+        {
+            // "And this is love, that we walk according to his commandments." (2 John 6)
+            OracleHarness.Righteous(OracleHarness.Witness("the believers walk in love according to God's commandments", new ObedienceToGod(), new CovenantFaithfulness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void ManyDeceiversGoneOutDenyingChristCameInFlesh_IsSin()
+        {
+            // "Many deceivers have gone out into the world, who do not confess Jesus Christ as coming in the flesh. This is the deceiver and the antichrist." (2 John 7)
+            OracleHarness.Sin(OracleHarness.Witness("many deceivers deny that Jesus Christ has come in the flesh", new Deceit(), new Blasphemy(), new Treachery()));
+        }
+
+        [Fact]
+        public void RunningAheadAndNotAbidingInChristsTeaching_IsSin()
+        {
+            // "Whoever goes on ahead and does not abide in the teaching of Christ, does not have God." (2 John 9)
+            OracleHarness.Sin(OracleHarness.Witness("the false teacher runs ahead and abandons the doctrine of Christ", new Rebellion(), new Disobedience(), new Pride()));
+        }
+
+        [Fact]
+        public void AbidingInTheTeachingOfChristHasBothFatherAndSon_IsRighteous()
+        {
+            // "Whoever abides in the teaching has both the Father and the Son." (2 John 9)
+            OracleHarness.Righteous(OracleHarness.Witness("the faithful abide in the teaching of Christ and hold to sound doctrine", new Fidelity(), new CovenantFaithfulness(), new Endurance()));
+        }
+
+        [Fact]
+        public void ReceivingAFalseTeacherSharesInHisWickedWorks_IsSin()
+        {
+            // "If anyone ... receives him into your house ... shares in his wicked works." (2 John 10-11)
+            OracleHarness.Sin(OracleHarness.Witness("welcoming the false teacher and greeting him shares in his wicked works", new Deceit(), new Treachery(), new Wrongdoing()));
+        }
+
+        [Fact]
+        public void RefusingToHostTheDeceiverGuardsTheHousehold_IsRighteous()
+        {
+            // "Do not receive him into your house or give him any greeting." (2 John 10) - guarding the flock from the deceiver
+            OracleHarness.Righteous(OracleHarness.Witness("the elect lady protects her household by refusing to harbor the deceiver", new Protection(), new DefendingTheWeak(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void ElderDesiresToComeAndSpeakFaceToFaceForFullJoy_IsRighteous()
+        {
+            // "I hope to come to you and talk face to face, so that our joy may be complete." (2 John 12)
+            OracleHarness.Righteous(OracleHarness.Witness("the elder longs to visit face to face that their joy may be full", new Joy(), new Kindness(), new Peacemaking()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/SecondPeterNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/SecondPeterNarrativeTests.cs
@@ -1,0 +1,126 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 2 Peter narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class SecondPeterNarrativeTests
+    {
+        [Fact]
+        public void DivinePowerGrantsAllThingsForLifeAndGodliness_IsADivineAct()
+        {
+            // "His divine power has granted to us all things that pertain to life and godliness ... his precious and very great promises." (2 Peter 1:3-4)
+            OracleHarness.DivineAct(OracleHarness.Witness("God's divine power graciously grants all things for life and godliness through His precious promises", new Generosity(), new PromiseFulfilled(), new Goodness()));
+        }
+
+        [Fact]
+        public void BelieverSupplementsFaithWithVirtueKnowledgeAndSelfControl_IsRighteous()
+        {
+            // "supplement your faith with virtue ... self-control ... steadfastness ... godliness ... brotherly affection." (2 Peter 1:5-7)
+            OracleHarness.Righteous(OracleHarness.Witness("the believer adds to his faith goodness, self-control, and steadfast endurance, growing in godliness and love", new Fidelity(), new SelfControl(), new Endurance(), new Kindness()));
+        }
+
+        [Fact]
+        public void MakingYourCallingAndElectionSureByDiligence_IsRighteous()
+        {
+            // "be all the more diligent to confirm your calling and election ... so an entrance ... will be richly provided." (2 Peter 1:10-11)
+            OracleHarness.Righteous(OracleHarness.Witness("the believer is diligent to confirm his calling and election, walking faithfully so he never stumbles", new Fidelity(), new Endurance(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TransfigurationVoiceFromTheMajesticGloryHonoringTheSon_IsADivineAct()
+        {
+            // "he received honor and glory from God the Father ... 'This is my beloved Son' ... on the holy mountain." (2 Peter 1:16-18)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Father bears witness from the Majestic Glory, honoring His beloved Son on the holy mountain", new TeachingTruth(), new Trustworthiness(), new Goodness()));
+        }
+
+        [Fact]
+        public void ProphecyCameFromMenCarriedAlongByTheHolySpirit_IsADivineAct()
+        {
+            // "men spoke from God as they were carried along by the Holy Spirit." (2 Peter 1:19-21)
+            OracleHarness.DivineAct(OracleHarness.Witness("God carries holy men along by His Spirit to speak the sure prophetic word of truth", new TeachingTruth(), new Trustworthiness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void FalseTeachersSecretlyBringDestructiveHeresiesForGreed_IsSin()
+        {
+            // "false teachers ... will secretly bring in destructive heresies ... in their greed they will exploit you with false words." (2 Peter 2:1-3)
+            OracleHarness.Sin(OracleHarness.Witness("false teachers secretly bring in destructive heresies, denying the Master and in greed exploiting souls with deceit", new Deceit(), new Greed(), new Blasphemy()));
+        }
+
+        [Fact]
+        public void GodCastTheSinningAngelsIntoChainsOfGloomyDarkness_IsADivineAct()
+        {
+            // "God did not spare angels when they sinned, but cast them into hell ... to be kept until the judgment." (2 Peter 2:4)
+            OracleHarness.DivineAct(OracleHarness.Witness("God justly judges the rebellious angels, committing them to chains of gloomy darkness until the day of judgment", new JustRecompense(), new Righteousness(), new CreationOrder()));
+        }
+
+        [Fact]
+        public void GodPreservedRighteousNoahWhileBringingTheFlood_IsADivineAct()
+        {
+            // "he preserved Noah, a herald of righteousness, with seven others, when he brought a flood." (2 Peter 2:5)
+            OracleHarness.DivineAct(OracleHarness.Witness("God protects righteous Noah and seven others, delivering the herald of righteousness when He brings the flood upon the ungodly", new Protection(), new Deliverance(), new Righteousness()));
+        }
+
+        [Fact]
+        public void GodRescuedRighteousLotFromSodom_IsADivineAct()
+        {
+            // "if he rescued righteous Lot, greatly distressed by the sensual conduct of the wicked ... the Lord knows how to rescue the godly." (2 Peter 2:7-9)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Lord rescues righteous Lot, tormented by lawless deeds, and knows how to deliver the godly from trial", new Deliverance(), new Protection(), new Righteousness()));
+        }
+
+        [Fact]
+        public void TheUngodlyIndulgeDefilingLustAndDespiseAuthority_IsSin()
+        {
+            // "those who indulge in the lust of defiling passion and despise authority. Bold and willful ..." (2 Peter 2:10)
+            OracleHarness.Sin(OracleHarness.Witness("the ungodly indulge in defiling lust, despise authority, and blaspheme the glorious ones in willful insolence", new Defilement(), new Rebellion(), new Blasphemy()));
+            Assert.Equal(1.0, OracleHarness.Witness("the ungodly indulge in defiling lust, despise authority, and blaspheme the glorious ones in willful insolence", new Defilement(), new Rebellion(), new Blasphemy()).Disorder);
+        }
+
+        [Fact]
+        public void BalaamLovedTheWagesOfUnrighteousness_IsSin()
+        {
+            // "they have followed the way of Balaam ... who loved gain from wrongdoing." (2 Peter 2:15-16)
+            OracleHarness.Sin(OracleHarness.Witness("the false teachers follow the way of Balaam, who loved the wages of wrongdoing and greed", new Greed(), new Wrongdoing(), new Covetousness()));
+        }
+
+        [Fact]
+        public void FalseTeachersPromiseFreedomWhileSlavesToCorruption_IsSin()
+        {
+            // "They promise them freedom, but they themselves are slaves of corruption ... entangled again in defilements." (2 Peter 2:18-20)
+            OracleHarness.Sin(OracleHarness.Witness("they entice with sensual lust and empty boasts, promising freedom while enslaved to corruption and defilement", new Lust(), new Boasting(), new Defilement()));
+            Assert.Equal(1.0, OracleHarness.Witness("they entice with sensual lust and empty boasts, promising freedom while enslaved to corruption and defilement", new Lust(), new Boasting(), new Defilement()).Disorder);
+        }
+
+        [Fact]
+        public void ScoffersWillComeFollowingTheirOwnSinfulDesires_IsSin()
+        {
+            // "scoffers will come ... following their own sinful desires ... 'Where is the promise of his coming?'" (2 Peter 3:3-4)
+            OracleHarness.Sin(OracleHarness.Witness("scoffers walk after their own sinful desires, mocking the promise of His coming in insolent unbelief", new Lust(), new Insolence(), new Blasphemy()));
+        }
+
+        [Fact]
+        public void TheLordIsPatientNotWishingAnyShouldPerishButReachRepentance_IsADivineAct()
+        {
+            // "The Lord is not slow ... but is patient toward you, not wishing that any should perish, but that all should reach repentance." (2 Peter 3:9)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Lord is patient toward all, not wishing any to perish but that all should reach repentance", new Patience(), new Compassion(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void BelieversAwaitNewHeavensAndNewEarthLivingHolyAndGodly_IsRighteous()
+        {
+            // "what sort of people ought you to be in lives of holiness and godliness ... we are waiting for new heavens and a new earth." (2 Peter 3:11-14)
+            OracleHarness.Righteous(OracleHarness.Witness("the believer lives in holiness and godliness, at peace and without spot, awaiting the new heavens and new earth", new Purity(), new Peace(), new Endurance()));
+        }
+
+        [Fact]
+        public void GrowInTheGraceAndKnowledgeOfTheLordJesusChrist_IsRighteous()
+        {
+            // "grow in the grace and knowledge of our Lord and Savior Jesus Christ." (2 Peter 3:18)
+            OracleHarness.Righteous(OracleHarness.Witness("the believer grows in the grace and knowledge of the Lord, giving Him glory in steadfast faith", new Fidelity(), new Worship(), new Endurance()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/SecondThessaloniansNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/SecondThessaloniansNarrativeTests.cs
@@ -1,0 +1,117 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 2 Thessalonians narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class SecondThessaloniansNarrativeTests
+    {
+        [Fact]
+        public void TheirFaithGrowsAndTheirLoveAbounds_IsRighteous()
+        {
+            // "Your faith is growing abundantly, and the love of every one of you for one another is increasing." (2 Thessalonians 1:3)
+            OracleHarness.Righteous(OracleHarness.Witness("the church grows in faith and abounding love for one another", new Fidelity(), new Kindness(), new Compassion()));
+        }
+
+        [Fact]
+        public void TheyEndurePersecutionsAndAfflictionsWithSteadfastness_IsRighteous()
+        {
+            // "Your steadfastness and faith in all your persecutions and in the afflictions that you are enduring." (2 Thessalonians 1:4)
+            OracleHarness.Righteous(OracleHarness.Witness("the believers endure persecution with steadfast faith", new Endurance(), new Fidelity(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void GodRepaysWithAfflictionThoseWhoAfflictTheChurch_IsADivineAct()
+        {
+            // "God considers it just to repay with affliction those who afflict you ... this is evidence of the righteous judgment of God." (2 Thessalonians 1:5-6)
+            OracleHarness.DivineAct(OracleHarness.Witness("God justly repays the afflicters and grants relief to the afflicted", new JustRecompense(), new Righteousness(), new Deliverance()));
+        }
+
+        [Fact]
+        public void GodGrantsReliefToTheAfflictedWhenChristIsRevealed_IsADivineAct()
+        {
+            // "To grant relief to you who are afflicted ... when the Lord Jesus is revealed from heaven." (2 Thessalonians 1:7)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Lord Jesus is revealed from heaven and rescues his afflicted people", new Deliverance(), new Protection(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void GodFulfillsEveryGoodResolveAndWorkOfFaith_IsADivineAct()
+        {
+            // "That our God ... may fulfill every resolve for good and every work of faith by his power." (2 Thessalonians 1:11-12)
+            OracleHarness.DivineAct(OracleHarness.Witness("God fulfills every good resolve and work of faith by his power", new PromiseFulfilled(), new Goodness(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheManOfLawlessnessExaltsHimselfAboveGod_IsSin()
+        {
+            // "The man of lawlessness ... opposes and exalts himself against every so-called god ... proclaiming himself to be God." (2 Thessalonians 2:3-4)
+            OracleHarness.Sin(OracleHarness.Grounded("the man of lawlessness exalts himself above God and claims to be God", Grounding.InIdol("self"), new Lawlessness(), new Pride(), new Blasphemy(), new Rebellion()));
+        }
+
+        [Fact]
+        public void TheLawlessOneWorksFalseSignsAndDeceivesThePerishing_IsSin()
+        {
+            // "The lawless one ... with all power and false signs and wonders, and with all wicked deception." (2 Thessalonians 2:9-10)
+            OracleHarness.Sin(OracleHarness.Grounded("the lawless one works false signs and wicked deception against the perishing", Grounding.InIdol("Satan"), new Deceit(), new Lawlessness(), new Sorcery()));
+        }
+
+        [Fact]
+        public void TheLordJesusSlaysTheLawlessOneWithTheBreathOfHisMouth_IsADivineAct()
+        {
+            // "The Lord Jesus will kill with the breath of his mouth and bring to nothing by the appearance of his coming." (2 Thessalonians 2:8)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Lord Jesus destroys the lawless one and overthrows his rebellion", new JustRecompense(), new Righteousness(), new Deliverance()));
+        }
+
+        [Fact]
+        public void GodChoseThemForSalvationThroughSanctificationOfTheSpirit_IsADivineAct()
+        {
+            // "God chose you ... to be saved, through sanctification by the Spirit and belief in the truth." (2 Thessalonians 2:13)
+            OracleHarness.DivineAct(OracleHarness.Witness("God chooses them for salvation through sanctification and belief in the truth", new Deliverance(), new RejoicingInTruth(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void GodComfortsTheirHeartsAndEstablishesThemInEveryGoodWork_IsADivineAct()
+        {
+            // "Comfort your hearts and establish them in every good work and word." (2 Thessalonians 2:16-17)
+            OracleHarness.DivineAct(OracleHarness.Witness("God comforts their hearts and establishes them in every good work", new Compassion(), new Goodness(), new Protection()));
+        }
+
+        [Fact]
+        public void TheLordIsFaithfulAndGuardsThemFromTheEvilOne_IsADivineAct()
+        {
+            // "The Lord is faithful. He will establish you and guard you against the evil one." (2 Thessalonians 3:3)
+            OracleHarness.DivineAct(OracleHarness.Witness("the faithful Lord establishes and guards them from the evil one", new Fidelity(), new Protection(), new Trustworthiness()));
+        }
+
+        [Fact]
+        public void PaulWorkedNightAndDaySoAsNotToBurdenAnyone_IsRighteous()
+        {
+            // "With toil and labor we worked night and day, that we might not be a burden to any of you." (2 Thessalonians 3:8)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul labors night and day to burden no one and to set an example", new SelfSacrifice(), new Generosity(), new SelfControl()));
+        }
+
+        [Fact]
+        public void TheIdleBusybodiesWhoWillNotWork_IsSin()
+        {
+            // "Some who walk among you in idleness, not busy at work, but busybodies." (2 Thessalonians 3:11)
+            OracleHarness.Sin(OracleHarness.Witness("certain men live in idleness, refusing to work and meddling as busybodies", new Sloth(), new Disobedience(), new Chaos()));
+        }
+
+        [Fact]
+        public void TheBelieversDoNotGrowWearyInDoingGood_IsRighteous()
+        {
+            // "As for you, brothers, do not grow weary in doing good." (2 Thessalonians 3:13)
+            OracleHarness.Righteous(OracleHarness.Witness("the believers persevere in doing good and do not grow weary", new Goodness(), new Endurance(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheLordOfPeaceGivesThemPeaceAtAllTimes_IsADivineAct()
+        {
+            // "Now may the Lord of peace himself give you peace at all times in every way." (2 Thessalonians 3:16)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Lord of peace himself grants them peace at all times in every way", new Peace(), new Goodness(), new Fidelity()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/SecondTimothyNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/SecondTimothyNarrativeTests.cs
@@ -1,0 +1,138 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 2 Timothy narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class SecondTimothyNarrativeTests
+    {
+        [Fact]
+        public void GodSavesAndCallsUsByGraceNotWorks_IsADivineAct()
+        {
+            // "He has saved us and called us to a holy life ... because of his own purpose and grace." (2 Timothy 1:9)
+            OracleHarness.DivineAct(OracleHarness.Witness("God saves and calls his people by grace", new Deliverance(), new Fidelity()));
+        }
+
+        [Fact]
+        public void ChristJesusDestroysDeathAndBringsLifeToLight_IsADivineAct()
+        {
+            // "Christ Jesus ... has destroyed death and has brought life and immortality to light through the gospel." (2 Timothy 1:10)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ abolishes death and brings life to light", new RestoringLife(), new Deliverance()));
+        }
+
+        [Fact]
+        public void TimothyFannsIntoFlameTheGiftWithoutTimidity_IsRighteous()
+        {
+            // "Fan into flame the gift of God ... a spirit of power, of love and of self-discipline." (2 Timothy 1:6-7)
+            OracleHarness.Righteous(OracleHarness.Witness("Timothy stirs up his gift in courage and self-control", new CourageousFaith(), new SelfControl()));
+        }
+
+        [Fact]
+        public void PaulIsUnashamedAndGuardsTheDepositEntrustedToHim_IsRighteous()
+        {
+            // "I am not ashamed ... he is able to guard what I have entrusted to him." (2 Timothy 1:12)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul keeps faith and guards the gospel deposit", new Fidelity(), new Endurance()));
+        }
+
+        [Fact]
+        public void OnesiphorusRefreshesPaulAndSeeksHimOutInChains_IsRighteous()
+        {
+            // "He often refreshed me and was not ashamed of my chains ... he searched hard for me." (2 Timothy 1:16-17)
+            OracleHarness.Righteous(OracleHarness.Witness("Onesiphorus seeks out and refreshes the imprisoned Paul", new Compassion(), new VisitingThePrisoner()));
+        }
+
+        [Fact]
+        public void EntrustingTheTeachingToFaithfulMenWhoWillTeachOthers_IsRighteous()
+        {
+            // "Entrust to reliable people who will also be qualified to teach others." (2 Timothy 2:2)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul commits the sound teaching to trustworthy men", new TeachingTruth(), new Trustworthiness()));
+        }
+
+        [Fact]
+        public void TheSoldierEnduresHardshipAndCompetesByTheRules_IsRighteous()
+        {
+            // "Endure hardship ... competes as an athlete ... according to the rules." (2 Timothy 2:3-5)
+            OracleHarness.Righteous(OracleHarness.Witness("Timothy endures as a soldier of Christ Jesus", new Endurance(), new SelfControl()));
+        }
+
+        [Fact]
+        public void ChristRemainsFaithfulEvenWhenWeAreFaithless_IsADivineAct()
+        {
+            // "If we are faithless, he remains faithful, for he cannot disown himself." (2 Timothy 2:13)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ remains faithful and cannot disown himself", new Fidelity(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void QuarrelingOverWordsAndGodlessChatterThatRuinsHearers_IsSin()
+        {
+            // "Quarreling about words ... only ruins those who listen ... godless chatter." (2 Timothy 2:14, 16)
+            OracleHarness.Sin(OracleHarness.Witness("the false teachers quarrel over words and spread godless chatter", new Discord(), new Deceit()));
+        }
+
+        [Fact]
+        public void HymenaeusAndPhiletusSpreadTheLieThatTheResurrectionIsPast_IsSin()
+        {
+            // "They say that the resurrection has already taken place, and they destroy the faith of some." (2 Timothy 2:17-18)
+            OracleHarness.Sin(OracleHarness.Witness("Hymenaeus and Philetus teach a destroying falsehood", new Deceit(), new FalseWitness()));
+        }
+
+        [Fact]
+        public void TheLordsServantIsKindNotQuarrelsomeGentlyInstructingOpponents_IsRighteous()
+        {
+            // "Must not be quarrelsome but must be kind to everyone ... gently instruct." (2 Timothy 2:24-25)
+            OracleHarness.Righteous(OracleHarness.Witness("the Lord's servant teaches gently and kindly", new Kindness(), new Gentleness(), new TeachingTruth()));
+        }
+
+        [Fact]
+        public void TheGodlessOfTheLastDaysAreLoversOfSelfAndMoney_IsSin()
+        {
+            // "Lovers of themselves, lovers of money, boastful, proud ... unforgiving ... without self-control." (2 Timothy 3:2-3)
+            OracleHarness.Sin(OracleHarness.Witness("the people of the last days are lovers of self and money", new SelfSeeking(), new Greed(), new Boasting()));
+        }
+
+        [Fact]
+        public void TheLastDaysCrowdIsHeartlessUnforgivingAndUngrateful_IsSin()
+        {
+            // "Ungrateful, unholy, without love, unforgiving, slanderous." (2 Timothy 3:2-3)
+            OracleHarness.Sin(OracleHarness.Witness("the godless are heartless, ungrateful, and unforgiving", new Heartlessness(), new Ingratitude(), new Unforgiveness()));
+        }
+
+        [Fact]
+        public void AllScriptureIsGodBreathedForTrainingInRighteousness_IsADivineAct()
+        {
+            // "All Scripture is God-breathed ... for training in righteousness." (2 Timothy 3:16)
+            OracleHarness.DivineAct(OracleHarness.Witness("God breathes out the Scriptures to train in righteousness", new TeachingTruth(), new Righteousness()));
+        }
+
+        [Fact]
+        public void PaulChargesTimothyToPreachTheWordWithGreatPatience_IsRighteous()
+        {
+            // "Preach the word ... with great patience and careful instruction." (2 Timothy 4:2)
+            OracleHarness.Righteous(OracleHarness.Witness("Timothy preaches the word with patience and teaching", new TeachingTruth(), new Patience()));
+        }
+
+        [Fact]
+        public void PaulHasFoughtTheGoodFightAndKeptTheFaith_IsRighteous()
+        {
+            // "I have fought the good fight, I have finished the race, I have kept the faith." (2 Timothy 4:7)
+            OracleHarness.Righteous(OracleHarness.Witness("Paul finishes the race and keeps the faith", new Endurance(), new Fidelity()));
+        }
+
+        [Fact]
+        public void DemasDesertsPaulInLoveWithThisPresentWorld_IsSin()
+        {
+            // "Demas, because he loved this world, has deserted me." (2 Timothy 4:10)
+            OracleHarness.Sin(OracleHarness.Witness("Demas loves this present world and deserts Paul", new Treachery(), new SelfSeeking()));
+        }
+
+        [Fact]
+        public void TheLordStandsAtPaulsSideAndRescuesHimFromTheLionsMouth_IsADivineAct()
+        {
+            // "The Lord stood at my side ... I was delivered from the lion's mouth." (2 Timothy 4:17-18)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Lord stands by Paul and rescues him", new Protection(), new Deliverance()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/SirachJosephasOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/SirachJosephasOracleTests.cs
@@ -1,0 +1,41 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 45 & 46: Sirach (Joshua son of Sirach) and Josephas son of Bengorion (Ethiopic Yosippon).
+    public class SirachJosephasOracleTests
+    {
+        [Fact]
+        public void Sirach_MercyAndAlmsgiving_IsRighteous()
+        {
+            // "Water extinguishes a blazing fire: so almsgiving atones for sin." (Sirach 3:30; 4:1-10)
+            OracleHarness.Righteous(OracleHarness.Witness("almsgiving and mercy", new Generosity(), new Compassion()));
+        }
+
+        [Fact]
+        public void Sirach_TheFearOfTheLord_IsRighteous()
+        {
+            // "The fear of the Lord is the beginning of wisdom." (Sirach 1:14)
+            OracleHarness.Righteous(OracleHarness.Witness("the fear of the Lord", new Humility(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void Josephas_FaithfulnessAcrossHistory_IsRighteous()
+        {
+            // The Ethiopic history recounts the people kept by God when they were faithful.
+            OracleHarness.Righteous(OracleHarness.Witness("faithfulness across history",
+                new CovenantFaithfulness(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void Josephas_ApostasyBringsRuin_IsSin()
+        {
+            // And ruined when they turned to idols and treachery.
+            OracleHarness.Sin(OracleHarness.Witness("apostasy brings ruin", new Idolatry(), new Rebellion()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/SirachNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/SirachNarrativeTests.cs
@@ -1,0 +1,112 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Sirach (Wisdom of Ben Sira / Ecclesiasticus) narrative oracle: the engine must return the verdict
+    // Scripture gives at each step. Ben Sira teaches the fear of the Lord as the beginning of wisdom,
+    // and weighs the deeds of the wise against the deeds of fools and the wicked.
+    public class SirachNarrativeTests
+    {
+        [Fact]
+        public void AllWisdomComesFromTheLordAndIsPouredOutByHim_IsADivineAct()
+        {
+            // "All wisdom comes from the Lord and is with him forever... he poured her out upon all his works." (Sirach 1:1-10)
+            OracleHarness.DivineAct(OracleHarness.Witness("the Lord creates wisdom and lavishes her on all his works", new CreationOrder(), new Generosity(), new Goodness()));
+        }
+
+        [Fact]
+        public void TheFearOfTheLordIsTheBeginningOfWisdom_IsRighteous()
+        {
+            // "The fear of the Lord is the beginning of wisdom... To fear the Lord is the fullness of wisdom." (Sirach 1:14-20)
+            OracleHarness.Righteous(OracleHarness.Witness("the godly man begins in the fear of the Lord", new Worship(), new ObedienceToGod(), new Humility()));
+        }
+
+        [Fact]
+        public void TrustingGodWithEnduranceWhenTestedInTheFurnace_IsRighteous()
+        {
+            // "My son, if you come forward to serve the Lord... set your heart right and be steadfast... For gold is tested in the fire." (Sirach 2:1-6)
+            OracleHarness.Righteous(OracleHarness.Witness("the servant stays steadfast and trusts God through testing", new Trust(), new Endurance(), new Fidelity(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void HonoringFatherAndMotherInDeedAndWord_IsRighteous()
+        {
+            // "Whoever honors his father atones for sins... Honor your father by word and deed." (Sirach 3:1-9)
+            OracleHarness.Righteous(OracleHarness.Witness("the son honors and cares for his father and mother", new ObedienceToGod(), new HonoringTheVulnerable(), new Kindness()));
+        }
+
+        [Fact]
+        public void TheGreaterYouAreTheMoreYouMustHumbleYourself_IsRighteous()
+        {
+            // "The greater you are, the more you must humble yourself... For great is the might of the Lord." (Sirach 3:18-20)
+            OracleHarness.Righteous(OracleHarness.Witness("the great man humbles himself before the Lord", new Humility(), new Meekness()));
+        }
+
+        [Fact]
+        public void NotRejectingTheSupplicantOrTurningAwayFromThePoor_IsRighteous()
+        {
+            // "Do not reject an afflicted suppliant... Incline your ear to the poor, and answer him peaceably." (Sirach 4:1-10)
+            OracleHarness.Righteous(OracleHarness.Witness("the wise man hears the poor and rescues the oppressed", new Compassion(), new FeedingTheHungry(), new DefendingTheWeak(), new Kindness()));
+        }
+
+        [Fact]
+        public void PresumingOnGodsMercyToHeapSinUponSin_IsSin()
+        {
+            // "Do not say, 'His mercy is great, he will forgive...' and so heap sin upon sin." (Sirach 5:4-7)
+            OracleHarness.Sin(OracleHarness.Witness("the presumptuous man heaps sin upon sin, gambling on God's mercy", new Pride(), new Disobedience(), new Insolence()));
+        }
+
+        [Fact]
+        public void TheDoubleTonguedSlandererWhoBetraysAFriend_IsSin()
+        {
+            // "Curse the gossip and the double-tongued, for they destroy the peace of many." (Sirach 5:14-6:1, 28:13-15)
+            OracleHarness.Sin(OracleHarness.Witness("the double-tongued slanderer destroys friendships and peace", new Slander(), new Gossip(), new Treachery(), new SowingDiscord()));
+        }
+
+        [Fact]
+        public void GivingGladlyAndLendingToTheNeighborInNeed_IsRighteous()
+        {
+            // "Help the poor for the commandment's sake... Lose your silver for the sake of a brother." (Sirach 29:1-13)
+            OracleHarness.Righteous(OracleHarness.Witness("the merciful man lends gladly and gives alms to his neighbor", new Generosity(), new Compassion(), new Kindness()));
+        }
+
+        [Fact]
+        public void NourishingRageAndNursingTheGrudgeAgainstANeighbor_IsSin()
+        {
+            // "Anger and wrath, these also are abominations... He who takes vengeance will suffer the vengeance of the Lord." (Sirach 27:30-28:7)
+            OracleHarness.Sin(OracleHarness.Witness("the man who nurses wrath and refuses to forgive his neighbor", new FitsOfRage(), new Grudge(), new Unforgiveness(), new Hatred()));
+        }
+
+        [Fact]
+        public void ForgivingTheNeighborSoThatYourOwnSinsArePardoned_IsRighteous()
+        {
+            // "Forgive your neighbor the wrong he has done, and then your sins will be pardoned when you pray." (Sirach 28:2-4)
+            OracleHarness.Righteous(OracleHarness.Witness("the godly man forgives his neighbor's wrong before he prays", new Forgiveness(), new Pardon(), new Compassion()));
+        }
+
+        [Fact]
+        public void TheDrunkardAndGluttonGivenToWineAndExcess_IsSin()
+        {
+            // "Wine drunk to excess is bitterness of soul... Do not try to prove your strength by wine-drinking." (Sirach 31:25-31, 37:27-31)
+            OracleHarness.Sin(OracleHarness.Witness("the man given over to drunkenness and gluttonous excess", new Drunkenness(), new Gluttony(), new Carousing()));
+        }
+
+        [Fact]
+        public void DefraudingTheHiredLaborerOfHisWages_IsSin()
+        {
+            // "To take away a neighbor's living is to commit murder; to deprive an employee of his wages is to shed blood." (Sirach 34:21-27)
+            OracleHarness.Sin(OracleHarness.Witness("the oppressor robs the hired laborer of the wages that sustain his life", new WithholdingWhatIsDue(), new Oppression(), new Wrongdoing(), new Theft()));
+        }
+
+        [Fact]
+        public void FearingTheLordAndKeepingTheCommandmentsAsTheWholeDuty_IsRighteous()
+        {
+            // "Whoever keeps the law controls his thoughts... fear of the Lord is the beginning of acceptance." (Sirach 19:20, 1:11-13)
+            OracleHarness.Righteous(OracleHarness.Witness("the wise man keeps the law and walks in the fear of the Lord", new ObedienceToGod(), new Fidelity(), new SelfControl(), new Worship()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/SirateTsionNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/SirateTsionNarrativeTests.cs
@@ -1,0 +1,151 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Sirate Tsion (the "Order of Zion") narrative oracle: the engine must return the verdict the
+    // book gives at each step. Canon: ETH (Ethiopic-only; best-effort). Sirate Tsion is the first
+    // of the four parts of the Sinodos, the apostolic "Book of Order" of the Church: it sets out the
+    // ordination of bishops, priests, and deacons, the order of worship and the Eucharist, the care
+    // of the poor, widows, and orphans, baptism, and the disciplines that guard the Church from
+    // false teaching and immorality. The tests below trace its load-bearing teachings and orders.
+    public class SirateTsionNarrativeTests
+    {
+        [Fact]
+        public void ChristGivesTheApostlesTheOrderOfTheChurch_IsADivineAct()
+        {
+            // The apostles set down the "Book of Order" because the Lord Himself appointed them and
+            // delivered to them the pattern of the Church's worship and ministry. (Sirate Tsion,
+            // prologue: the Holy Order given by Christ to the apostles)
+            // Christ ordering His Church: teaching, covenant, and the right ordering of creation.
+            OracleHarness.DivineAct(OracleHarness.Grounded("Christ delivers to the apostles the Holy Order of Zion for His Church",
+                Grounding.InGod(),
+                new TeachingTruth(), new CreationOrder(), new CovenantFaithfulness(),
+                new ObedienceToGod(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheApostlesOrdainBishopsToShepherdTheFlock_IsRighteous()
+        {
+            // The apostles, as Christ ordained them, ordain bishops to succeed them and to guard and
+            // feed the flock. (Sirate Tsion, on the ordination of the bishop)
+            // Faithful obedience that shepherds and protects the people of God.
+            OracleHarness.Righteous(OracleHarness.Witness("the apostles ordain bishops to shepherd and guard the flock",
+                new ObedienceToGod(), new Protection(), new CovenantFaithfulness(),
+                new TeachingTruth(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheBishopMustBeBlamelessTemperateAndHospitable_IsRighteous()
+        {
+            // The bishop is to be without reproach, self-controlled, gentle, given to hospitality,
+            // and apt to teach. (Sirate Tsion, on the qualities of the bishop; cf. 1 Tim 3)
+            // The ordering of a holy life: self-mastery, gentleness, welcome, and sound teaching.
+            OracleHarness.Righteous(OracleHarness.Witness("the bishop is to be blameless, self-controlled, gentle, hospitable, and apt to teach",
+                new SelfControl(), new Gentleness(), new Hospitality(),
+                new TeachingTruth(), new Humility(), new Purity()));
+        }
+
+        [Fact]
+        public void DeaconsAreSetApartToServeThePoorAndTheSick_IsRighteous()
+        {
+            // Deacons are ordained to minister at the table of the Lord and to serve the widows, the
+            // poor, and the sick. (Sirate Tsion, on the order of deacons)
+            // Service to the vulnerable: feeding, caring for the sick, and honoring the lowly.
+            OracleHarness.Righteous(OracleHarness.Witness("deacons are set apart to serve the widows, the poor, and the sick",
+                new CaringForTheSick(), new FeedingTheHungry(), new HonoringTheVulnerable(),
+                new Kindness(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void TheChurchGathersToOfferTheEucharistInWorship_IsRighteous()
+        {
+            // The order of the holy offering: the people gather, give thanks, and the Body and Blood
+            // of the Lord are offered in remembrance of Him. (Sirate Tsion, on the order of the
+            // Eucharist and the prayers of thanksgiving)
+            // The Church's right worship: thanksgiving, reverence, and obedient remembrance.
+            OracleHarness.Righteous(OracleHarness.Grounded("the Church gathers to offer the Eucharist with thanksgiving and worship",
+                Grounding.InGod(),
+                new Worship(), new ObedienceToGod(), new Joy(),
+                new Peace(), new Fidelity()));
+        }
+
+        [Fact]
+        public void ConvertsAreBaptizedAndRenounceTheDevil_IsRighteous()
+        {
+            // The order of baptism: the catechumen renounces the devil and his works, is washed, and
+            // is sealed unto the Lord. (Sirate Tsion, on the order of baptism)
+            // A turning from evil to God: repentance, cleansing, and faithful worship.
+            OracleHarness.Righteous(OracleHarness.Witness("the convert renounces the devil and is baptized unto the Lord",
+                new Repentance(), new Purity(), new Worship(),
+                new ObedienceToGod(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void TheChurchCommandsCareForWidowsAndOrphans_IsRighteous()
+        {
+            // The Order commands the bishop and faithful to feed the hungry, clothe the naked, and
+            // sustain the widows and the fatherless out of the Church's gifts. (Sirate Tsion, on the
+            // care of the poor and the offerings of the faithful)
+            // Mercy embodied: feeding, clothing, generosity, and honor toward the defenseless.
+            OracleHarness.Righteous(OracleHarness.Witness("the Church feeds, clothes, and sustains the widows and orphans",
+                new FeedingTheHungry(), new ClothingTheNaked(), new Generosity(),
+                new HonoringTheVulnerable(), new DefendingTheWeak(), new Compassion()));
+        }
+
+        [Fact]
+        public void TheFaithfulOfferTheirFirstfruitsAndTithesToGod_IsRighteous()
+        {
+            // The Order directs the people to bring their firstfruits and offerings to the bishop for
+            // the Lord and for the poor. (Sirate Tsion, on offerings and firstfruits)
+            // Grateful, generous worship that obeys God and provides for the needy.
+            OracleHarness.Righteous(OracleHarness.Grounded("the faithful bring their firstfruits and offerings to God and the poor",
+                Grounding.InGod(),
+                new Generosity(), new Worship(), new ObedienceToGod(), new Goodness()));
+        }
+
+        [Fact]
+        public void TheUnworthyManSeizesTheOfficeOfBishopForGain_IsSin()
+        {
+            // The Order warns against the man who pushes himself forward to the episcopate out of
+            // pride and greed rather than calling. (Sirate Tsion, against unworthy ordination)
+            // Ambition and avarice corrupting the holy office: pride, greed, and self-seeking.
+            OracleHarness.Sin(OracleHarness.Grounded("an unworthy, greedy man seizes the office of bishop for gain",
+                Grounding.InIdol("self"),
+                new Pride(), new Greed(), new SelfishAmbition(), new SelfSeeking(), new Boasting()));
+        }
+
+        [Fact]
+        public void FalseTeachersAndHereticsLeadTheFlockAstray_IsSin()
+        {
+            // The Order commands that heretics and false teachers who corrupt the doctrine of the
+            // apostles be rejected. (Sirate Tsion, against false teaching and heresy)
+            // Deceit and rebellion against the truth, sowing division in the Church.
+            OracleHarness.Sin(OracleHarness.Witness("false teachers corrupt the apostolic doctrine and lead the flock astray",
+                new Deceit(), new FalseWitness(), new Rebellion(), new SowingDiscord(), new Blasphemy()));
+        }
+
+        [Fact]
+        public void TheClergymanGivenToDrunkennessAndImmorality_IsSin()
+        {
+            // The Order forbids the clergy from drunkenness, fornication, and filthy living, and
+            // commands the deposing of such. (Sirate Tsion, on the discipline of the clergy)
+            // Debauchery defiling the holy office: drunkenness, immorality, and impurity.
+            OracleHarness.Sin(OracleHarness.Witness("a clergyman given to drunkenness and fornication defiles his office",
+                new Drunkenness(), new SexualImmorality(), new Debauchery(), new Impurity(), new Defilement()));
+        }
+
+        [Fact]
+        public void TheChurchPursuesPeaceAndReconcilesTheBrethren_IsRighteous()
+        {
+            // The Order charges the bishop to make peace among the brethren, to forgive the penitent,
+            // and to restore the fallen. (Sirate Tsion, on reconciliation and discipline)
+            // The shepherd's mercy: peacemaking, patience, forgiveness, and restored fellowship.
+            OracleHarness.Righteous(OracleHarness.Witness("the bishop makes peace among the brethren and forgives the penitent",
+                new Peacemaking(), new Forgiveness(), new Patience(), new Pardon(), new Gentleness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/SongOfSongsNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/SongOfSongsNarrativeTests.cs
@@ -1,0 +1,99 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Song of Songs narrative oracle: the engine must return the verdict Scripture gives at each step.
+    // The Song celebrates covenant marital love between the bride (the Shulammite) and her beloved,
+    // read by the Church as a figure of the love between Christ and His bride. Its delights are pure,
+    // and its one warning is against rousing love out of its God-appointed order.
+    public class SongOfSongsNarrativeTests
+    {
+        [Fact]
+        public void BrideLongingForTheKissesOfHerBeloved_IsRighteous()
+        {
+            // "Let him kiss me with the kisses of his mouth! For your love is better than wine." (Song 1:2)
+            OracleHarness.Righteous(OracleHarness.Witness("the bride yearns purely for her beloved's love", new Purity(), new Joy(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void BelovedDrawsHisBrideAndSheRejoices_IsRighteous()
+        {
+            // "Draw me after you; let us run... we will exult and rejoice in you." (Song 1:4)
+            OracleHarness.Righteous(OracleHarness.Witness("the beloved draws his bride and they rejoice together", new Joy(), new Kindness(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TheBelovedPraisesHisBrideAsAltogetherFair_IsRighteous()
+        {
+            // "Behold, you are beautiful, my love... there is no flaw in you." (Song 1:15; 4:7)
+            OracleHarness.Righteous(OracleHarness.Witness("the beloved honors his bride as wholly fair and flawless", new Kindness(), new HonoringTheVulnerable(), new RejoicingInTruth()));
+        }
+
+        [Fact]
+        public void HisBannerOverHerWasLove_IsRighteous()
+        {
+            // "He brought me to the banqueting house, and his banner over me was love." (Song 2:4)
+            OracleHarness.Righteous(OracleHarness.Witness("the beloved shelters his bride under the banner of love", new Protection(), new Kindness(), new Gentleness()));
+        }
+
+        [Fact]
+        public void TheChargeNotToStirUpLoveUntilItPleases_IsRighteous()
+        {
+            // "I adjure you... that you not stir up or awaken love until it pleases." (Song 2:7; 3:5; 8:4)
+            OracleHarness.Righteous(OracleHarness.Witness("the daughters of Jerusalem are charged to keep love in its appointed order", new SelfControl(), new Purity(), new CreationOrder()));
+        }
+
+        [Fact]
+        public void TheCatchingOfTheLittleFoxesThatSpoilTheVineyard_IsRighteous()
+        {
+            // "Catch the foxes for us, the little foxes that spoil the vineyards." (Song 2:15)
+            OracleHarness.Righteous(OracleHarness.Witness("guarding the vineyard of love from the little foxes that would spoil it", new Protection(), new SelfControl(), new Fidelity()));
+        }
+
+        [Fact]
+        public void MyBelovedIsMineAndIAmHis_IsRighteous()
+        {
+            // "My beloved is mine, and I am his; he grazes among the lilies." (Song 2:16; 6:3)
+            OracleHarness.Righteous(OracleHarness.Witness("the bride and beloved belong wholly to one another", new CovenantFaithfulness(), new Fidelity(), new Joy()));
+        }
+
+        [Fact]
+        public void TheBrideSeeksHerBelovedThroughTheCityUntilSheFindsHim_IsRighteous()
+        {
+            // "I will seek him whom my soul loves... I found him whom my soul loves." (Song 3:1-4)
+            OracleHarness.Righteous(OracleHarness.Witness("the bride seeks her beloved through the night until she finds him", new Endurance(), new CovenantFaithfulness(), new Patience()));
+        }
+
+        [Fact]
+        public void TheWatchmenBeatAndWoundTheSeekingBride_IsSin()
+        {
+            // "The watchmen found me... they beat me, they bruised me, they took away my veil." (Song 5:7)
+            OracleHarness.Sin(OracleHarness.Witness("the city watchmen strike and wound the bride who seeks her beloved", new Oppression(), new Wrongdoing(), new Rudeness()));
+        }
+
+        [Fact]
+        public void ABridePerfectAndAGardenLockedFountainSealed_IsRighteous()
+        {
+            // "A garden locked is my sister, my bride, a spring locked, a fountain sealed." (Song 4:12)
+            OracleHarness.Righteous(OracleHarness.Witness("the bride kept as a garden locked and a fountain sealed", new Purity(), new SelfControl(), new Fidelity()));
+        }
+
+        [Fact]
+        public void LoveIsStrongAsDeathAndManyWatersCannotQuenchIt_IsRighteous()
+        {
+            // "Set me as a seal upon your heart... for love is strong as death... Many waters cannot quench love." (Song 8:6-7)
+            OracleHarness.Righteous(OracleHarness.Witness("covenant love proves strong as death and unquenchable", new CovenantFaithfulness(), new Endurance(), new SelfSacrifice()));
+        }
+
+        [Fact]
+        public void TheManWhoWouldBuyLoveWithAllHisWealthIsUtterlyScorned_IsSin()
+        {
+            // "If a man offered for love all the wealth of his house, he would be utterly despised." (Song 8:7)
+            OracleHarness.Sin(OracleHarness.Witness("a man tries to purchase covenant love with the wealth of his house", new Greed(), new Covetousness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/TegsatsNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/TegsatsNarrativeTests.cs
@@ -1,0 +1,156 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Tegsats (Reproof) narrative oracle (Ethiopic OT book 25, best-effort ETH canon):
+    // a wisdom book of admonition and reproof, gathered with the Solomonic corpus. The engine
+    // must return the verdict Scripture gives at each admonition: the wisdom of God and the
+    // righteous deeds it commands read coherent, while the folly it reproves reads as sin.
+    public class TegsatsNarrativeTests
+    {
+        [Fact]
+        public void WisdomOfGodCallsAloudToTeachTheSimple_IsADivineAct()
+        {
+            // The book of Reproof opens as the wisdom of God crying out to instruct the simple,
+            // disclosing truth to all who will hear. (cf. Proverbs 1:20-23)
+            // The teaching of God's own wisdom is a divine act, composed only of virtue.
+            OracleHarness.DivineAct(OracleHarness.Witness("The wisdom of God calls aloud in the streets to teach truth to the simple",
+                new TeachingTruth(), new RejoicingInTruth(), new Goodness(),
+                new Fidelity(), new Righteousness()));
+        }
+
+        [Fact]
+        public void TheWiseSonReceivesCorrectionInHumility_IsRighteous()
+        {
+            // "Whoever heeds correction gains understanding." The reproof of Tegsats is welcomed,
+            // not resented, by the one who would be wise. (cf. Proverbs 15:32)
+            OracleHarness.Righteous(OracleHarness.Witness("The wise son hears reproof and turns from his folly in humility",
+                new Repentance(), new Humility(), new HungerForRighteousness(),
+                new ObedienceToGod(), new SelfControl()));
+        }
+
+        [Fact]
+        public void TheScornerHatesReproofAndRefusesCorrection_IsSin()
+        {
+            // The book reproves the scoffer who despises instruction and loves his own folly. (cf. Proverbs 9:7-8, 15:12)
+            // To hate reproof is rebellion against the wisdom of God.
+            OracleHarness.Sin(OracleHarness.Grounded("The scorner hates reproof, mocks the one who corrects him, and clings to his folly",
+                Grounding.InIdol("his own folly"),
+                new Pride(), new Rebellion(), new Insolence(),
+                new Disobedience(), new HaughtyEyes()));
+        }
+
+        [Fact]
+        public void TheFearOfTheLordIsTheBeginningOfWisdom_IsRighteous()
+        {
+            // "The fear of the LORD is the beginning of wisdom." The reproof grounds all instruction
+            // in reverent worship and obedience to God. (cf. Proverbs 1:7, 9:10)
+            OracleHarness.Righteous(OracleHarness.Witness("The wise fear the LORD as the beginning of knowledge and keep His commandments",
+                new Worship(), new ObedienceToGod(), new Humility(),
+                new Fidelity(), new Trust()));
+        }
+
+        [Fact]
+        public void TheProudHeartIsAnAbominationReprovedByWisdom_IsSin()
+        {
+            // The book reproves the haughty eyes and the proud heart that God hates. (cf. Proverbs 6:16-17, 16:5)
+            OracleHarness.Sin(OracleHarness.Grounded("The proud man exalts himself with haughty eyes and a boastful heart",
+                Grounding.InIdol("his own glory"),
+                new Pride(), new HaughtyEyes(), new Boasting(),
+                new Insolence(), new SelfSeeking()));
+        }
+
+        [Fact]
+        public void TheGenerousManSharesHisBreadWithThePoor_IsRighteous()
+        {
+            // The admonition commends the one who is generous and gives to the needy. (cf. Proverbs 19:17, 22:9)
+            OracleHarness.Righteous(OracleHarness.Witness("The wise man shares his bread with the poor and is generous to the needy",
+                new Generosity(), new FeedingTheHungry(), new Compassion(),
+                new HonoringTheVulnerable(), new Kindness()));
+        }
+
+        [Fact]
+        public void TheSluggardWillNotPlowAndReapsNothing_IsSin()
+        {
+            // The reproof rebukes the sluggard who refuses to work and follows worthless pursuits. (cf. Proverbs 6:6-11, 24:30-34)
+            OracleHarness.Sin(OracleHarness.Grounded("The sluggard refuses to plow because of the cold and lets his field grow over with thorns",
+                Grounding.InIdol("his own ease"),
+                new Sloth(), new Disobedience(), new Indifference(),
+                new Ingratitude(), new SelfSeeking()));
+        }
+
+        [Fact]
+        public void TheLyingTongueAndFalseWitnessAreReproved_IsSin()
+        {
+            // Among the things wisdom hates are a lying tongue and a false witness who breathes out lies. (cf. Proverbs 6:17-19, 12:22)
+            OracleHarness.Sin(OracleHarness.Grounded("The deceiver bears false witness and sows discord among brothers with a lying tongue",
+                Grounding.InIdol("his crooked schemes"),
+                new Deceit(), new FalseWitness(), new SowingDiscord(),
+                new Slander(), new WickedScheming()));
+        }
+
+        [Fact]
+        public void HonestScalesAndJustWeightsArePraised_IsRighteous()
+        {
+            // "A false balance is an abomination ... but a just weight is His delight." The reproof commends
+            // honest dealing and just recompense in the marketplace. (cf. Proverbs 11:1, 16:11)
+            OracleHarness.Righteous(OracleHarness.Witness("The upright merchant uses honest scales and just weights and renders what is due",
+                new Trustworthiness(), new Righteousness(), new JustRecompense(),
+                new RejoicingInTruth(), new SelfControl()));
+        }
+
+        [Fact]
+        public void TheDrunkardAndGluttonComeToPoverty_IsSin()
+        {
+            // The book reproves the drunkard and the glutton who waste themselves in carousing. (cf. Proverbs 23:20-21)
+            OracleHarness.Sin(OracleHarness.Grounded("The drunkard and glutton give themselves to wine and carousing until they come to ruin",
+                Grounding.InIdol("the cup and the table"),
+                new Drunkenness(), new Gluttony(), new Carousing(),
+                new SelfSeeking(), new Sloth()));
+        }
+
+        [Fact]
+        public void TheRighteousDefendsTheWeakAndPleadsTheCauseOfTheNeedy_IsRighteous()
+        {
+            // "Open thy mouth for the dumb ... plead the cause of the poor and needy." The reproof
+            // commands the wise to defend those who cannot defend themselves. (cf. Proverbs 31:8-9)
+            OracleHarness.Righteous(OracleHarness.Witness("The wise open their mouth for the voiceless and plead the cause of the poor and needy",
+                new DefendingTheWeak(), new HonoringTheVulnerable(), new Righteousness(),
+                new Compassion(), new JustRecompense()));
+        }
+
+        [Fact]
+        public void TheManWhoOppressesThePoorReproachesHisMaker_IsSin()
+        {
+            // "He that oppresseth the poor reproacheth his Maker." The reproof condemns the violent
+            // who grind down the helpless for gain. (cf. Proverbs 14:31, 22:16)
+            OracleHarness.Sin(OracleHarness.Grounded("The oppressor crushes the poor and withholds their due to enlarge his own gain",
+                Grounding.InIdol("his greed for gain"),
+                new Oppression(), new Greed(), new WithholdingWhatIsDue(),
+                new Heartlessness(), new Wrongdoing()));
+        }
+
+        [Fact]
+        public void WisdomCommendsTheSoftAnswerThatTurnsAwayWrath_IsRighteous()
+        {
+            // "A soft answer turneth away wrath." The reproof commends the peacemaker who is slow to anger. (cf. Proverbs 15:1, 16:32)
+            OracleHarness.Righteous(OracleHarness.Witness("The wise give a soft answer that turns away wrath and are slow to anger",
+                new Peacemaking(), new Gentleness(), new SelfControl(),
+                new Patience(), new Peace()));
+        }
+
+        [Fact]
+        public void TheGodOfWisdomKeepsAndProtectsThoseWhoWalkUprightly_IsADivineAct()
+        {
+            // "He layeth up sound wisdom for the righteous ... he keepeth the paths of judgment, and
+            // preserveth the way of his saints." (cf. Proverbs 2:7-8)
+            OracleHarness.DivineAct(OracleHarness.Witness("The God of wisdom is a shield to the upright and guards the path of His faithful ones",
+                new Protection(), new Fidelity(), new Goodness(),
+                new CovenantFaithfulness(), new Righteousness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/ThirdJohnNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/ThirdJohnNarrativeTests.cs
@@ -1,0 +1,103 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // 3 John narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class ThirdJohnNarrativeTests
+    {
+        [Fact]
+        public void ElderLovesGaiusInTruth_IsRighteous()
+        {
+            // "The elder unto the wellbeloved Gaius, whom I love in the truth." (3 John 1)
+            OracleHarness.Righteous(OracleHarness.Witness("the elder loves Gaius in the truth", new RejoicingInTruth(), new Fidelity()));
+        }
+
+        [Fact]
+        public void ElderPraysForGaiusHealthAndProsperity_IsRighteous()
+        {
+            // "Beloved, I wish above all things that thou mayest prosper and be in health, even as thy soul prospereth." (3 John 2)
+            OracleHarness.Righteous(OracleHarness.Witness("the elder prays that Gaius may prosper and be in health", new Kindness(), new Compassion()));
+        }
+
+        [Fact]
+        public void ElderRejoicesThatGaiusWalksInTruth_IsRighteous()
+        {
+            // "I rejoiced greatly ... even as thou walkest in the truth." (3 John 3-4)
+            OracleHarness.Righteous(OracleHarness.Witness("the elder rejoices greatly that Gaius walks in the truth", new Joy(), new RejoicingInTruth(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void GaiusFaithfullyHostsTravelingBrethrenAndStrangers_IsRighteous()
+        {
+            // "thou doest faithfully whatsoever thou doest to the brethren, and to strangers." (3 John 5)
+            OracleHarness.Righteous(OracleHarness.Witness("Gaius faithfully serves the brethren and the strangers who come to him", new Hospitality(), new Fidelity(), new Kindness()));
+        }
+
+        [Fact]
+        public void GaiusBringsTheBrethrenForwardOnTheirJourneyAfterAGodlyManner_IsRighteous()
+        {
+            // "whom if thou bring forward on their journey after a godly sort, thou shalt do well." (3 John 6)
+            OracleHarness.Righteous(OracleHarness.Witness("Gaius sends the missionary brethren onward in a manner worthy of God", new Generosity(), new Hospitality(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void MissionariesWentForthForHisNameTakingNothingOfTheGentiles_IsRighteous()
+        {
+            // "Because that for his name's sake they went forth, taking nothing of the Gentiles." (3 John 7)
+            OracleHarness.Righteous(OracleHarness.Witness("the brethren go forth for the Name, taking nothing from the Gentiles", new SelfSacrifice(), new CourageousFaith(), new Fidelity()));
+        }
+
+        [Fact]
+        public void ReceivingSuchMissionariesAsFellowhelpersToTheTruth_IsRighteous()
+        {
+            // "We therefore ought to receive such, that we might be fellowhelpers to the truth." (3 John 8)
+            OracleHarness.Righteous(OracleHarness.Witness("believers ought to receive such men, becoming fellow workers for the truth", new Hospitality(), new RejoicingInTruth(), new Generosity()));
+        }
+
+        [Fact]
+        public void DiotrephesLovesPreeminenceAndRefusesTheElder_IsSin()
+        {
+            // "Diotrephes, who loveth to have the preeminence among them, receiveth us not." (3 John 9)
+            OracleHarness.Sin(OracleHarness.Witness("Diotrephes loves to be first and refuses to receive the elder", new Pride(), new SelfishAmbition(), new Rebellion()));
+        }
+
+        [Fact]
+        public void DiotrephesPratesAgainstTheElderWithMaliciousWords_IsSin()
+        {
+            // "prating against us with malicious words." (3 John 10)
+            OracleHarness.Sin(OracleHarness.Witness("Diotrephes spreads malicious words and slander against the elder", new Slander(), new Malice(), new Gossip()));
+        }
+
+        [Fact]
+        public void DiotrephesRefusesTheBrethrenAndCastsOutThoseWhoWould_IsSin()
+        {
+            // "neither doth he himself receive the brethren, and forbiddeth them that would, and casteth them out of the church." (3 John 10)
+            OracleHarness.Sin(OracleHarness.Witness("Diotrephes refuses the brethren, forbids those who would help, and casts them out of the church", new Oppression(), new Indifference(), new Heartlessness()));
+        }
+
+        [Fact]
+        public void ElderExhortsToFollowGoodNotEvilForHeThatDoethGoodIsOfGod_IsRighteous()
+        {
+            // "Beloved, follow not that which is evil, but that which is good. He that doeth good is of God." (3 John 11)
+            OracleHarness.Righteous(OracleHarness.Witness("the elder exhorts Gaius to follow good and not evil, for the doer of good is of God", new Goodness(), new ObedienceToGod(), new Righteousness()));
+        }
+
+        [Fact]
+        public void DemetriusHasGoodReportOfAllMenAndOfTheTruth_IsRighteous()
+        {
+            // "Demetrius hath good report of all men, and of the truth itself." (3 John 12)
+            OracleHarness.Righteous(OracleHarness.Witness("Demetrius has a good report of all men and of the truth itself", new Trustworthiness(), new RejoicingInTruth(), new Fidelity()));
+        }
+
+        [Fact]
+        public void ElderHopesToComeAndSpeakFaceToFaceAndGreetsTheFriendsByName_IsRighteous()
+        {
+            // "I trust I shall shortly see thee, and we shall speak face to face. ... Greet the friends by name." (3 John 14)
+            OracleHarness.Righteous(OracleHarness.Witness("the elder hopes to speak face to face and greets the friends by name", new Peace(), new Kindness(), new Peacemaking()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/TitusNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/TitusNarrativeTests.cs
@@ -1,0 +1,110 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Titus narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class TitusNarrativeTests
+    {
+        [Fact]
+        public void GodWhoDoesNotLiePromisedEternalLifeBeforeTheAges_IsADivineAct()
+        {
+            // "in the hope of eternal life, which God, who does not lie, promised before the ages began." (Titus 1:2)
+            OracleHarness.DivineAct(OracleHarness.Witness("God who never lies keeps His promise of eternal life", new PromiseFulfilled(), new Trustworthiness(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TitusIsLeftInCreteToAppointElders_IsRighteous()
+        {
+            // "appoint elders in every town as I directed you." (Titus 1:5)
+            OracleHarness.Righteous(OracleHarness.Witness("Titus sets in order what was lacking and appoints faithful elders", new CreationOrder(), new Fidelity()));
+        }
+
+        [Fact]
+        public void TheOverseerMustBeHospitableAndSelfControlled_IsRighteous()
+        {
+            // "hospitable, a lover of good, self-controlled, upright, holy and disciplined." (Titus 1:8)
+            OracleHarness.Righteous(OracleHarness.Witness("the overseer holds firm to the trustworthy word, hospitable and self-controlled", new Hospitality(), new SelfControl(), new Goodness()));
+        }
+
+        [Fact]
+        public void EldersMustHoldFirmAndTeachSoundDoctrine_IsRighteous()
+        {
+            // "He must hold firmly to the trustworthy message ... encourage others by sound doctrine." (Titus 1:9)
+            OracleHarness.Righteous(OracleHarness.Witness("the elder holds firm to the trustworthy word and teaches sound doctrine", new TeachingTruth(), new Trustworthiness()));
+        }
+
+        [Fact]
+        public void TheCretanDeceiversUpsetWholeHouseholdsForGain_IsSin()
+        {
+            // "They must be silenced, because they are disrupting whole households by teaching ... for the sake of dishonest gain." (Titus 1:11)
+            OracleHarness.Sin(OracleHarness.Witness("the rebellious deceivers ruin households for dishonest gain", new Deceit(), new Greed(), new Discord()));
+        }
+
+        [Fact]
+        public void TheCretansAreLiarsEvilBrutesAndGluttons_IsSin()
+        {
+            // "Cretans are always liars, evil brutes, lazy gluttons." (Titus 1:12)
+            OracleHarness.Sin(OracleHarness.Witness("the Cretans are liars, brutes, and lazy gluttons", new Deceit(), new Gluttony(), new Sloth()));
+        }
+
+        [Fact]
+        public void TheDefiledRejectGodWhileClaimingToKnowHim_IsSin()
+        {
+            // "To the corrupt and unbelieving nothing is pure ... They claim to know God, but by their actions they deny him." (Titus 1:15-16)
+            OracleHarness.Sin(OracleHarness.Witness("they profess to know God but by their works deny Him, their minds defiled", new Defilement(), new Disobedience()));
+        }
+
+        [Fact]
+        public void OlderWomenTeachWhatIsGoodAndLoveTheirFamilies_IsRighteous()
+        {
+            // "they can urge the younger women to love their husbands and children, to be self-controlled and pure." (Titus 2:3-5)
+            OracleHarness.Righteous(OracleHarness.Witness("older women teach what is good so the young are self-controlled and pure", new TeachingTruth(), new SelfControl(), new Purity()));
+        }
+
+        [Fact]
+        public void TitusModelsIntegrityAndSoundSpeech_IsRighteous()
+        {
+            // "In your teaching show integrity, seriousness and soundness of speech that cannot be condemned." (Titus 2:7-8)
+            OracleHarness.Righteous(OracleHarness.Witness("Titus shows integrity and sound speech as a model of good works", new Goodness(), new TeachingTruth(), new Trustworthiness()));
+        }
+
+        [Fact]
+        public void TheGraceOfGodAppearedBringingSalvation_IsADivineAct()
+        {
+            // "the grace of God has appeared that offers salvation to all people." (Titus 2:11)
+            OracleHarness.DivineAct(OracleHarness.Witness("the saving grace of God appears to all people", new Deliverance(), new Kindness()));
+        }
+
+        [Fact]
+        public void ChristGaveHimselfToRedeemAndPurifyAPeople_IsADivineAct()
+        {
+            // "Jesus Christ, who gave himself for us to redeem us ... and to purify for himself a people." (Titus 2:13-14)
+            OracleHarness.DivineAct(OracleHarness.Witness("Christ gives Himself to redeem and purify a people for His own", new SelfSacrifice(), new Atonement(), new Purity()));
+        }
+
+        [Fact]
+        public void GodSavedUsByHisMercyThroughRebirthAndRenewal_IsADivineAct()
+        {
+            // "he saved us ... because of his mercy ... through the washing of rebirth and renewal by the Holy Spirit." (Titus 3:4-5)
+            OracleHarness.DivineAct(OracleHarness.Witness("God saves us by His mercy through the washing of rebirth and renewal", new Compassion(), new Deliverance(), new RestoringLife()));
+        }
+
+        [Fact]
+        public void BelieversDevoteThemselvesToGoodWorks_IsRighteous()
+        {
+            // "those who have trusted in God may be careful to devote themselves to doing what is good." (Titus 3:8)
+            OracleHarness.Righteous(OracleHarness.Witness("believers devote themselves to good works that profit everyone", new Goodness(), new Generosity()));
+        }
+
+        [Fact]
+        public void TheDivisivePersonIsWarpedAndSelfCondemned_IsSin()
+        {
+            // "Warn a divisive person once, and then warn them a second time ... they are warped and sinful." (Titus 3:10-11)
+            OracleHarness.Sin(OracleHarness.Witness("the divisive person stirs foolish controversies and is warped, self-condemned", new Faction(), new Discord(), new Disobedience()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/TizazNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/TizazNarrativeTests.cs
@@ -1,0 +1,116 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Tizaz (Te'ezaz, "The Commandment / Ordinance") narrative oracle. Tizaz is a book of the
+    // Ethiopic broader New Testament (the Sinodos / apostolic church-order corpus). Its calling is
+    // the ordinance of holiness: love of God and neighbor, right worship, mercy to the penitent,
+    // charity to the needy, care for the vulnerable, and the rebuke of the sins that break the
+    // covenant. The engine must return the verdict Scripture gives at each commandment.
+    public class TizazNarrativeTests
+    {
+        // The first and great commandment: love the Lord your God, ordained in Tizaz.
+        [Fact]
+        public void TheCommandToLoveAndWorshipGod_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("the commandment to love and worship God", new Worship(), new ObedienceToGod()));
+        }
+
+        // The second commandment, like it: love your neighbor as yourself (Tizaz).
+        [Fact]
+        public void TheCommandToLoveTheNeighbor_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("love your neighbor as yourself", new Compassion(), new Kindness()));
+        }
+
+        // The ordinance to keep faith with God's covenant and obey His statutes (Tizaz).
+        [Fact]
+        public void KeepingTheCovenantOrdinance_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("keeping the covenant ordinance", new CovenantFaithfulness(), new ObedienceToGod()));
+        }
+
+        // The command to receive and restore the penitent in mercy (Tizaz on repentance).
+        [Fact]
+        public void ReceivingThePenitentInMercy_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("receiving the penitent in mercy", new Forgiveness(), new Repentance()));
+        }
+
+        // The command of charity: give alms and feed the hungry (Tizaz on almsgiving).
+        [Fact]
+        public void CharityAndAlmsgivingToTheNeedy_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("alms to the needy and bread to the hungry", new Generosity(), new FeedingTheHungry()));
+        }
+
+        // The command to care for the orphan, the widow, and the stranger (Tizaz).
+        [Fact]
+        public void CaringForOrphanWidowAndStranger_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("care for orphan, widow, and stranger", new HonoringTheVulnerable(), new Hospitality()));
+        }
+
+        // The command to clothe the naked and visit the sick and the prisoner (Tizaz on mercy).
+        [Fact]
+        public void TendingTheSickClothingTheNaked_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("clothe the naked and tend the sick", new ClothingTheNaked(), new CaringForTheSick()));
+        }
+
+        // The command to walk in holiness and purity of heart before God (Tizaz on sanctification).
+        [Fact]
+        public void WalkingInHolinessAndPurity_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("walk in holiness and purity of heart", new Purity(), new SelfControl()));
+        }
+
+        // The ordinance to render every man his due in justice and truth (Tizaz).
+        [Fact]
+        public void RenderingJusticeAndTruth_IsRighteous()
+        {
+            OracleHarness.Righteous(OracleHarness.Witness("render justice and speak the truth", new JustRecompense(), new TeachingTruth()));
+        }
+
+        // Tizaz forbids idolatry: turning from the Lord to serve other gods breaks the first ordinance.
+        [Fact]
+        public void TurningToIdols_IsSin()
+        {
+            OracleHarness.Sin(OracleHarness.Grounded("turning to serve idols", Grounding.InIdol("an idol"), new Idolatry(), new Disobedience()));
+        }
+
+        // Tizaz forbids bloodshed and murder against the neighbor, capital defilement of the covenant.
+        [Fact]
+        public void TheBloodshedOfMurder_IsSin()
+        {
+            Resolution r = OracleHarness.Witness("the shedding of innocent blood", new Murder(), new Bloodshed());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        // Tizaz forbids theft and oppression, withholding from the laborer and the poor.
+        [Fact]
+        public void TheftAndOppressionOfThePoor_IsSin()
+        {
+            OracleHarness.Sin(OracleHarness.Witness("theft and oppression of the poor", new Theft(), new Oppression()));
+        }
+
+        // Tizaz forbids adultery and uncleanness, defiling the body and the covenant.
+        [Fact]
+        public void AdulteryAndUncleanness_IsSin()
+        {
+            OracleHarness.Sin(OracleHarness.Witness("adultery and uncleanness", new Adultery(), new Impurity()));
+        }
+
+        // Tizaz forbids false witness and slander against the brother (the lying tongue).
+        [Fact]
+        public void FalseWitnessAndSlander_IsSin()
+        {
+            OracleHarness.Sin(OracleHarness.Witness("false witness and slander against the brother", new FalseWitness(), new Slander()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/TobitJudithEstherOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/TobitJudithEstherOracleTests.cs
@@ -1,0 +1,52 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 17, 18, 19: Tobit, Judith, Esther.
+    public class TobitJudithEstherOracleTests
+    {
+        [Fact]
+        public void TobitsAlmsgivingAndBurialOfTheDead_IsRighteous()
+        {
+            // Tobit risks himself to feed the hungry and bury the dead (Tobit 1:16-17; 4:7-11).
+            OracleHarness.Righteous(OracleHarness.Witness("Tobit's almsgiving", new Generosity(), new Compassion()));
+        }
+
+        [Fact]
+        public void GodsProvidentialHealing_IsADivineAct()
+        {
+            // God sends Raphael to heal Tobit and deliver Sarah (Tobit 3:16-17; 11).
+            OracleHarness.DivineAct(OracleHarness.Witness("God heals Tobit", new Healing(), new Compassion()));
+        }
+
+        [Fact]
+        public void GodDeliversThroughJudith_DefendsTheWeak()
+        {
+            // God saves His people from the besieging oppressor through Judith's faith (Judith 8-13).
+            OracleHarness.DivineAct(OracleHarness.Witness("the deliverance through Judith",
+                new Deliverance(), new DefendingTheWeak()));
+        }
+
+        [Fact]
+        public void EstherDeliversHerPeopleFromGenocide_IsRighteous()
+        {
+            // "If I perish, I perish." (Esther 4:16) Courage to save her people.
+            OracleHarness.Righteous(OracleHarness.Witness("Esther pleads for her people",
+                new CourageousFaith(), new Protection()));
+        }
+
+        [Fact]
+        public void HamansGenocidalPlot_IsGraveSin()
+        {
+            // Haman plots to destroy all the Jews out of wounded pride (Esther 3).
+            Resolution r = OracleHarness.Witness("Haman's plot to destroy a people", new Murder(), new Pride());
+
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/TobitNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/TobitNarrativeTests.cs
@@ -1,0 +1,141 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Tobit narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class TobitNarrativeTests
+    {
+        [Fact]
+        public void TobitGivesAlmsAndFeedsTheHungryInExile_IsRighteous()
+        {
+            // "I gave many alms to my kindred ... I would give my bread to the hungry and my garments to the naked." (Tobit 1:3,16-17)
+            // Tobit's lifelong charity to the poor and exiled.
+            OracleHarness.Righteous(OracleHarness.Witness("Tobit gives alms, feeds the hungry, clothes the naked",
+                new Generosity(), new FeedingTheHungry(), new ClothingTheNaked(),
+                new Compassion(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void TobitWalksInCovenantFaithfulnessWhileOthersApostatize_IsRighteous()
+        {
+            // While the tribes sacrificed to Baal, Tobit alone went to Jerusalem to worship the LORD. (Tobit 1:4-8)
+            // Steadfast obedience to the Law and worship of the one true God in a faithless generation.
+            OracleHarness.Righteous(OracleHarness.Witness("Tobit alone keeps the Law and worships at Jerusalem",
+                new ObedienceToGod(), new Worship(), new CovenantFaithfulness(),
+                new Fidelity(), new CourageousFaith()));
+        }
+
+        [Fact]
+        public void TobitRisksHisLifeToBuryTheDead_IsRighteous()
+        {
+            // "If the king ... slew any of the Jews, I buried them privily." (Tobit 1:17-19; 2:3-8)
+            // At peril of death Tobit honors the abandoned slain by burying them.
+            OracleHarness.Righteous(OracleHarness.Witness("Tobit secretly buries the murdered dead despite the king's wrath",
+                new CourageousFaith(), new HonoringTheVulnerable(), new Compassion(),
+                new SelfSacrifice(), new Righteousness()));
+        }
+
+        [Fact]
+        public void TheDemonAsmodeusSlaysSarahsSevenHusbands_IsSin()
+        {
+            // "Asmodeus the evil spirit had slain" Sarah's seven husbands before they came to her. (Tobit 3:8)
+            // The demon's murderous jealousy is capital bloodshed and disorders reality utterly.
+            Resolution r = OracleHarness.Grounded("the demon Asmodeus murders Sarah's seven bridegrooms",
+                Grounding.InIdol("Asmodeus"),
+                new Murder(), new Bloodshed(), new Jealousy(), new Malice());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void TobitPraysInHisAfflictionAndBlindness_IsRighteous()
+        {
+            // Blinded and grieved, Tobit prays: "Deal with me according to thy pleasure ... command my spirit to be taken." (Tobit 3:1-6)
+            // Humble, repentant trust that justifies God even in suffering.
+            OracleHarness.Righteous(OracleHarness.Witness("Tobit prays in his blindness, trusting God's justice",
+                new Repentance(), new Trust(), new Humility(), new Worship(), new Endurance()));
+        }
+
+        [Fact]
+        public void SarahPraysInHerDistressRefusingToCurseOrDespair_IsRighteous()
+        {
+            // Reproached and grieved to death, Sarah will not take her life but prays toward heaven. (Tobit 3:11-15)
+            // She blesses God and pleads her innocence with patient trust.
+            OracleHarness.Righteous(OracleHarness.Witness("Sarah prays toward heaven in her grief and blesses God",
+                new Worship(), new Trust(), new Purity(), new Humility(), new Endurance()));
+        }
+
+        [Fact]
+        public void GodSendsRaphaelToHealTobitAndSarah_IsADivineAct()
+        {
+            // "The prayers of them both were heard ... Raphael was sent to heal them both." (Tobit 3:16-17)
+            // God hears the afflicted and dispatches His angel to deliver and heal.
+            OracleHarness.DivineAct(OracleHarness.Witness("God sends the angel Raphael to heal Tobit and Sarah",
+                new Healing(), new Deliverance(), new Compassion(),
+                new CovenantFaithfulness(), new Goodness()));
+        }
+
+        [Fact]
+        public void TobitTeachesTobiasToFearGodAndGiveAlms_IsRighteous()
+        {
+            // "Give alms of thy substance ... for alms deliver from death." (Tobit 4:5-11,16)
+            // The father instructs his son in righteousness, charity, and the fear of the Lord.
+            OracleHarness.Righteous(OracleHarness.Witness("Tobit instructs Tobias to fear God and give alms",
+                new TeachingTruth(), new Generosity(), new ObedienceToGod(),
+                new Righteousness(), new FeedingTheHungry()));
+        }
+
+        [Fact]
+        public void RaphaelGuidesAndProtectsTobiasOnTheJourney_IsADivineAct()
+        {
+            // The angel goes with Tobias as a faithful guide and guardian on the road to Media. (Tobit 5:4-6:1)
+            // God's messenger protects and leads the son safely.
+            OracleHarness.DivineAct(OracleHarness.Witness("Raphael guides and guards Tobias on the journey",
+                new Protection(), new Trustworthiness(), new Fidelity(),
+                new Deliverance(), new Goodness()));
+        }
+
+        [Fact]
+        public void TobiasBindsTheDemonAndMarriesSarahInPrayer_IsRighteous()
+        {
+            // Tobias burns the fish heart so the demon flees, then prays with Sarah: "not for lust but in truth." (Tobit 8:1-9)
+            // Pure, prayerful marriage that drives out evil and honors God.
+            OracleHarness.Righteous(OracleHarness.Witness("Tobias drives off the demon and weds Sarah in pure prayer",
+                new Purity(), new Worship(), new SelfControl(),
+                new CourageousFaith(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TobiasHealsHisFathersBlindnessWithTheGall_IsRighteous()
+        {
+            // Tobias anoints Tobit's eyes with the fish gall and his sight is restored. (Tobit 11:10-14)
+            // The son, by God's appointed remedy, heals his blind father and restores him.
+            OracleHarness.Righteous(OracleHarness.Witness("Tobias anoints and heals his father's blind eyes",
+                new Healing(), new CaringForTheSick(), new Compassion(), new Goodness()));
+        }
+
+        [Fact]
+        public void RaphaelRevealsHePresentedTheirPrayersBeforeGod_IsADivineAct()
+        {
+            // "I am Raphael, one of the seven holy angels, which ... go in before the glory of the Holy One." (Tobit 12:6-15)
+            // The angel reveals he bore their prayers and almsdeeds to God, who heard and delivered them.
+            OracleHarness.DivineAct(OracleHarness.Witness("Raphael reveals he carried their prayers before God's glory",
+                new Deliverance(), new Healing(), new Fidelity(),
+                new RejoicingInTruth(), new Goodness()));
+        }
+
+        [Fact]
+        public void TobitSingsHisHymnBlessingTheGodOfIsrael_IsRighteous()
+        {
+            // "Blessed be God that liveth for ever ... let all men praise him." (Tobit 13:1-18)
+            // Restored Tobit pours out a hymn of joyful, faithful praise to the Lord.
+            OracleHarness.Righteous(OracleHarness.Witness("Tobit sings his hymn of praise to the everlasting God",
+                new Worship(), new Joy(), new RejoicingInTruth(),
+                new Fidelity(), new Goodness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/WisdomBooksOracleTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/WisdomBooksOracleTests.cs
@@ -1,0 +1,50 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Oracle 25, 26, 27, 28: Tegsats (Reproof), Metsihafe Tibeb (Wisdom of Solomon), Ecclesiastes,
+    // Song of Songs.
+    public class WisdomBooksOracleTests
+    {
+        [Fact]
+        public void ReceivingReproofInHumility_IsRighteous()
+        {
+            // The book of Reproof: "whoever heeds correction gains understanding." (Proverbs 15:32)
+            OracleHarness.Righteous(OracleHarness.Witness("heeding reproof", new Repentance(), new Humility()));
+        }
+
+        [Fact]
+        public void TheUngodlyOppressTheRighteous_IsSin()
+        {
+            // "Let us oppress the righteous poor man." (Wisdom of Solomon 2:10)
+            OracleHarness.Sin(OracleHarness.Witness("the ungodly oppress the righteous", new Oppression(), new Wrongdoing()));
+        }
+
+        [Fact]
+        public void TheSoulsOfTheRighteousAreInGodsHand_IsADivineAct()
+        {
+            // "The souls of the righteous are in the hand of God." (Wisdom of Solomon 3:1)
+            OracleHarness.DivineAct(OracleHarness.Witness("the righteous in God's hand", new Righteousness(), new Compassion()));
+        }
+
+        [Fact]
+        public void FearGodAndKeepHisCommandments_IsRighteous()
+        {
+            // "Fear God and keep his commandments ... God will bring every deed into judgment." (Ecc 12:13-14)
+            OracleHarness.Righteous(OracleHarness.Witness("fear God and keep His commandments",
+                new ObedienceToGod(), new Humility()));
+        }
+
+        [Fact]
+        public void CovenantLoveOfTheBride_IsRighteous()
+        {
+            // "Love is as strong as death." (Song of Songs 8:6) Faithful covenant love.
+            OracleHarness.Righteous(OracleHarness.Witness("the love of the bride and bridegroom",
+                new CovenantFaithfulness(), new Compassion()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/WisdomOfSolomonNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/WisdomOfSolomonNarrativeTests.cs
@@ -1,0 +1,147 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Wisdom of Solomon narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class WisdomOfSolomonNarrativeTests
+    {
+        [Fact]
+        public void LoveRighteousnessAndSeekTheLordInSinglenessOfHeart_IsRighteous()
+        {
+            // "Love righteousness, you rulers of the earth ... seek him in singleness of heart." (Wisdom 1:1-2)
+            // The book opens calling the powerful to honest, trusting pursuit of God.
+            OracleHarness.Righteous(OracleHarness.Witness("The rulers of the earth are called to love righteousness and seek the Lord in singleness of heart",
+                new Righteousness(), new Trust(), new RejoicingInTruth(), new Purity(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void TheUngodlyOppressThePoorManAndCrushTheWidow_IsSin()
+        {
+            // "Let us oppress the righteous poor man ... let not the widow's costly garment escape us." (Wisdom 2:10)
+            // The ungodly reason themselves into preying on the weak as their measure of strength.
+            OracleHarness.Sin(OracleHarness.Witness("The ungodly resolve to oppress the poor man and crush the widow and the aged",
+                new Oppression(), new Greed(), new Heartlessness(), new Wrongdoing()));
+        }
+
+        [Fact]
+        public void TheUngodlyPlotToCondemnTheRighteousManToAShamefulDeath_IsSin()
+        {
+            // "Let us lie in wait for the righteous man ... let us condemn him to a shameful death." (Wisdom 2:12-20)
+            // They hate the righteous one for reproving them and conspire to murder him by torture.
+            OracleHarness.Sin(OracleHarness.Witness("The ungodly lie in wait to condemn the righteous man to a shameful death",
+                new Murder(), new WickedScheming(), new Hatred(), new Bloodshed(), new Condemnation()));
+            Assert.Equal(1.0, OracleHarness.Witness("The ungodly lie in wait to condemn the righteous man to a shameful death",
+                new Murder(), new WickedScheming(), new Hatred(), new Bloodshed(), new Condemnation()).Disorder);
+        }
+
+        [Fact]
+        public void TheSoulsOfTheRighteousAreInTheHandOfGod_IsADivineAct()
+        {
+            // "The souls of the righteous are in the hand of God, and no torment will ever touch them." (Wisdom 3:1-9)
+            // God Himself guards, tests as gold, and grants peace and immortality to the faithful.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God holds the souls of the righteous in His hand, beyond the reach of torment",
+                Grounding.InGod(),
+                new Protection(), new Peace(), new Fidelity(), new RestoringLife(), new JustRecompense()));
+        }
+
+        [Fact]
+        public void SolomonLovesWisdomAndPraysToReceiveHerFromGod_IsRighteous()
+        {
+            // "I prayed, and understanding was given me; I called upon God, and the spirit of wisdom came to me." (Wisdom 7:7; 8:21)
+            // Solomon counts wisdom above thrones and wealth and humbly asks God for her.
+            OracleHarness.Righteous(OracleHarness.Grounded("Solomon prays to God and receives the spirit of wisdom, prizing her above power and riches",
+                Grounding.InGod(),
+                new Humility(), new Worship(), new Trust(), new HungerForRighteousness(), new ObedienceToGod()));
+        }
+
+        [Fact]
+        public void WisdomDeliversTheRighteousThroughHistoryFromAdamToTheExodus_IsADivineAct()
+        {
+            // "Wisdom protected the first-formed father ... she rescued a righteous man ... she did not abandon
+            //  the righteous man when he was sold." (Wisdom 10:1-21) God's wisdom guards Adam, Noah, Abraham,
+            //  Lot, Jacob, and Joseph, and brings Israel through the sea.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God's wisdom protects and delivers the righteous from Adam down to the Exodus",
+                Grounding.InGod(),
+                new Protection(), new Deliverance(), new Righteousness(), new Fidelity(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void GodIsMercifulToAllAndOverlooksSinsThatMenMayRepent_IsADivineAct()
+        {
+            // "You are merciful to all ... you overlook men's sins, that they may repent ... you spare all things,
+            //  for they are yours, O Lord who loves the living." (Wisdom 11:23-26; 12:16-19)
+            // God's sovereign power is shown in mercy, patience, and the call to repentance.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God in His mercy spares all and overlooks sins so that men may repent",
+                Grounding.InGod(),
+                new Compassion(), new Patience(), new Forgiveness(), new Goodness(), new Pardon()));
+        }
+
+        [Fact]
+        public void MenWorshipTheCreaturesOfTheWorldInsteadOfTheirMaker_IsSin()
+        {
+            // "They supposed that either fire or wind ... or the luminaries of heaven were the gods that rule the world."
+            //  (Wisdom 13:1-9) Vain men admire the works and miss the Artisan, exchanging the Creator for creation.
+            OracleHarness.Sin(OracleHarness.Grounded("Men worship fire, wind, and the stars as gods instead of their Maker",
+                Grounding.InIdol("the elements and luminaries of the world"),
+                new Idolatry(), new GravenImage(), new Ingratitude(), new Deceit()));
+        }
+
+        [Fact]
+        public void TheIdolMakerPraysForLifeToALifelessThingHisHandsHaveShaped_IsSin()
+        {
+            // "He prays for ... health he calls upon a thing that is weak; for life he prays to a thing that is dead."
+            //  (Wisdom 13:10-19; 15:7-17) The craftsman shapes a dead idol and bows to the work of his own hands.
+            OracleHarness.Sin(OracleHarness.Grounded("The craftsman shapes a lifeless idol and prays to the dead work of his own hands",
+                Grounding.InIdol("an idol carved by the craftsman's hands"),
+                new Idolatry(), new GravenImage(), new Blasphemy(), new Deceit()));
+        }
+
+        [Fact]
+        public void IdolatryDescendsIntoChildSacrificeAndEveryDefilement_IsSin()
+        {
+            // "For ... they either kill their children in their initiations ... the worship of idols ... is the
+            //  beginning and cause and end of every evil." (Wisdom 14:23-27) Idolatry breeds child-murder,
+            //  defilement, and lawlessness.
+            OracleHarness.Sin(OracleHarness.Grounded("Idol worshippers slaughter their children in secret rites and plunge into every defilement",
+                Grounding.InIdol("idols of the heathen"),
+                new ChildSacrifice(), new Idolatry(), new Defilement(), new Bloodshed(), new SexualImmorality()));
+            Assert.Equal(1.0, OracleHarness.Grounded("Idol worshippers slaughter their children in secret rites and plunge into every defilement",
+                Grounding.InIdol("idols of the heathen"),
+                new ChildSacrifice(), new Idolatry(), new Defilement(), new Bloodshed(), new SexualImmorality()).Disorder);
+        }
+
+        [Fact]
+        public void GodFeedsHisPeopleWithBreadFromHeavenSuitedToEveryTaste_IsADivineAct()
+        {
+            // "You gave your people food of angels ... bread ready to eat ... suited to every taste." (Wisdom 16:20-26)
+            // While Egypt is plagued, God nourishes Israel with manna from heaven by His sustaining word.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God feeds Israel in the wilderness with bread from heaven suited to every taste",
+                Grounding.InGod(),
+                new FeedingTheHungry(), new Goodness(), new Kindness(), new Fidelity(), new Protection()));
+        }
+
+        [Fact]
+        public void GodSavesByTheBronzeSerpentAsASymbolOfDeliverance_IsADivineAct()
+        {
+            // "He who turned toward it was saved, not by what he saw, but by you, the Savior of all." (Wisdom 16:5-7)
+            // When the serpents bit Israel, the one who looked was healed, for God Himself is their deliverance.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God heals the serpent-bitten who look to the bronze sign, saving them as the Deliverer of all",
+                Grounding.InGod(),
+                new Healing(), new Deliverance(), new RestoringLife(), new Compassion(), new Protection()));
+        }
+
+        [Fact]
+        public void GodLeadsIsraelThroughTheRedSeaWhileTheEgyptiansAreDrowned_IsADivineAct()
+        {
+            // "They saw a marvelous crossing ... grass sprang up in the deep ... the whole creation was fashioned anew."
+            //  (Wisdom 19:1-9) God opens the sea as a saving path for His covenant people at the Exodus.
+            OracleHarness.DivineAct(OracleHarness.Grounded("God brings Israel safely through the Red Sea as on dry land and delivers them from Egypt",
+                Grounding.InGod(),
+                new Deliverance(), new Protection(), new CovenantFaithfulness(), new CreationOrder(), new PromiseFulfilled()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/ZechariahNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/ZechariahNarrativeTests.cs
@@ -1,0 +1,204 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Zechariah narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class ZechariahNarrativeTests
+    {
+        [Fact]
+        public void GodCallsThePeopleToReturnToHim_IsADivineAct()
+        {
+            // Return to Me, says the LORD of hosts, and I will return to you (Zechariah 1:3).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD of hosts calls His people to return to Him, promising He will return to them",
+                new Compassion(), new CovenantFaithfulness(), new Forgiveness()));
+        }
+
+        [Fact]
+        public void TheFathersRebelledAgainstTheProphets_IsSin()
+        {
+            // Be not as your fathers, who would not hear nor heed Me, says the LORD (Zechariah 1:4-6).
+            OracleHarness.Sin(OracleHarness.Witness("the fathers refused to hear the former prophets and turn from their evil ways and deeds",
+                new Disobedience(), new Rebellion()));
+        }
+
+        [Fact]
+        public void GodIsJealousForZionAndAngryWithTheNationsAtEase_IsADivineAct()
+        {
+            // I am exceedingly jealous for Jerusalem and for Zion, and very angry with the nations at ease (Zechariah 1:14-15).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD declares His jealous love for Zion and His just anger against the nations who furthered the affliction",
+                new CovenantFaithfulness(), new JustRecompense(), new Protection()));
+        }
+
+        [Fact]
+        public void GodPromisesToReturnToJerusalemWithMercyAndRebuildHisHouse_IsADivineAct()
+        {
+            // I have returned to Jerusalem with mercy; My house shall be built in it (Zechariah 1:16-17).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD returns to Jerusalem with mercy, that His house may be rebuilt and His cities overflow with prosperity",
+                new Compassion(), new RestoringLife(), new PromiseFulfilled(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void TheHornsScatteredJudahAndIsrael_IsSin()
+        {
+            // These are the horns that have scattered Judah, Israel, and Jerusalem (Zechariah 1:18-21).
+            OracleHarness.Sin(OracleHarness.Witness("the nations as horns scatter and oppress Judah, Israel, and Jerusalem so none lifts up his head",
+                new Oppression(), new Wrongdoing()));
+        }
+
+        [Fact]
+        public void GodPromisesToBeAWallOfFireAndGloryAroundJerusalem_IsADivineAct()
+        {
+            // I will be to her a wall of fire all around, and I will be the glory in her midst (Zechariah 2:5).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD promises to dwell in the midst of Jerusalem as a wall of fire around her and her glory within",
+                new Protection(), new Deliverance(), new PromiseFulfilled(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void GodGuardsHisPeopleAsTheAppleOfHisEye_IsADivineAct()
+        {
+            // He who touches you touches the apple of His eye (Zechariah 2:8-9).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD guards His people as the apple of His eye and rises to defend them against the plundering nations",
+                new Protection(), new DefendingTheWeak(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void SatanAccusesJoshuaTheHighPriest_IsSin()
+        {
+            // Satan stood at his right hand to accuse him (Zechariah 3:1).
+            OracleHarness.Sin(OracleHarness.Witness("Satan stands at the right hand of Joshua the high priest to accuse and condemn him before the angel of the LORD",
+                new Condemnation(), new Malice()));
+        }
+
+        [Fact]
+        public void GodTakesAwayJoshuasFilthAndClothesHimAnew_IsADivineAct()
+        {
+            // I have taken your iniquity away from you, and I will clothe you with pure vestments (Zechariah 3:4).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD removes Joshua's filthy garments, takes away his iniquity, and clothes him with clean vestments",
+                new Pardon(), new Forgiveness(), new Atonement(), new RestoringLife()));
+        }
+
+        [Fact]
+        public void GodPromisesToRemoveIniquityInOneDayThroughTheBranch_IsADivineAct()
+        {
+            // I will bring forth My servant the Branch, and I will remove the iniquity of this land in a single day (Zechariah 3:8-9).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD promises to bring His servant the Branch and to remove the iniquity of the land in a single day",
+                new PromiseFulfilled(), new Atonement(), new Pardon(), new Deliverance()));
+        }
+
+        [Fact]
+        public void TheWorkIsDoneNotByMightButByGodsSpirit_IsADivineAct()
+        {
+            // Not by might, nor by power, but by My Spirit, says the LORD of hosts (Zechariah 4:6).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD declares that Zerubbabel will finish the temple not by might nor by power but by His Spirit",
+                new PromiseFulfilled(), new CovenantFaithfulness(), new Deliverance()));
+        }
+
+        [Fact]
+        public void TheFlyingScrollCursesThievesAndFalseSwearers_IsSin()
+        {
+            // This is the curse: every thief and everyone who swears falsely shall be cut off (Zechariah 5:3-4).
+            OracleHarness.Sin(OracleHarness.Witness("the flying scroll brings the curse upon every thief and everyone who swears falsely by the LORD's name",
+                new Theft(), new FalseWitness(), new MisusingGodsName()));
+        }
+
+        [Fact]
+        public void TheBranchBuildsTheTempleAndRulesAsPriestKing_IsADivineAct()
+        {
+            // Behold the Man whose name is the Branch; He shall build the temple of the LORD and be a priest on His throne (Zechariah 6:12-13).
+            OracleHarness.DivineAct(OracleHarness.Witness("the Branch builds the temple of the LORD and reigns as priest upon His throne in peace",
+                new PromiseFulfilled(), new Peacemaking(), new Righteousness(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void GodCommandsTrueJusticeMercyAndCareForTheVulnerable_IsADivineAct()
+        {
+            // Render true judgments, show kindness and mercy; do not oppress the widow, orphan, sojourner, or poor (Zechariah 7:9-10).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD commands His people to render true judgments and show kindness and mercy to the widow, orphan, sojourner, and poor",
+                new Righteousness(), new Kindness(), new Compassion(), new DefendingTheWeak(), new HonoringTheVulnerable()));
+        }
+
+        [Fact]
+        public void ThePeopleRefusedToListenAndHardenedTheirHearts_IsSin()
+        {
+            // They refused to pay attention, turned a stubborn shoulder, and made their hearts diamond-hard (Zechariah 7:11-12).
+            OracleHarness.Sin(OracleHarness.Witness("the people turn a stubborn shoulder, stop their ears, and make their hearts hard so they will not hear the law",
+                new Disobedience(), new Rebellion(), new Heartlessness()));
+        }
+
+        [Fact]
+        public void GodPromisesToReturnAndDwellInZionAsTheFaithfulCity_IsADivineAct()
+        {
+            // I will return to Zion and dwell in Jerusalem, and it shall be called the faithful city (Zechariah 8:3-5).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD returns to dwell in Zion so old men and children fill the streets of the faithful city in peace",
+                new RestoringLife(), new Protection(), new PromiseFulfilled(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void GodCommandsTruthfulSpeechAndPeacefulJudgmentNotEvilScheming_IsADivineAct()
+        {
+            // Speak the truth to one another, render true and peaceful judgments, do not devise evil or love false oaths (Zechariah 8:16-17).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD commands His people to speak truth to one another and render judgments of truth and peace in their gates",
+                new TeachingTruth(), new Peacemaking(), new Righteousness(), new Trustworthiness()));
+        }
+
+        [Fact]
+        public void ZionsKingComesLowlyAndRidingOnADonkeyBringingPeace_IsADivineAct()
+        {
+            // Behold, your King comes to you, righteous and having salvation, lowly and riding on a donkey (Zechariah 9:9-10).
+            OracleHarness.DivineAct(OracleHarness.Witness("Zion's King comes righteous and bringing salvation, lowly and riding on a donkey, speaking peace to the nations",
+                new Humility(), new Righteousness(), new Deliverance(), new Peacemaking(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void TheWorthlessShepherdsAndDivinersLeadThePeopleAstray_IsSin()
+        {
+            // The idols speak deceit, the diviners see lies; the people wander for lack of a shepherd (Zechariah 10:2).
+            OracleHarness.Sin(OracleHarness.Witness("the household idols speak deceit and the diviners see lies, so the people wander like sheep afflicted for want of a shepherd",
+                new Idolatry(), new Deceit(), new Sorcery(), new Oppression()));
+        }
+
+        [Fact]
+        public void TheGoodShepherdIsValuedAtThirtyPiecesOfSilver_IsSin()
+        {
+            // So they weighed out my wages, thirty pieces of silver, the lordly price at which I was priced (Zechariah 11:12-13).
+            OracleHarness.Sin(OracleHarness.Witness("the flock prices the good shepherd at thirty pieces of silver and casts him off, despising the LORD's care",
+                new Treachery(), new Ingratitude(), new Greed()));
+        }
+
+        [Fact]
+        public void GodPoursOutTheSpiritOfGraceAndTheyMournHimWhomTheyPierced_IsADivineAct()
+        {
+            // I will pour out a spirit of grace and supplication; they shall look on Me whom they have pierced and mourn (Zechariah 12:10).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD pours out a spirit of grace and supplication so they look on Him whom they pierced and mourn in repentance",
+                new Compassion(), new Forgiveness(), new RestoringLife(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void GodOpensAFountainToCleanseFromSinAndImpurity_IsADivineAct()
+        {
+            // On that day a fountain shall be opened for the house of David to cleanse them from sin and uncleanness (Zechariah 13:1).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD opens a fountain for the house of David and Jerusalem to cleanse them from sin and uncleanness",
+                new Atonement(), new Pardon(), new Healing(), new RestoringLife()));
+        }
+
+        [Fact]
+        public void GodRefinesTheRemnantSoTheyAreHisPeople_IsADivineAct()
+        {
+            // I will refine them as silver, and they will call on My name; I will say, They are My people (Zechariah 13:9).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD refines the remnant like silver and gold so they call on His name and He answers, They are My people",
+                new RestoringLife(), new CovenantFaithfulness(), new PromiseFulfilled(), new Atonement()));
+        }
+
+        [Fact]
+        public void TheLordBecomesKingOverAllTheEarthHolyToHimAlone_IsADivineAct()
+        {
+            // The LORD will be king over all the earth; on that day the LORD will be one and His name one (Zechariah 14:9).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD becomes King over all the earth, making Jerusalem secure and all things holy to His name",
+                new Righteousness(), new Protection(), new Worship(), new PromiseFulfilled(), new CovenantFaithfulness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/Canon/ZephaniahNarrativeTests.cs
+++ b/AnointedAutomation.Objects.Tests/Canon/ZephaniahNarrativeTests.cs
@@ -1,0 +1,144 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests.Canon
+{
+    // Zephaniah narrative oracle: the engine must return the verdict Scripture gives at each step.
+    public class ZephaniahNarrativeTests
+    {
+        [Fact]
+        public void GodDeclaresTheGreatDayOfJudgmentOverTheWholeEarth_IsADivineAct()
+        {
+            // I will utterly sweep away everything from the face of the earth, declares the LORD (Zephaniah 1:2-3).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD announces His just judgment to sweep away the corruption of the whole land",
+                new JustRecompense(), new Righteousness()));
+        }
+
+        [Fact]
+        public void JudahWorshipsBaalAndBowsToTheHostOfHeaven_IsSin()
+        {
+            // I will cut off the remnant of Baal, and those who bow down on the roofs to the host of the heavens (Zephaniah 1:4-5).
+            OracleHarness.Sin(OracleHarness.Grounded("Judah burns incense to Baal and bows to the starry host upon their rooftops",
+                Grounding.InIdol("Baal"), new Idolatry(), new Worship()));
+        }
+
+        [Fact]
+        public void ThePeopleSwearByMilcomAndTurnBackFromTheLord_IsSin()
+        {
+            // Those who bow down and swear to the LORD and yet swear by Milcom, who have turned back from following the LORD (Zephaniah 1:5-6).
+            OracleHarness.Sin(OracleHarness.Grounded("the people swear by Milcom and turn back from following the LORD",
+                Grounding.InIdol("Milcom"), new Idolatry(), new Treachery(), new CovenantBreaking()));
+        }
+
+        [Fact]
+        public void TheOfficialsClotheThemselvesInForeignAttireAndPlunder_IsSin()
+        {
+            // I will punish the officials and the king's sons and all who fill their master's house with violence and fraud (Zephaniah 1:8-9).
+            Resolution r = OracleHarness.Witness("the officials and the king's sons fill their master's house with violence and fraud",
+                new Bloodshed(), new Oppression(), new Deceit(), new Theft());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void TheComplacentSayTheLordWillDoNothing_IsSin()
+        {
+            // I will punish the men who are complacent, who say in their hearts, the LORD will not do good, nor will He do ill (Zephaniah 1:12).
+            OracleHarness.Sin(OracleHarness.Witness("the complacent men say in their hearts that the LORD will do neither good nor ill",
+                new Sloth(), new Pride(), new Disobedience()));
+        }
+
+        [Fact]
+        public void TheDayOfTheLordIsAtHandAsWrathAndDistress_IsADivineAct()
+        {
+            // The great day of the LORD is near; a day of wrath, a day of distress and anguish (Zephaniah 1:14-18).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD brings near the great Day of the LORD, a day of wrath and just reckoning against sin",
+                new JustRecompense(), new Righteousness()));
+        }
+
+        [Fact]
+        public void ZephaniahCallsTheNationToSeekTheLordInHumility_IsRighteous()
+        {
+            // Seek the LORD, all you humble of the land; seek righteousness, seek humility (Zephaniah 2:1-3).
+            OracleHarness.Righteous(OracleHarness.Witness("Zephaniah calls the humble of the land to gather, seek the LORD, and pursue righteousness and humility",
+                new Repentance(), new Humility(), new Righteousness(), new Worship()));
+        }
+
+        [Fact]
+        public void GodJudgesPhilistiaMoabAndAmmonForTheirTaunts_IsADivineAct()
+        {
+            // I have heard the taunts of Moab and the revilings of the Ammonites, how they have taunted My people (Zephaniah 2:4-11).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD justly judges Philistia, Moab, and Ammon and defends the remnant of His people whom they reviled",
+                new JustRecompense(), new DefendingTheWeak(), new Righteousness()));
+        }
+
+        [Fact]
+        public void NinevehBoastsThatThereIsNoneBesidesHer_IsSin()
+        {
+            // This is the exultant city that said in her heart, I am, and there is no one else (Zephaniah 2:15).
+            OracleHarness.Sin(OracleHarness.Witness("Nineveh, the exultant city, boasts in her heart that there is none besides her",
+                new Pride(), new Boasting(), new SelfSeeking()));
+        }
+
+        [Fact]
+        public void JerusalemsOfficialsAreRoaringLionsAndJudgesAreEveningWolves_IsSin()
+        {
+            // Her officials within her are roaring lions; her judges are evening wolves that leave nothing till the morning (Zephaniah 3:1-3).
+            Resolution r = OracleHarness.Witness("the officials of Jerusalem are roaring lions and her judges are evening wolves who devour the people",
+                new Oppression(), new Bloodshed(), new Greed(), new Lawlessness());
+            OracleHarness.Sin(r);
+            Assert.Equal(1.0, r.Disorder);
+        }
+
+        [Fact]
+        public void HerProphetsAreTreacherousAndPriestsProfaneWhatIsHoly_IsSin()
+        {
+            // Her prophets are fickle, treacherous men; her priests profane what is holy and do violence to the law (Zephaniah 3:4).
+            OracleHarness.Sin(OracleHarness.Witness("the prophets of Jerusalem are treacherous and her priests profane the sanctuary and do violence to the law",
+                new Treachery(), new Defilement(), new Lawlessness()));
+        }
+
+        [Fact]
+        public void TheLordWithinHerIsRighteousAndDoesNoInjustice_IsADivineAct()
+        {
+            // The LORD within her is righteous; He does no injustice; every morning He shows forth His justice (Zephaniah 3:5).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD in the midst of the city is righteous and does no injustice, bringing His justice to light every morning",
+                new Righteousness(), new JustRecompense(), new Fidelity()));
+        }
+
+        [Fact]
+        public void GodPromisesToPurifyThePeoplesSpeechToCallOnHisName_IsADivineAct()
+        {
+            // For at that time I will change the speech of the peoples to a pure speech, that all of them may call upon the LORD (Zephaniah 3:9).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD purifies the lips of the peoples that all may call upon His name and serve Him with one accord",
+                new Purity(), new RestoringLife(), new PromiseFulfilled()));
+        }
+
+        [Fact]
+        public void GodLeavesAHumbleAndLowlyRemnantWhoTrustInHisName_IsADivineAct()
+        {
+            // I will leave in your midst a people humble and lowly; they shall seek refuge in the name of the LORD (Zephaniah 3:12-13).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD leaves a humble and lowly remnant who take refuge in His name and speak no lies",
+                new Protection(), new Deliverance(), new CovenantFaithfulness(), new Humility()));
+        }
+
+        [Fact]
+        public void GodRejoicesOverHisPeopleWithGladnessAndQuietsThemWithLove_IsADivineAct()
+        {
+            // The LORD your God is in your midst, a mighty one who will save; He will rejoice over you with gladness and quiet you by His love (Zephaniah 3:17).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD rejoices over His people with gladness, quiets them by His love, and exults over them with loud singing",
+                new Joy(), new Compassion(), new Deliverance(), new CovenantFaithfulness()));
+        }
+
+        [Fact]
+        public void GodGathersTheOutcastAndRestoresTheFortunesOfHisPeople_IsADivineAct()
+        {
+            // I will save the lame and gather the outcast; I will restore your fortunes before your eyes, says the LORD (Zephaniah 3:19-20).
+            OracleHarness.DivineAct(OracleHarness.Witness("the LORD saves the lame, gathers the outcast, and restores the fortunes of His people, gathering them home",
+                new HonoringTheVulnerable(), new RestoringLife(), new Deliverance(), new PromiseFulfilled()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/DivineCharacterTests.cs
+++ b/AnointedAutomation.Objects.Tests/DivineCharacterTests.cs
@@ -1,0 +1,82 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests
+{
+    public class DivineCharacterTests
+    {
+        [Fact]
+        public void TheCross_SatisfiesJusticeAndMercyTogether_FullyCoherent_NoDisorder()
+        {
+            // The keystone. The cross is full Justice (the debt is paid, Romans 3:25) and full Mercy
+            // (the guilty go free, Romans 5:8) in one act. A character that SELECTED one attribute
+            // could never express this. Because every facet is always live and they harmonize, both
+            // read fully high and reality is not destabilized.
+            DivineCharacter character = new DivineCharacter(new Justice(), new Mercy());
+            Act theCross = new Act("the cross", new Atonement(), new Pardon());
+
+            Resolution resolution = character.Harmonize(theCross);
+
+            Assert.Equal(1.0, resolution.Coherence);
+            Assert.Equal(0.0, resolution.Disorder);
+            Assert.Equal(1.0, resolution.Reading("Justice"));
+            Assert.Equal(1.0, resolution.Reading("Mercy"));
+        }
+
+        [Fact]
+        public void Injustice_ReadsLowAndIntroducesDisorder()
+        {
+            // An act that wrongs a neighbour offends Justice gravely; Mercy is indifferent to it.
+            // Theft is serious but not capital, so it injects serious, not total, disorder.
+            DivineCharacter character = new DivineCharacter(new Justice(), new Mercy());
+            Act theft = new Act("a theft", new Theft());
+
+            Resolution resolution = character.Harmonize(theft);
+
+            Assert.Equal(0.25, resolution.Coherence);
+            Assert.Equal(0.5, resolution.Disorder);
+        }
+
+        [Fact]
+        public void Murder_UnleashesMoreDisorderThanTheft()
+        {
+            // Scripture grades sin: murder is capital (Genesis 9:6), theft is answered by restitution
+            // (Exodus 22:1). The gravest wrong must destabilize reality more, not the same.
+            DivineCharacter character = new DivineCharacter(new Justice(), new LoveFacet());
+
+            Resolution murder = character.Harmonize(new Act("Cain kills Abel", new Murder()));
+            Resolution theft = character.Harmonize(new Act("a theft", new Theft()));
+
+            Assert.Equal(1.0, murder.Disorder);
+            Assert.True(murder.Disorder > theft.Disorder);
+        }
+
+        [Fact]
+        public void Rudeness_BarelyDisordersReality()
+        {
+            // A rude word is a real wrong, but minor: it troubles reality only slightly, nothing like
+            // the destruction of a capital crime.
+            DivineCharacter character = new DivineCharacter(new LoveFacet());
+
+            Resolution resolution = character.Harmonize(new Act("a harsh word", new Rudeness()));
+
+            Assert.Equal(0.25, resolution.Disorder);
+        }
+
+        [Fact]
+        public void IndifferentAct_IsNeitherCoherentNorDisordering()
+        {
+            // An act that touches no facet sits neutral and does not destabilize reality.
+            DivineCharacter character = new DivineCharacter(new Justice(), new Mercy());
+            Act sunset = new Act("watching a sunset");
+
+            Resolution resolution = character.Harmonize(sunset);
+
+            Assert.Equal(0.5, resolution.Coherence);
+            Assert.Equal(0.0, resolution.Disorder);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/FaithfulnessTests.cs
+++ b/AnointedAutomation.Objects.Tests/FaithfulnessTests.cs
@@ -1,0 +1,39 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests
+{
+    public class FaithfulnessTests
+    {
+        [Fact]
+        public void Faithfulness_IsNamed()
+        {
+            Faithfulness faith = new Faithfulness();
+
+            Assert.Equal("Faithfulness", faith.Name);
+        }
+
+        [Fact]
+        public void CovenantFaithfulness_ReadsFullyCoherent_ToOrder()
+        {
+            // "Great is your faithfulness." (Lamentations 3:23)
+            Faithfulness faith = new Faithfulness();
+            Act act = new Act("a covenant kept", new CovenantFaithfulness());
+
+            Assert.Equal(1.0, faith.Read(act));
+        }
+
+        [Fact]
+        public void Treachery_ReadsIncoherent_ToOrder()
+        {
+            // Breaking faith transgresses the order God decreed (Malachi 2:10; 1 Enoch 80).
+            Faithfulness faith = new Faithfulness();
+            Act act = new Act("a covenant betrayed", new Treachery());
+
+            Assert.Equal(0.0, faith.Read(act));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/GravityTests.cs
+++ b/AnointedAutomation.Objects.Tests/GravityTests.cs
@@ -1,0 +1,70 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests
+{
+    public class GravityTests
+    {
+        [Fact]
+        public void AVirtue_HasNoGravity()
+        {
+            // A virtue introduces no destruction; it has no gravity of disorder.
+            Assert.Equal(Gravity.None, new Compassion().Gravity);
+        }
+
+        [Fact]
+        public void Murder_IsCapital()
+        {
+            // "Whoever sheds human blood, by humans shall their blood be shed." (Genesis 9:6)
+            Assert.Equal(Gravity.Capital, new Murder().Gravity);
+        }
+
+        [Fact]
+        public void Bloodshed_IsCapital()
+        {
+            // The shedding of innocent blood (Deuteronomy 19; Proverbs 6:17).
+            Assert.Equal(Gravity.Capital, new Bloodshed().Gravity);
+        }
+
+        [Fact]
+        public void ChildSacrifice_IsCapital()
+        {
+            // "Anyone who sacrifices a child to Molek is to be put to death." (Leviticus 20:2)
+            Assert.Equal(Gravity.Capital, new ChildSacrifice().Gravity);
+        }
+
+        [Fact]
+        public void Defilement_IsCapital()
+        {
+            // The violation of a person is equated with murder: "this case is like that of someone
+            // who attacks and murders a neighbor." (Deuteronomy 22:25-27)
+            Assert.Equal(Gravity.Capital, new Defilement().Gravity);
+        }
+
+        [Fact]
+        public void Theft_IsSerious_NotCapital()
+        {
+            // Theft is grave but answered by restitution, not death (Exodus 22:1-4).
+            Assert.Equal(Gravity.Serious, new Theft().Gravity);
+        }
+
+        [Fact]
+        public void Rudeness_IsMinor()
+        {
+            // A wrong, but not heinous: "Love ... does not dishonor others." (1 Corinthians 13:5)
+            Assert.Equal(Gravity.Minor, new Rudeness().Gravity);
+        }
+
+        [Fact]
+        public void GravityIncreasesInWeight_FromMinorToCapital()
+        {
+            // The ordering is meaningful: heavier wrongs unleash more destruction.
+            Assert.True(Gravity.Minor < Gravity.Serious);
+            Assert.True(Gravity.Serious < Gravity.Grave);
+            Assert.True(Gravity.Grave < Gravity.Capital);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/GroundingTests.cs
+++ b/AnointedAutomation.Objects.Tests/GroundingTests.cs
@@ -1,0 +1,56 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests
+{
+    public class GroundingTests
+    {
+        [Fact]
+        public void InGod_IsGroundedInTheLivingGod()
+        {
+            Grounding grounding = Grounding.InGod();
+
+            Assert.True(grounding.IsInGod);
+        }
+
+        [Fact]
+        public void InIdol_IsNotGroundedInGod_AndIsNamed()
+        {
+            // The idols "do not truly live, they cannot give life." (1 Meqabyan 1)
+            Grounding grounding = Grounding.InIdol("Baal");
+
+            Assert.False(grounding.IsInGod);
+            Assert.Equal("Baal", grounding.Name);
+        }
+
+        [Fact]
+        public void GroundedInGod_BearsADeedUnchanged()
+        {
+            // What stands on the living God keeps its life (1 Meqabyan: God alone gives life).
+            Grounding grounding = Grounding.InGod();
+            Resolution deed = new Resolution(1.0, 0.0);
+
+            Resolution borne = grounding.Bear(deed);
+
+            Assert.Equal(1.0, borne.Coherence);
+            Assert.Equal(0.0, borne.Disorder);
+        }
+
+        [Fact]
+        public void GroundedInAnIdol_DriftsADeedTowardNonBeing()
+        {
+            // Even an outwardly good deed cannot hold when its foundation has no ground: its life
+            // drains and disorder rises (1 Meqabyan).
+            Grounding grounding = Grounding.InIdol("Baal");
+            Resolution deed = new Resolution(1.0, 0.0);
+
+            Resolution borne = grounding.Bear(deed);
+
+            Assert.True(borne.Coherence < 1.0);
+            Assert.True(borne.Disorder > 0.0);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/HeavenlyTabletsTests.cs
+++ b/AnointedAutomation.Objects.Tests/HeavenlyTabletsTests.cs
@@ -1,0 +1,73 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests
+{
+    public class HeavenlyTabletsTests
+    {
+        [Fact]
+        public void NewTablets_AreFullyOrdered()
+        {
+            // Before any deed is witnessed, reality stands fully ordered (1 Enoch 72-82: the courses
+            // of creation keep their decreed law).
+            HeavenlyTablets tablets = new HeavenlyTablets();
+
+            Assert.Equal(1.0, tablets.Coherence());
+        }
+
+        [Fact]
+        public void RecordingDisorder_DegradesCoherence()
+        {
+            // A deed that introduces disorder warps the order of reality (1 Enoch 80).
+            HeavenlyTablets tablets = new HeavenlyTablets();
+
+            tablets.Record(new Resolution(0.5, 0.5));
+
+            Assert.Equal(0.5, tablets.Coherence());
+        }
+
+        [Fact]
+        public void RecordingFaithfulDeeds_LeavesRealityOrdered()
+        {
+            // Deeds that fully cohere introduce no disorder, so the courses of reality keep their law.
+            HeavenlyTablets tablets = new HeavenlyTablets();
+
+            tablets.Record(new Resolution(1.0, 0.0));
+            tablets.Record(new Resolution(1.0, 0.0));
+
+            Assert.Equal(1.0, tablets.Coherence());
+        }
+
+        [Fact]
+        public void Disorder_Accumulates_AcrossDeeds()
+        {
+            // As sinners multiply, disorder compounds and reality drifts further from its order
+            // (1 Enoch 80).
+            HeavenlyTablets tablets = new HeavenlyTablets();
+
+            tablets.Record(new Resolution(0.5, 0.5));
+            tablets.Record(new Resolution(0.5, 0.5));
+
+            Assert.Equal(0.25, tablets.Coherence());
+        }
+
+        [Fact]
+        public void History_ReturnsEveryDeedRecorded_InOrder()
+        {
+            // The tablets hold "the earlier and the later" (Jubilees): the whole record of what was.
+            HeavenlyTablets tablets = new HeavenlyTablets();
+            Resolution first = new Resolution(0.9, 0.1);
+            Resolution second = new Resolution(0.2, 0.8);
+
+            tablets.Record(first);
+            tablets.Record(second);
+
+            Assert.Equal(2, tablets.History().Count);
+            Assert.Same(first, tablets.History()[0]);
+            Assert.Same(second, tablets.History()[1]);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/JusticeTests.cs
+++ b/AnointedAutomation.Objects.Tests/JusticeTests.cs
@@ -1,0 +1,49 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests
+{
+    public class JusticeTests
+    {
+        [Fact]
+        public void Justice_IsNamed()
+        {
+            Justice justice = new Justice();
+
+            Assert.Equal("Justice", justice.Name);
+        }
+
+        [Fact]
+        public void JustAct_RendersWhatIsDue_ReadsFullyCoherent()
+        {
+            // "Render to all what is due them." (Romans 13:7)
+            Justice justice = new Justice();
+            Act act = new Act("a debt rendered", new JustRecompense());
+
+            Assert.Equal(1.0, justice.Read(act));
+        }
+
+        [Fact]
+        public void Theft_ReadsIncoherent_ToJustice()
+        {
+            // Taking what is not yours wrongs the neighbour (Exodus 20:15).
+            Justice justice = new Justice();
+            Act act = new Act("a theft", new Theft());
+
+            Assert.Equal(0.0, justice.Read(act));
+        }
+
+        [Fact]
+        public void IndifferentAct_ReadsNeutral_ToJustice()
+        {
+            // An act that neither renders due nor wrongs anyone sits at the neutral midpoint.
+            Justice justice = new Justice();
+            Act act = new Act("watching a sunset");
+
+            Assert.Equal(0.5, justice.Read(act));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/LoveFacetTests.cs
+++ b/AnointedAutomation.Objects.Tests/LoveFacetTests.cs
@@ -1,0 +1,58 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests
+{
+    public class LoveFacetTests
+    {
+        [Fact]
+        public void LoveFacet_IsNamed()
+        {
+            LoveFacet love = new LoveFacet();
+
+            Assert.Equal("Love", love.Name);
+        }
+
+        [Fact]
+        public void LoveFacet_IsBackedByAgape()
+        {
+            // God's love is agape, perfect and sourced in Him (1 John 4:8; 1 Corinthians 13:4-8).
+            LoveFacet love = new LoveFacet();
+
+            Assert.True(love.Agape.IsPerfect());
+        }
+
+        [Fact]
+        public void Compassion_ReadsFullyCoherent_ToLove()
+        {
+            // "Love ... always protects." (1 Corinthians 13:7)
+            LoveFacet love = new LoveFacet();
+            Act act = new Act("binding the wounds of a stranger", new Compassion());
+
+            Assert.Equal(1.0, love.Read(act));
+        }
+
+        [Fact]
+        public void SelfSacrifice_ReadsFullyCoherent_ToLove()
+        {
+            // "Greater love has no one than this: to lay down one's life for one's friends." (John 15:13)
+            LoveFacet love = new LoveFacet();
+            Act act = new Act("the cross", new SelfSacrifice());
+
+            Assert.Equal(1.0, love.Read(act));
+        }
+
+        [Fact]
+        public void SelfSeeking_ReadsIncoherent_ToLove()
+        {
+            // Agape "is not self-seeking." (1 Corinthians 13:5)
+            LoveFacet love = new LoveFacet();
+            Act act = new Act("passing by on the other side", new SelfSeeking());
+
+            Assert.Equal(0.0, love.Read(act));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/MercyTests.cs
+++ b/AnointedAutomation.Objects.Tests/MercyTests.cs
@@ -1,0 +1,49 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests
+{
+    public class MercyTests
+    {
+        [Fact]
+        public void Mercy_IsNamed()
+        {
+            Mercy mercy = new Mercy();
+
+            Assert.Equal("Mercy", mercy.Name);
+        }
+
+        [Fact]
+        public void Pardon_ReadsFullyCoherent_ToMercy()
+        {
+            // "While we were still sinners, Christ died for us." (Romans 5:8); the guilty spared.
+            Mercy mercy = new Mercy();
+            Act act = new Act("the guilty pardoned", new Pardon());
+
+            Assert.Equal(1.0, mercy.Read(act));
+        }
+
+        [Fact]
+        public void Compassion_ReadsFullyCoherent_ToMercy()
+        {
+            // "Be merciful, even as your Father is merciful." (Luke 6:36)
+            Mercy mercy = new Mercy();
+            Act act = new Act("tending the wounded", new Compassion());
+
+            Assert.Equal(1.0, mercy.Read(act));
+        }
+
+        [Fact]
+        public void Condemnation_ReadsIncoherent_ToMercy()
+        {
+            // "A bruised reed he will not break." (Matthew 12:20)
+            Mercy mercy = new Mercy();
+            Act act = new Act("crushing the contrite", new Condemnation());
+
+            Assert.Equal(0.0, mercy.Read(act));
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/MoralConceptTests.cs
+++ b/AnointedAutomation.Objects.Tests/MoralConceptTests.cs
@@ -1,0 +1,53 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests
+{
+    public class MoralConceptTests
+    {
+        [Fact]
+        public void MoralConcept_IsAbstract()
+        {
+            // A moral concept is abstract code, not a magic string; each concrete concept supplies
+            // its own name, Scripture, and stance toward God's character.
+            Assert.True(typeof(MoralConcept).IsAbstract);
+        }
+
+        [Fact]
+        public void Compassion_UpholdsLoveAndMercy_AndCarriesScripture()
+        {
+            // "Be merciful, even as your Father is merciful." (Luke 6:36)
+            Compassion compassion = new Compassion();
+
+            Assert.True(compassion.Upholds(new LoveFacet()));
+            Assert.True(compassion.Upholds(new Mercy()));
+            Assert.False(compassion.Violates(new Justice()));
+            Assert.False(string.IsNullOrEmpty(compassion.Scripture));
+        }
+
+        [Fact]
+        public void Murder_ViolatesJusticeAndLove()
+        {
+            // "You shall not murder." (Exodus 20:13)
+            Murder murder = new Murder();
+
+            Assert.True(murder.Violates(new Justice()));
+            Assert.True(murder.Violates(new LoveFacet()));
+            Assert.False(murder.Upholds(new Mercy()));
+        }
+
+        [Fact]
+        public void Act_CarriesItsConcepts_AndADescription()
+        {
+            MoralConcept compassion = new Compassion();
+            Act act = new Act("the Samaritan binds the wounds", compassion);
+
+            Assert.Equal("the Samaritan binds the wounds", act.Description);
+            Assert.Single(act.Concepts);
+            Assert.Same(compassion, act.Concepts[0]);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/OracleHarness.cs
+++ b/AnointedAutomation.Objects.Tests/OracleHarness.cs
@@ -1,0 +1,82 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests
+{
+    /// <summary>
+    /// The shared oracle for the canon tests. Scripture is the regression standard: the engine must
+    /// always agree with the Biblical record. A deed is composed of moral concepts, witnessed under
+    /// God's whole revealed character, and judged by one of three verdicts.
+    /// </summary>
+    internal static class OracleHarness
+    {
+        /// <summary>Witnesses a deed (composed of moral concepts) on reality grounded in God.</summary>
+        public static Resolution Witness(string deed, params MoralConcept[] concepts)
+        {
+            return Reality.Revealed().Witness(new Act(deed, concepts));
+        }
+
+        /// <summary>Witnesses a deed done by an agent grounded in something other than God.</summary>
+        public static Resolution Grounded(string deed, Grounding grounding, params MoralConcept[] concepts)
+        {
+            return Reality.Revealed().Witness(new Act(deed, concepts), grounding);
+        }
+
+        /// <summary>
+        /// Witnesses a deed framed by context (war, divine command, defense of the innocent), so a
+        /// context-sensitive concept can be read in its light.
+        /// </summary>
+        public static Resolution WitnessInContext(string deed, Circumstance[] context, params MoralConcept[] concepts)
+        {
+            return Reality.Revealed().Witness(new Act(deed, concepts).InContext(context));
+        }
+
+        /// <summary>An act of God or of Christ: never incoherent, never disorders reality.</summary>
+        public static void DivineAct(Resolution r)
+        {
+            Assert.True(r.Coherence >= 0.5, "An act of God can never read incoherent.");
+            Assert.Equal(0.0, r.Disorder);
+        }
+
+        /// <summary>A righteous human deed: coherent, and it destabilizes nothing.</summary>
+        public static void Righteous(Resolution r)
+        {
+            Assert.True(r.Coherence > 0.5, "A righteous deed must read coherent.");
+            Assert.Equal(0.0, r.Disorder);
+        }
+
+        /// <summary>Sin: always reads incoherent, and always introduces disorder (1 Enoch 80).</summary>
+        public static void Sin(Resolution r)
+        {
+            Assert.True(r.Coherence < 0.5, "Sin must read incoherent.");
+            Assert.True(r.Disorder > 0.0, "Sin must introduce disorder into reality.");
+        }
+
+        /// <summary>
+        /// The fullness: an act in which the whole of God's character is satisfied at once, reading
+        /// perfectly coherent with no disorder (the cross; Micah 6:8). Stricter than DivineAct, which
+        /// only requires non-incoherence. This pins the exact arithmetic so a regression fails loudly.
+        /// </summary>
+        public static void FullyDivine(Resolution r)
+        {
+            Assert.Equal(1.0, r.Coherence);
+            Assert.Equal(0.0, r.Disorder);
+        }
+
+        /// <summary>Asserts a single facet read an exact value, so per-facet nuance is pinned.</summary>
+        public static void Facet(Resolution r, string facet, double expected)
+        {
+            Assert.Equal(expected, r.Reading(facet));
+        }
+
+        /// <summary>Asserts exact coherence and disorder, the finest-grained verdict.</summary>
+        public static void Exact(Resolution r, double coherence, double disorder)
+        {
+            Assert.Equal(coherence, r.Coherence);
+            Assert.Equal(disorder, r.Disorder);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/RealityTests.cs
+++ b/AnointedAutomation.Objects.Tests/RealityTests.cs
@@ -1,0 +1,78 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests
+{
+    public class RealityTests
+    {
+        [Fact]
+        public void Witness_ReturnsTheHarmonizedResolution()
+        {
+            Reality reality = new Reality(new DivineCharacter(new Justice(), new Mercy()));
+            Act theCross = new Act("the cross", new Atonement(), new Pardon());
+
+            Resolution resolution = reality.Witness(theCross);
+
+            Assert.Equal(1.0, resolution.Coherence);
+            Assert.Equal(0.0, resolution.Disorder);
+        }
+
+        [Fact]
+        public void Witness_WritesTheDeedOntoTheTablets()
+        {
+            // State and truth are one system: witnessing both judges the act and records it.
+            Reality reality = new Reality(new DivineCharacter(new Justice(), new Mercy()));
+            Act deed = new Act("a kindness", new JustRecompense());
+
+            reality.Witness(deed);
+
+            Assert.Single(reality.Tablets.History());
+        }
+
+        [Fact]
+        public void WitnessingInjustice_DegradesTheStandingOrderOfReality()
+        {
+            // As sinners multiply their wrong, the order of reality drifts (1 Enoch 80).
+            Reality reality = new Reality(new DivineCharacter(new Justice(), new Mercy()));
+
+            Assert.Equal(1.0, reality.Tablets.Coherence());
+
+            reality.Witness(new Act("a theft", new Theft()));
+
+            // Theft is serious (not capital), so it degrades the world's order without zeroing it.
+            Assert.Equal(0.5, reality.Tablets.Coherence());
+        }
+
+        [Fact]
+        public void WitnessBorneOnAnIdol_RecordsGreaterDisorderThanOnGod()
+        {
+            // The same outwardly-right deed cannot hold on a dead foundation (1 Meqabyan).
+            Act deed = new Act("alms to be seen", new JustRecompense());
+
+            Reality onGod = Reality.Revealed();
+            onGod.Witness(deed, Grounding.InGod());
+
+            Reality onIdol = Reality.Revealed();
+            onIdol.Witness(deed, Grounding.InIdol("vainglory"));
+
+            Assert.Equal(1.0, onGod.Tablets.Coherence());
+            Assert.True(onIdol.Tablets.Coherence() < 1.0);
+        }
+
+        [Fact]
+        public void Revealed_WiresTheStandardCharacter()
+        {
+            // The factory reveals reality already grounded in God's character; no facet is missing.
+            Reality reality = Reality.Revealed();
+            Act theCross = new Act("the cross", new Atonement(), new Pardon());
+
+            Resolution resolution = reality.Witness(theCross);
+
+            Assert.True(resolution.Reading("Justice") >= 0.5);
+            Assert.True(resolution.Reading("Mercy") >= 0.5);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/RedemptiveArcTests.cs
+++ b/AnointedAutomation.Objects.Tests/RedemptiveArcTests.cs
@@ -1,0 +1,217 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests
+{
+    /// <summary>
+    /// The whole arc of Scripture as a regression oracle: creation and the fall, covenant, the
+    /// exodus and the law, Israel as a light to the nations, the line that brings forth the Messiah,
+    /// and Jesus who saves the entire world. The engine must return the verdict the Biblical record
+    /// gives at every step. The acts of God and of Jesus read coherent and never disorder reality;
+    /// alignment with God flourishes, rebellion brings disorder; the deeds that set Israel apart in
+    /// antiquity (not sacrificing children, honoring the vulnerable and the stranger) read coherent,
+    /// and the surrounding nations' practices read as sin. If any step disagrees with Scripture, the
+    /// code is wrong.
+    /// </summary>
+    public class RedemptiveArcTests
+    {
+        // ===== Creation and the Fall (Genesis 1-3) =====
+
+        [Fact]
+        public void GodCreatesAndOrdersTheWorld_IsVeryGood()
+        {
+            // "God saw all that he had made, and it was very good." (Genesis 1:31)
+            AssertDivineAct(Witness(new Act("creation", new CreationOrder(), new CovenantFaithfulness())));
+        }
+
+        [Fact]
+        public void AdamAndEveWalkWithGod_IsCoherent()
+        {
+            // Before the fall, they dwell with God in the garden, aligned with Him (Genesis 2).
+            AssertRighteous(Witness(new Act("walking with God in the garden", new ObedienceToGod())));
+        }
+
+        [Fact]
+        public void TheFall_IsSin_AndDisordersCreation()
+        {
+            // Eating what God forbade is rebellion; death and the curse enter (Genesis 3:6, 3:17-19;
+            // Romans 5:12). Disorder enters reality.
+            AssertSin(Witness(new Act("the fall", new Disobedience(), new Rebellion())));
+        }
+
+        // ===== Covenant (Noah, Abraham) =====
+
+        [Fact]
+        public void GodMakesAndKeepsCovenant_IsFaithful()
+        {
+            // The covenants with Noah and Abraham (Genesis 9; 15; 17). God keeps His word.
+            AssertDivineAct(Witness(new Act("the covenant",
+                new CovenantFaithfulness(), new Trustworthiness())));
+        }
+
+        [Fact]
+        public void AbrahamTrustsGod_IsCreditedAsRighteousness()
+        {
+            // "Abram believed the LORD, and he credited it to him as righteousness." (Genesis 15:6)
+            AssertRighteous(Witness(new Act("Abraham believes God",
+                new ObedienceToGod(), new CovenantFaithfulness())));
+        }
+
+        // ===== Exodus: deliverance, and judgment on the oppressor =====
+
+        [Fact]
+        public void GodDeliversIsraelFromEgypt_IsMercyAndFaithfulness()
+        {
+            // "I have come down to rescue them from the hand of the Egyptians." (Exodus 3:8)
+            AssertDivineAct(Witness(new Act("the exodus", new Deliverance(), new CovenantFaithfulness())));
+        }
+
+        [Fact]
+        public void PharaohEnslavesAndOppresses_IsSin_AndDisordersReality()
+        {
+            // Pharaoh oppresses the Hebrews and orders their sons killed (Exodus 1).
+            AssertSin(Witness(new Act("Pharaoh's oppression", new Oppression(), new Wrongdoing())));
+        }
+
+        // ===== The Law: safe when aligned, disciplined when not =====
+
+        [Fact]
+        public void IsraelAlignedWithGod_IsKeptSafe()
+        {
+            // "If you fully obey the LORD your God ... you will be blessed." (Deuteronomy 28:1-2)
+            AssertRighteous(Witness(new Act("Israel keeps the covenant", new ObedienceToGod())));
+        }
+
+        [Fact]
+        public void IsraelRebelsAgainstGod_BringsDisorder()
+        {
+            // The golden calf and the wilderness rebellions (Exodus 32; Numbers 14).
+            AssertSin(Witness(new Act("Israel rebels", new Disobedience(), new Rebellion())));
+        }
+
+        // ===== The Law set Israel apart in antiquity =====
+
+        [Fact]
+        public void SacrificingChildren_AsTheNationsDid_IsGraveSin()
+        {
+            // "Do not give any of your children to be sacrificed to Molek." (Leviticus 18:21;
+            // Deuteronomy 12:31). The practice of the surrounding nations is detestable.
+            AssertSin(Witness(new Act("child sacrifice to Molek", new ChildSacrifice(), new Bloodshed())));
+        }
+
+        [Fact]
+        public void ForbiddingChildSacrificeAndProtectingTheChild_IsCoherent()
+        {
+            // The law that forbids it protects the vulnerable.
+            AssertRighteous(Witness(new Act("the child is protected",
+                new HonoringTheVulnerable(), new Protection())));
+        }
+
+        [Fact]
+        public void WelcomingTheStrangerAndHonoringTheVulnerable_IsCoherent()
+        {
+            // "Love the foreigner ... for you were foreigners in Egypt." (Deuteronomy 10:18-19);
+            // care for the widow and the orphan (Exodus 22:21-22).
+            AssertRighteous(Witness(new Act("the stranger welcomed",
+                new Hospitality(), new HonoringTheVulnerable())));
+        }
+
+        // ===== Israel brings forth the Messiah =====
+
+        [Fact]
+        public void GodPreservesTheLineToBringForthTheMessiah_IsFaithful()
+        {
+            // From the promise in Eden (Genesis 3:15) through the line of David to Christ
+            // (Matthew 1:1-17). God is faithful to bring it about.
+            AssertDivineAct(Witness(new Act("the messianic line preserved",
+                new CovenantFaithfulness(), new PromiseFulfilled())));
+        }
+
+        // ===== Jesus saves the entire world: every recorded act is verifiable =====
+
+        [Fact]
+        public void TheIncarnation_TheWordMadeFlesh_IsCoherent()
+        {
+            // "The Word became flesh and made his dwelling among us." (John 1:14)
+            AssertDivineAct(Witness(new Act("the incarnation", new Compassion(), new PromiseFulfilled())));
+        }
+
+        [Fact]
+        public void JesusHealsTheSick_IsCoherent_AndDestabilizesNothing()
+        {
+            // He healed every disease and sickness (Matthew 9:35).
+            AssertDivineAct(Witness(new Act("Jesus heals the sick", new Healing(), new Compassion())));
+        }
+
+        [Fact]
+        public void JesusForgivesSins_IsMercy()
+        {
+            // "Son, your sins are forgiven." (Mark 2:5)
+            AssertDivineAct(Witness(new Act("Jesus forgives sins", new Forgiveness(), new Pardon())));
+        }
+
+        [Fact]
+        public void JesusTeachesTheTruth_IsCoherent()
+        {
+            // "You will know the truth, and the truth will set you free." (John 8:32)
+            AssertDivineAct(Witness(new Act("Jesus teaches the truth", new TeachingTruth())));
+        }
+
+        [Fact]
+        public void JesusCleansesTheTemple_IsRighteousZeal_NotDisorder()
+        {
+            // Driving out those who made His Father's house a market (John 2:13-17). Righteous zeal,
+            // not sin: it renders what is due and defends the wronged.
+            AssertDivineAct(Witness(new Act("Jesus cleanses the temple",
+                new JustRecompense(), new DefendingTheWeak())));
+        }
+
+        [Fact]
+        public void JesusRaisesTheDead_RestoresLifeAndOrder()
+        {
+            // "Lazarus, come out!" (John 11:43); the resurrection (Matthew 28). Death is reversed:
+            // the very opposite of disorder.
+            AssertDivineAct(Witness(new Act("Jesus raises the dead",
+                new RestoringLife(), new CreationOrder())));
+        }
+
+        [Fact]
+        public void TheCross_SavesTheEntireWorld_PerfectlyCoherent()
+        {
+            // "For God so loved the world." (John 3:16); the fullness of God's character in one act.
+            Resolution r = Witness(new Act("the cross saves the world",
+                new SelfSacrifice(), new Atonement(), new Pardon(), new CovenantFaithfulness()));
+
+            Assert.Equal(1.0, r.Coherence);
+            Assert.Equal(0.0, r.Disorder);
+        }
+
+        // ===== Oracle helpers =====
+
+        private static Resolution Witness(Act act)
+        {
+            return Reality.Revealed().Witness(act);
+        }
+
+        private static void AssertDivineAct(Resolution r)
+        {
+            Assert.True(r.Coherence >= 0.5, "An act of God can never read incoherent.");
+            Assert.Equal(0.0, r.Disorder);
+        }
+
+        private static void AssertRighteous(Resolution r)
+        {
+            Assert.True(r.Coherence > 0.5, "A righteous deed must read coherent.");
+            Assert.Equal(0.0, r.Disorder);
+        }
+
+        private static void AssertSin(Resolution r)
+        {
+            Assert.True(r.Coherence < 0.5, "Sin must read incoherent.");
+            Assert.True(r.Disorder > 0.0, "Sin must introduce disorder into reality.");
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/ResolutionTests.cs
+++ b/AnointedAutomation.Objects.Tests/ResolutionTests.cs
@@ -1,0 +1,43 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests
+{
+    public class ResolutionTests
+    {
+        [Fact]
+        public void Coherence_IsClampedIntoUnitRange()
+        {
+            // Reality cannot be more than fully coherent, nor less than fully incoherent.
+            Resolution tooHigh = new Resolution(1.5, 0.0);
+            Resolution tooLow = new Resolution(-0.5, 0.0);
+
+            Assert.Equal(1.0, tooHigh.Coherence);
+            Assert.Equal(0.0, tooLow.Coherence);
+        }
+
+        [Fact]
+        public void Disorder_IsClampedIntoUnitRange()
+        {
+            // An act cannot introduce more than total disorder, nor negative disorder.
+            Resolution tooHigh = new Resolution(0.0, 1.5);
+            Resolution tooLow = new Resolution(1.0, -0.5);
+
+            Assert.Equal(1.0, tooHigh.Disorder);
+            Assert.Equal(0.0, tooLow.Disorder);
+        }
+
+        [Fact]
+        public void Resolution_ExposesTheValuesItWitnessed()
+        {
+            // A faithful act: highly coherent, introducing no disorder.
+            Resolution faithful = new Resolution(0.9, 0.0);
+
+            Assert.Equal(0.9, faithful.Coherence);
+            Assert.Equal(0.0, faithful.Disorder);
+        }
+    }
+}

--- a/AnointedAutomation.Objects.Tests/SacrificialLoveTests.cs
+++ b/AnointedAutomation.Objects.Tests/SacrificialLoveTests.cs
@@ -15,7 +15,7 @@ namespace AnointedAutomation.Objects.Tests
             // Arrange (John 15:13)
             Love love = new SacrificialLove();
             Situation situation = new Situation("A friend's life is at stake; saving them costs my own.")
-                .Set("friendsLifeAtStake");
+                .With(new MortalPeril());
 
             // Act
             LoveAction action = love.Decide(situation);
@@ -33,8 +33,8 @@ namespace AnointedAutomation.Objects.Tests
             // Arrange — no ultimate sacrifice is needed, but a neighbor is in need.
             Love love = new SacrificialLove();
             Situation situation = new Situation("A stranger in need by the road.")
-                .Set("inNeed")
-                .Set("iCanHelp");
+                .With(new Need())
+                .With(new Means());
 
             // Act
             LoveAction action = love.Decide(situation);
@@ -48,7 +48,7 @@ namespace AnointedAutomation.Objects.Tests
         public void Decide_GreaterDeedThanAgape_ForSameSituation()
         {
             // Arrange — "greater love" (John 15:13): same situation, a greater deed.
-            Situation situation = new Situation("A friend's life is at stake.").Set("friendsLifeAtStake");
+            Situation situation = new Situation("A friend's life is at stake.").With(new MortalPeril());
             Love agape = new Agape();
             Love sacrificial = new SacrificialLove();
 

--- a/AnointedAutomation.Objects.Tests/SituationTests.cs
+++ b/AnointedAutomation.Objects.Tests/SituationTests.cs
@@ -1,6 +1,5 @@
-// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-05-28 12:05:18
-// Edited by Alexander Fields https://www.alexanderfields.me 2026-05-28 12:05:18
-//Stewarded by Alexander Fields
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
 
 using Xunit;
 using AnointedAutomation.Objects.Concepts;
@@ -10,146 +9,98 @@ namespace AnointedAutomation.Objects.Tests
     public class SituationTests
     {
         [Fact]
-        public void Set_ThenIs_ReturnsTrue()
+        public void With_ThenHas_ReturnsTrue()
         {
-            // Arrange
             Situation situation = new Situation();
 
-            // Act
-            situation.Set("inNeed");
+            situation.With(new Need());
 
-            // Assert
-            Assert.True(situation.Is("inNeed"));
+            Assert.True(situation.Has(new Need()));
         }
 
         [Fact]
-        public void Set_FalseValue_IsReturnsFalse()
+        public void Has_UnknownCircumstance_ReturnsFalse()
         {
-            // Arrange
+            // A circumstance never added simply does not hold.
             Situation situation = new Situation();
 
-            // Act
-            situation.Set("inNeed", false);
-
-            // Assert
-            Assert.False(situation.Is("inNeed"));
+            Assert.False(situation.Has(new Circumstance("neverHeardOfIt")));
         }
 
         [Fact]
-        public void Is_UnknownFact_ReturnsFalse()
+        public void With_ReturnsSameInstance_ForChaining()
         {
-            // Arrange
             Situation situation = new Situation();
 
-            // Assert — a fact never recorded simply does not hold
-            Assert.False(situation.Is("neverHeardOfIt"));
-        }
+            Situation chained = situation.With(new Circumstance("a")).With(new Circumstance("b"));
 
-        [Fact]
-        public void Has_RecordedFact_ReturnsTrue_EvenWhenFalse()
-        {
-            // Arrange
-            Situation situation = new Situation().Set("inNeed", false);
-
-            // Assert
-            Assert.True(situation.Has("inNeed"));
-            Assert.False(situation.Is("inNeed"));
-        }
-
-        [Fact]
-        public void Has_UnknownFact_ReturnsFalse()
-        {
-            // Arrange
-            Situation situation = new Situation();
-
-            // Assert
-            Assert.False(situation.Has("nope"));
-        }
-
-        [Fact]
-        public void Set_ReturnsSameInstance_ForChaining()
-        {
-            // Arrange
-            Situation situation = new Situation();
-
-            // Act
-            Situation chained = situation.Set("a").Set("b");
-
-            // Assert
             Assert.Same(situation, chained);
         }
 
         [Fact]
         public void Constructor_WithDescription_SetsDescription()
         {
-            // Act
             Situation situation = new Situation("A stranger lies beaten by the road.");
 
-            // Assert
             Assert.Equal("A stranger lies beaten by the road.", situation.Description);
         }
 
         [Fact]
-        public void Facts_ArePopulated_AfterSet()
+        public void Circumstances_ArePopulated_AfterWith()
         {
-            // Arrange
-            Situation situation = new Situation().Set("a").Set("b", false);
+            Situation situation = new Situation().With(new Circumstance("a")).With(new Circumstance("b"));
 
-            // Assert
-            Assert.Equal(2, situation.Facts.Count);
+            Assert.Equal(2, situation.Circumstances.Count);
+        }
+
+        [Fact]
+        public void ANamedCircumstance_MatchesANovelOneOfTheSameName()
+        {
+            // A typed circumstance and a directly-named one are the same state when they share a name.
+            Situation situation = new Situation().With(new Hunger());
+
+            Assert.True(situation.Has(new Circumstance("hungry")));
+        }
+
+        [Fact]
+        public void ANovelCircumstance_NeverNamedInScripture_Works()
+        {
+            // The world is open-ended; any circumstance can be expressed.
+            Situation situation = new Situation().With(new Circumstance("quantumComputerMalfunctioned"));
+
+            Assert.True(situation.Has(new Circumstance("quantumComputerMalfunctioned")));
         }
 
         // EDGE CASE TESTS - per CLAUDE_TESTING.md requirements
 
         [Fact]
-        public void Set_WithNullFact_ThrowsArgumentNullException()
+        public void With_WithNullCircumstance_ThrowsArgumentNullException()
         {
-            // Arrange
             Situation situation = new Situation();
 
-            // Assert
-            Assert.Throws<System.ArgumentNullException>(() => situation.Set(null));
+            Assert.Throws<System.ArgumentNullException>(() => situation.With(null));
         }
 
         [Fact]
-        public void Is_WithNullFact_ThrowsArgumentNullException()
+        public void Has_WithNullCircumstance_ThrowsArgumentNullException()
         {
-            // Arrange
             Situation situation = new Situation();
 
-            // Assert
-            Assert.Throws<System.ArgumentNullException>(() => situation.Is(null));
-        }
-
-        [Fact]
-        public void Has_WithNullFact_ThrowsArgumentNullException()
-        {
-            // Arrange
-            Situation situation = new Situation();
-
-            // Assert
             Assert.Throws<System.ArgumentNullException>(() => situation.Has(null));
         }
 
         [Fact]
-        public void Set_SameFactTwice_TakesLatestValue()
+        public void Circumstance_WithNullName_ThrowsArgumentNullException()
         {
-            // Arrange
-            Situation situation = new Situation().Set("inNeed", true).Set("inNeed", false);
-
-            // Assert
-            Assert.False(situation.Is("inNeed"));
-            Assert.Single(situation.Facts);
+            Assert.Throws<System.ArgumentNullException>(() => new Circumstance(null));
         }
 
         [Fact]
-        public void Set_WithUnicodeFactName_Works()
+        public void With_UnicodeCircumstanceName_Works()
         {
-            // Arrange
-            Situation situation = new Situation().Set("σε ανάγκη 需要");
+            Situation situation = new Situation().With(new Circumstance("σε ανάγκη 需要"));
 
-            // Assert
-            Assert.True(situation.Is("σε ανάγκη 需要"));
+            Assert.True(situation.Has(new Circumstance("σε ανάγκη 需要")));
         }
     }
 }

--- a/AnointedAutomation.Objects.Tests/WordTests.cs
+++ b/AnointedAutomation.Objects.Tests/WordTests.cs
@@ -1,0 +1,36 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+using Xunit;
+using AnointedAutomation.Objects.Concepts;
+
+namespace AnointedAutomation.Objects.Tests
+{
+    public class WordTests
+    {
+        [Fact]
+        public void Speaking_CarriesADeedIntoReality_AndReturnsItsResolution()
+        {
+            // "Through him all things were made." (John 1:3) The Word is the medium through which an
+            // agent and reality meet, not a locked gate.
+            Reality reality = Reality.Revealed();
+            Word word = new Word(reality);
+
+            Resolution resolution = word.Speak(new Act("a mercy", new Compassion()), Grounding.InGod());
+
+            Assert.Equal(1.0, resolution.Reading("Mercy"));
+        }
+
+        [Fact]
+        public void Speaking_RecordsTheDeedOnReality()
+        {
+            // The medium does not bypass reality; what is spoken through it is written on the tablets.
+            Reality reality = Reality.Revealed();
+            Word word = new Word(reality);
+
+            word.Speak(new Act("a kindness", new JustRecompense()), Grounding.InGod());
+
+            Assert.Single(reality.Tablets.History());
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Agape.cs
+++ b/AnointedAutomation.Objects/Concepts/Agape.cs
@@ -61,18 +61,18 @@ namespace AnointedAutomation.Objects.Concepts
         protected override BehaviorNode BuildBehavior()
         {
             return new Selector(
-                new Sequence(Condition.Fact("wronged"), new Deed(Forgive())),
-                new Sequence(Condition.Fact("enemy").And(Condition.Fact("hungry").Or("thirsty")), new Deed(FeedYourEnemy())),
-                new Sequence(Condition.Fact("hungry"), new Deed(Feed())),
-                new Sequence(Condition.Fact("thirsty"), new Deed(GiveDrink())),
-                new Sequence(Condition.Fact("stranger"), new Deed(Welcome())),
-                new Sequence(Condition.Fact("naked"), new Deed(Clothe())),
-                new Sequence(Condition.Fact("sick"), new Deed(CareForSick())),
-                new Sequence(Condition.Fact("imprisoned"), new Deed(Visit())),
-                new Sequence(Condition.Fact("inNeed").And("iCanHelp"), new Deed(MeetTheNeed())),
-                new Sequence(Condition.Fact("grieving"), new Deed(MournWith())),
-                new Sequence(Condition.Fact("rejoicing"), new Deed(RejoiceWith())),
-                new Sequence(Condition.Fact("enemy"), new Deed(LoveEnemy())),
+                new Sequence(Condition.For(new Grievance()), new Deed(Forgive())),
+                new Sequence(Condition.For(new Enmity()).And(Condition.For(new Hunger()).Or(new Thirst())), new Deed(FeedYourEnemy())),
+                new Sequence(Condition.For(new Hunger()), new Deed(Feed())),
+                new Sequence(Condition.For(new Thirst()), new Deed(GiveDrink())),
+                new Sequence(Condition.For(new Estrangement()), new Deed(Welcome())),
+                new Sequence(Condition.For(new Nakedness()), new Deed(Clothe())),
+                new Sequence(Condition.For(new Sickness()), new Deed(CareForSick())),
+                new Sequence(Condition.For(new Imprisonment()), new Deed(Visit())),
+                new Sequence(Condition.For(new Need()).And(new Means()), new Deed(MeetTheNeed())),
+                new Sequence(Condition.For(new Grief()), new Deed(MournWith())),
+                new Sequence(Condition.For(new Gladness()), new Deed(RejoiceWith())),
+                new Sequence(Condition.For(new Enmity()), new Deed(LoveEnemy())),
                 new Deed(BePatientAndKind()));
         }
 

--- a/AnointedAutomation.Objects/Concepts/Circumstance.cs
+++ b/AnointedAutomation.Objects/Concepts/Circumstance.cs
@@ -1,0 +1,63 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// A state of the world that love responds to: hunger, enmity, grief, a friend in mortal peril.
+    /// A circumstance carries no moral weight of its own (unlike a <see cref="MoralConcept"/>); it is
+    /// simply the case. Well-known circumstances are their own types (<see cref="Hunger"/>,
+    /// <see cref="Enmity"/>, ...), but because the world is open-ended, any circumstance can be named
+    /// directly, including ones Scripture never described. Two circumstances are the same when they
+    /// share a name.
+    /// </summary>
+    public class Circumstance : Concept
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Circumstance"/> class. Use a named subclass
+        /// for a well-known circumstance, or this constructor directly for a novel one.
+        /// </summary>
+        /// <param name="name">The name of the circumstance (for example, "hungry").</param>
+        public Circumstance(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new System.ArgumentNullException(nameof(name));
+            }
+
+            this.name = name;
+        }
+
+        private readonly string name;
+
+        /// <inheritdoc />
+        public override string Name
+        {
+            get
+            {
+                return name;
+            }
+        }
+
+        /// <summary>
+        /// Two circumstances are equal when they share a name, so a novel circumstance and a named
+        /// subclass for the same state match.
+        /// </summary>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns><c>true</c> if the other is a circumstance with the same name.</returns>
+        public override bool Equals(object obj)
+        {
+            Circumstance other = obj as Circumstance;
+            return other != null && Name.Equals(other.Name);
+        }
+
+        /// <summary>
+        /// A hash code consistent with name-based equality.
+        /// </summary>
+        /// <returns>The hash of the circumstance's name.</returns>
+        public override int GetHashCode()
+        {
+            return Name.GetHashCode();
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Circumstances.cs
+++ b/AnointedAutomation.Objects/Concepts/Circumstances.cs
@@ -1,0 +1,113 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    // Well-known states of the world that love responds to, each a first-class circumstance rather
+    // than a string. Many answer to the works of mercy (Matthew 25:35-36). A circumstance never
+    // named here can still be expressed with `new Circumstance("...")`, so any situation is possible.
+
+    /// <summary>Hunger: someone is hungry. "I was hungry and you gave me something to eat." (Matthew 25:35)</summary>
+    public sealed class Hunger : Circumstance
+    {
+        public Hunger() : base("hungry")
+        {
+        }
+    }
+
+    /// <summary>Thirst: someone is thirsty. "I was thirsty and you gave me something to drink." (Matthew 25:35)</summary>
+    public sealed class Thirst : Circumstance
+    {
+        public Thirst() : base("thirsty")
+        {
+        }
+    }
+
+    /// <summary>Estrangement: someone is a stranger or foreigner. "I was a stranger and you invited me in." (Matthew 25:35)</summary>
+    public sealed class Estrangement : Circumstance
+    {
+        public Estrangement() : base("stranger")
+        {
+        }
+    }
+
+    /// <summary>Nakedness: someone needs clothing. "I needed clothes and you clothed me." (Matthew 25:36)</summary>
+    public sealed class Nakedness : Circumstance
+    {
+        public Nakedness() : base("naked")
+        {
+        }
+    }
+
+    /// <summary>Sickness: someone is sick. "I was sick and you looked after me." (Matthew 25:36)</summary>
+    public sealed class Sickness : Circumstance
+    {
+        public Sickness() : base("sick")
+        {
+        }
+    }
+
+    /// <summary>Imprisonment: someone is in prison. "I was in prison and you came to visit me." (Matthew 25:36)</summary>
+    public sealed class Imprisonment : Circumstance
+    {
+        public Imprisonment() : base("imprisoned")
+        {
+        }
+    }
+
+    /// <summary>Need: someone is in need. "Who is my neighbor?" (Luke 10:29-37)</summary>
+    public sealed class Need : Circumstance
+    {
+        public Need() : base("inNeed")
+        {
+        }
+    }
+
+    /// <summary>Means: I have it in my power to help. (Luke 10:33-35; Proverbs 3:27)</summary>
+    public sealed class Means : Circumstance
+    {
+        public Means() : base("iCanHelp")
+        {
+        }
+    }
+
+    /// <summary>Grievance: I have been wronged. (Colossians 3:13)</summary>
+    public sealed class Grievance : Circumstance
+    {
+        public Grievance() : base("wronged")
+        {
+        }
+    }
+
+    /// <summary>Enmity: this person is my enemy. "Love your enemies." (Matthew 5:44)</summary>
+    public sealed class Enmity : Circumstance
+    {
+        public Enmity() : base("enemy")
+        {
+        }
+    }
+
+    /// <summary>Grief: someone is grieving. "Mourn with those who mourn." (Romans 12:15)</summary>
+    public sealed class Grief : Circumstance
+    {
+        public Grief() : base("grieving")
+        {
+        }
+    }
+
+    /// <summary>Gladness: someone is rejoicing. "Rejoice with those who rejoice." (Romans 12:15)</summary>
+    public sealed class Gladness : Circumstance
+    {
+        public Gladness() : base("rejoicing")
+        {
+        }
+    }
+
+    /// <summary>Mortal peril: a friend's life is at stake. "Greater love has no one than this." (John 15:13)</summary>
+    public sealed class MortalPeril : Circumstance
+    {
+        public MortalPeril() : base("friendsLifeAtStake")
+        {
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Condition.cs
+++ b/AnointedAutomation.Objects/Concepts/Condition.cs
@@ -1,12 +1,12 @@
-// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-05-28 12:05:18
-// Edited by Alexander Fields https://www.alexanderfields.me 2026-05-28 12:05:18
-//Stewarded by Alexander Fields
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
 
 namespace AnointedAutomation.Objects.Concepts
 {
     /// <summary>
     /// A leaf node that tests the situation. It succeeds (producing no deed) when its predicate holds,
-    /// and fails otherwise. This is where arbitrary situational logic enters the tree.
+    /// and fails otherwise. This is where situational logic enters the tree, by reading the
+    /// <see cref="Circumstance"/>s that hold.
     /// </summary>
     public class Condition : BehaviorNode
     {
@@ -28,18 +28,18 @@ namespace AnointedAutomation.Objects.Concepts
         }
 
         /// <summary>
-        /// Creates a condition that holds when a named fact is true in the situation.
+        /// Creates a condition that holds when a given circumstance holds in the situation.
         /// </summary>
-        /// <param name="fact">The fact to test.</param>
-        /// <returns>A <see cref="Condition"/> over that fact.</returns>
-        public static Condition Fact(string fact)
+        /// <param name="circumstance">The circumstance to test for.</param>
+        /// <returns>A <see cref="Condition"/> over that circumstance.</returns>
+        public static Condition For(Circumstance circumstance)
         {
-            if (string.IsNullOrEmpty(fact))
+            if (circumstance == null)
             {
-                throw new System.ArgumentNullException(nameof(fact));
+                throw new System.ArgumentNullException(nameof(circumstance));
             }
 
-            return new Condition(situation => situation.Is(fact));
+            return new Condition(situation => situation.Has(circumstance));
         }
 
         /// <summary>
@@ -74,13 +74,13 @@ namespace AnointedAutomation.Objects.Concepts
         }
 
         /// <summary>
-        /// Combines this condition with a named fact using logical AND.
+        /// Combines this condition with a circumstance using logical AND.
         /// </summary>
-        /// <param name="fact">The fact to AND with this condition.</param>
-        /// <returns>A new <see cref="Condition"/> that holds when this condition holds and the fact is true.</returns>
-        public Condition And(string fact)
+        /// <param name="circumstance">The circumstance to AND with this condition.</param>
+        /// <returns>A new <see cref="Condition"/> that holds when this condition holds and the circumstance holds.</returns>
+        public Condition And(Circumstance circumstance)
         {
-            return And(Fact(fact));
+            return And(For(circumstance));
         }
 
         /// <summary>
@@ -100,13 +100,13 @@ namespace AnointedAutomation.Objects.Concepts
         }
 
         /// <summary>
-        /// Combines this condition with a named fact using logical OR.
+        /// Combines this condition with a circumstance using logical OR.
         /// </summary>
-        /// <param name="fact">The fact to OR with this condition.</param>
-        /// <returns>A new <see cref="Condition"/> that holds when this condition holds or the fact is true.</returns>
-        public Condition Or(string fact)
+        /// <param name="circumstance">The circumstance to OR with this condition.</param>
+        /// <returns>A new <see cref="Condition"/> that holds when this condition holds or the circumstance holds.</returns>
+        public Condition Or(Circumstance circumstance)
         {
-            return Or(Fact(fact));
+            return Or(For(circumstance));
         }
 
         /// <summary>

--- a/AnointedAutomation.Objects/Concepts/Reality/Act.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Act.cs
@@ -1,0 +1,103 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// A deed presented to reality, composed of the moral concepts it embodies and offends. This
+    /// replaces the old string blackboard: an act is no longer a bag of fact-names but a set of
+    /// first-class <see cref="MoralConcept"/> entities, each carrying its own Scripture and stance
+    /// toward God's character. Any situation can still be expressed, including ones never named in
+    /// Scripture, by composing the concepts it involves.
+    /// </summary>
+    public class Act
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Act"/> class from the moral concepts it
+        /// embodies.
+        /// </summary>
+        /// <param name="description">A human-readable description of the deed.</param>
+        /// <param name="concepts">The moral concepts this deed involves.</param>
+        public Act(string description, params MoralConcept[] concepts)
+        {
+            if (concepts == null)
+            {
+                throw new System.ArgumentNullException(nameof(concepts));
+            }
+
+            Description = description;
+            Concepts = concepts;
+        }
+
+        private Circumstance[] context = new Circumstance[0];
+
+        /// <summary>
+        /// A human-readable description of the deed.
+        /// </summary>
+        public string Description
+        {
+            get;
+        }
+
+        /// <summary>
+        /// The moral concepts this deed embodies and offends.
+        /// </summary>
+        public System.Collections.Generic.IReadOnlyList<MoralConcept> Concepts
+        {
+            get;
+        }
+
+        /// <summary>
+        /// The context in which the deed is done (war, divine command, defense of the innocent). A
+        /// concept can be read differently in light of context: Rahab's deception to save the spies
+        /// from murderers is not the lie God condemns (Joshua 2; Hebrews 11:31). Most acts carry no
+        /// context; the engine then reads concepts plainly.
+        /// </summary>
+        public System.Collections.Generic.IReadOnlyList<Circumstance> Context
+        {
+            get
+            {
+                return context;
+            }
+        }
+
+        /// <summary>
+        /// Sets the context of this deed and returns it for fluent chaining.
+        /// </summary>
+        /// <param name="circumstances">The circumstances that frame the deed.</param>
+        /// <returns>This <see cref="Act"/>.</returns>
+        public Act InContext(params Circumstance[] circumstances)
+        {
+            if (circumstances == null)
+            {
+                throw new System.ArgumentNullException(nameof(circumstances));
+            }
+
+            context = circumstances;
+            return this;
+        }
+
+        /// <summary>
+        /// Whether a given context frames this deed.
+        /// </summary>
+        /// <param name="circumstance">The context to test for.</param>
+        /// <returns><c>true</c> if the deed is done in that context.</returns>
+        public bool InContextOf(Circumstance circumstance)
+        {
+            if (circumstance == null)
+            {
+                throw new System.ArgumentNullException(nameof(circumstance));
+            }
+
+            foreach (Circumstance held in context)
+            {
+                if (held.Equals(circumstance))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Concept.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Concept.cs
@@ -1,0 +1,27 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// The root of the project's concept model: an idea modeled as first-class code rather than a
+    /// magic string. Two kinds descend from it, and distinguishing them in the type system is itself
+    /// meaningful, because a sin is not the same kind of thing as a situation:
+    /// <list type="bullet">
+    /// <item><description>A <see cref="MoralConcept"/> bears on the facets of God's character: it is
+    /// a virtue or a sin (Compassion, Murder), with a Scripture, a stance, and a gravity.</description></item>
+    /// <item><description>A <see cref="Circumstance"/> is a state of the world that love responds to
+    /// (hunger, enmity, grief). It carries no moral weight of its own; it is simply the case.</description></item>
+    /// </list>
+    /// </summary>
+    public abstract class Concept
+    {
+        /// <summary>
+        /// The name of this concept.
+        /// </summary>
+        public abstract string Name
+        {
+            get;
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/DivineAttribute.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/DivineAttribute.cs
@@ -1,0 +1,82 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// A facet of God's character (Love, Justice, Mercy, Faithfulness). God embodies each, yet is not
+    /// equal to any one of them ("God is love", 1 John 4:8, read as embodiment, not equation). Every
+    /// facet is always live: a facet never accepts or rejects an act, it only reads how fully the act
+    /// coheres with this aspect of God's character. The facets harmonize into one response in
+    /// <see cref="DivineCharacter"/>.
+    ///
+    /// <para>
+    /// A facet no longer carries a list of fact-strings. It reads an <see cref="Act"/> by asking each
+    /// <see cref="MoralConcept"/> in the deed how it stands toward this facet. The moral vocabulary
+    /// lives on the concepts themselves.
+    /// </para>
+    /// </summary>
+    public abstract class DivineAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DivineAttribute"/> class.
+        /// </summary>
+        /// <param name="name">The name of this facet of God's character.</param>
+        protected DivineAttribute(string name)
+        {
+            Name = name;
+        }
+
+        /// <summary>
+        /// Gets the name of this facet of God's character.
+        /// </summary>
+        public string Name
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Reads how fully an act coheres with this facet of God's character, from 0.0 (wholly
+        /// against it) through 0.5 (indifferent to it) to 1.0 (fully embodying it). An act that
+        /// embodies this facet without offending it reads fully coherent; one that offends it without
+        /// embodying it reads wholly against; mixed or indifferent acts sit at the neutral midpoint.
+        /// </summary>
+        /// <param name="act">The deed, composed of the moral concepts it embodies and offends.</param>
+        /// <returns>The coherence of the act with this facet, from 0.0 to 1.0.</returns>
+        public double Read(Act act)
+        {
+            if (act == null)
+            {
+                throw new System.ArgumentNullException(nameof(act));
+            }
+
+            bool upheld = false;
+            bool violated = false;
+            foreach (MoralConcept concept in act.Concepts)
+            {
+                if (concept.Upholds(this, act))
+                {
+                    upheld = true;
+                }
+
+                if (concept.Violates(this, act))
+                {
+                    violated = true;
+                }
+            }
+
+            double reading = 0.5;
+            if (upheld)
+            {
+                reading = reading + 0.5;
+            }
+
+            if (violated)
+            {
+                reading = reading - 0.5;
+            }
+
+            return reading;
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/DivineCharacter.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/DivineCharacter.cs
@@ -1,0 +1,131 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// The whole character of God, with every facet always live at once. Not a selector that picks
+    /// one attribute: a wound draws Mercy forward and a theft draws Justice forward, yet no facet is
+    /// ever switched off. The facets harmonize into a single <see cref="Resolution"/>.
+    ///
+    /// <para>
+    /// Harmonization is deliberately not a veto. Coherence is the mean of every facet's reading, so
+    /// an act that fully satisfies two facets at once stays fully coherent. This is what lets the
+    /// cross be full Justice and full Mercy together (Romans 3:25-26), which a "lowest wins" rule
+    /// could never express. Disorder, by contrast, is driven by the gravity of the gravest wrong the
+    /// deed commits: a capital crime (murder, innocent blood) destabilizes reality far more than a
+    /// minor wrong (Romans 8:20-22; Scripture grades sin, Matthew 23:23; John 19:11), and incidental good
+    /// elsewhere does not excuse it.
+    /// </para>
+    /// </summary>
+    public class DivineCharacter
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DivineCharacter"/> class from the facets that
+        /// are all always live.
+        /// </summary>
+        /// <param name="facets">The facets of God's character (Love, Justice, Mercy, Faithfulness).</param>
+        public DivineCharacter(params DivineAttribute[] facets)
+        {
+            if (facets == null)
+            {
+                throw new System.ArgumentNullException(nameof(facets));
+            }
+
+            if (facets.Length == 0)
+            {
+                throw new System.ArgumentException(
+                    "God's character is never empty; at least one facet must be live.", nameof(facets));
+            }
+
+            this.facets = facets;
+        }
+
+        private readonly DivineAttribute[] facets;
+
+        /// <summary>
+        /// Witnesses a situation under the whole of God's character at once and harmonizes every
+        /// facet's reading into one resolution.
+        /// </summary>
+        /// <param name="act">The deed to witness.</param>
+        /// <returns>The harmonized <see cref="Resolution"/>.</returns>
+        public Resolution Harmonize(Act act)
+        {
+            if (act == null)
+            {
+                throw new System.ArgumentNullException(nameof(act));
+            }
+
+            System.Collections.Generic.Dictionary<string, double> readings =
+                new System.Collections.Generic.Dictionary<string, double>();
+
+            double total = 0.0;
+            foreach (DivineAttribute facet in facets)
+            {
+                double reading = facet.Read(act);
+                readings[facet.Name] = reading;
+                total = total + reading;
+            }
+
+            double coherence = total / facets.Length;
+            double disorder = Disorder(act);
+
+            return new Resolution(coherence, disorder, readings);
+        }
+
+        /// <summary>
+        /// The disorder a deed unleashes into reality: the gravity of the gravest wrong it commits.
+        /// Scripture grades sin (Matthew 23:23; John 19:11), so a capital wrong (murder, innocent
+        /// blood) destabilizes reality far more than a minor one (a rude word). A deed that offends
+        /// no facet of God's character introduces no disorder at all.
+        /// </summary>
+        /// <param name="act">The deed being witnessed.</param>
+        /// <returns>The disorder introduced, from 0.0 to 1.0.</returns>
+        private double Disorder(Act act)
+        {
+            double disorder = 0.0;
+            foreach (MoralConcept concept in act.Concepts)
+            {
+                if (Offends(concept, act))
+                {
+                    double weight = Weight(concept.Gravity);
+                    if (weight > disorder)
+                    {
+                        disorder = weight;
+                    }
+                }
+            }
+
+            return disorder;
+        }
+
+        /// <summary>
+        /// Whether a concept offends any facet of this character of God, read in the deed's context.
+        /// </summary>
+        /// <param name="concept">The moral concept to test.</param>
+        /// <param name="act">The whole deed, carrying its context.</param>
+        /// <returns><c>true</c> if the concept violates at least one facet here.</returns>
+        private bool Offends(MoralConcept concept, Act act)
+        {
+            foreach (DivineAttribute facet in facets)
+            {
+                if (concept.Violates(facet, act))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// The disorder weight of a gravity, from 0.0 (none) to 1.0 (a capital wrong).
+        /// </summary>
+        /// <param name="gravity">The gravity of a wrong.</param>
+        /// <returns>The fraction of total disorder it unleashes.</returns>
+        private static double Weight(Gravity gravity)
+        {
+            return (double)(int)gravity / (double)(int)Gravity.Capital;
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Faithfulness.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Faithfulness.cs
@@ -1,0 +1,26 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-12
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// The facet of God's character that is faithful: He keeps His word and His covenant. This is
+    /// the fourth of the four facets, and all four are anchored in God's own self-description in
+    /// Exodus 34:6-7, "the LORD, the compassionate and gracious God, slow to anger, abounding in
+    /// love (<see cref="LoveFacet"/>) and faithfulness ... forgiving (<see cref="Mercy"/>) ... yet he
+    /// does not leave the guilty unpunished (<see cref="Justice"/>)." Faithfulness is "emeth," the
+    /// steadfast reliability of God; "great is your faithfulness" (Lamentations 3:22-23). The
+    /// ordered constancy of creation, that the world holds together and keeps its course
+    /// (Colossians 1:17), is a downstream expression of this faithfulness, not a separate attribute.
+    /// Which acts embody or offend Faithfulness is declared by the moral concepts themselves.
+    /// </summary>
+    public class Faithfulness : DivineAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Faithfulness"/> class.
+        /// </summary>
+        public Faithfulness() : base("Faithfulness")
+        {
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Gravity.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Gravity.cs
@@ -1,0 +1,31 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// How heinous a wrong is, and so how much destruction it unleashes into reality. Scripture
+    /// grades sin: not all wrongs are equal (Matthew 23:23, "the weightier matters of the law";
+    /// John 19:11, "the greater sin"). The Torah reserves death for the gravest, capital wrongs
+    /// (murder, the shedding of innocent blood, child sacrifice, the violation of a person), while
+    /// answering lesser wrongs with restitution or rebuke. Ordered from least to most heinous so the
+    /// weights can be compared.
+    /// </summary>
+    public enum Gravity
+    {
+        /// <summary>No wrong; introduces no disorder (a virtue).</summary>
+        None = 0,
+
+        /// <summary>A real wrong, but not heinous (rudeness, a boast, a grudge).</summary>
+        Minor = 1,
+
+        /// <summary>A grave wrong answered in the Law by restitution or rebuke (theft, withholding wages).</summary>
+        Serious = 2,
+
+        /// <summary>A heavy wrong that provokes God's judgment (oppression, rebellion, treachery).</summary>
+        Grave = 3,
+
+        /// <summary>The most heinous: a capital wrong (murder, innocent blood, child sacrifice, defilement).</summary>
+        Capital = 4
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Grounding.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Grounding.cs
@@ -1,0 +1,96 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// What an agent stands on. From 1 Meqabyan: God alone gives life, and the idols "do not truly
+    /// live, they cannot give life." To be grounded in God is to stand on the source of being; to be
+    /// grounded in an idol is to stand on what has no ground, so even an outwardly good deed cannot
+    /// hold and drifts toward non-being.
+    /// </summary>
+    public class Grounding
+    {
+        private Grounding(string name, bool isInGod, double lifelessness)
+        {
+            Name = name;
+            IsInGod = isInGod;
+            this.lifelessness = lifelessness;
+        }
+
+        /// <summary>
+        /// How little life the foundation can give, from 0.0 (the living God) to 1.0 (an utterly
+        /// dead idol). This is how far a deed standing on it drifts toward non-being.
+        /// </summary>
+        private readonly double lifelessness;
+
+        /// <summary>
+        /// Gets the name of what the agent is grounded in.
+        /// </summary>
+        public string Name
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets whether the agent is grounded in the living God, the source of being.
+        /// </summary>
+        public bool IsInGod
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Grounded in the living God, the one who gives life (1 Meqabyan 1; John 14:6, "the life").
+        /// </summary>
+        /// <returns>A grounding in God.</returns>
+        public static Grounding InGod()
+        {
+            return new Grounding("God", true, 0.0);
+        }
+
+        /// <summary>
+        /// Grounded in an idol, which cannot give life (1 Meqabyan 1). A deed standing on it drifts
+        /// toward non-being.
+        /// </summary>
+        /// <param name="name">The name of the idol.</param>
+        /// <returns>A grounding in an idol.</returns>
+        public static Grounding InIdol(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new System.ArgumentNullException(nameof(name));
+            }
+
+            return new Grounding(name, false, 0.5);
+        }
+
+        /// <summary>
+        /// Bears a deed on this foundation. What stands on the living God keeps its life unchanged;
+        /// what stands on an idol loses life and gains disorder, because the foundation cannot hold.
+        /// </summary>
+        /// <param name="deed">The resolution of the deed as God's character read it.</param>
+        /// <returns>The deed as its foundation can sustain it.</returns>
+        public Resolution Bear(Resolution deed)
+        {
+            if (deed == null)
+            {
+                throw new System.ArgumentNullException(nameof(deed));
+            }
+
+            if (IsInGod)
+            {
+                return deed;
+            }
+
+            double coherence = deed.Coherence * (1.0 - lifelessness);
+            double disorder = deed.Disorder;
+            if (lifelessness > disorder)
+            {
+                disorder = lifelessness;
+            }
+
+            return new Resolution(coherence, disorder, deed.Readings);
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/HeavenlyTablets.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/HeavenlyTablets.cs
@@ -1,0 +1,70 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// The one record where state and truth are the same thing: the books from which every deed is
+    /// judged. "The dead were judged ... as recorded in the books." (Revelation 20:12); "A scroll of
+    /// remembrance was written in his presence." (Malachi 3:16); "The court was seated, and the books
+    /// were opened." (Daniel 7:10); "All the days ordained for me were written in your book."
+    /// (Psalm 139:16). It holds the earlier and the later together. Every deed reality witnesses is
+    /// written here, and the standing <see cref="Coherence"/> of the world is read off the whole
+    /// record.
+    /// </summary>
+    public class HeavenlyTablets
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HeavenlyTablets"/> class. A new record holds
+        /// no deeds yet, so reality stands fully ordered.
+        /// </summary>
+        public HeavenlyTablets()
+        {
+        }
+
+        private readonly System.Collections.Generic.List<Resolution> record =
+            new System.Collections.Generic.List<Resolution>();
+
+        /// <summary>
+        /// Writes a witnessed deed onto the record. What is recorded is permanent; the tablets hold
+        /// "the earlier and the later" (Psalm 139:16).
+        /// </summary>
+        /// <param name="resolution">The resolution of a deed reality has witnessed.</param>
+        public void Record(Resolution resolution)
+        {
+            if (resolution == null)
+            {
+                throw new System.ArgumentNullException(nameof(resolution));
+            }
+
+            record.Add(resolution);
+        }
+
+        /// <summary>
+        /// The whole record of deeds witnessed so far, in the order they happened.
+        /// </summary>
+        /// <returns>A read-only view of every recorded resolution.</returns>
+        public System.Collections.Generic.IReadOnlyList<Resolution> History()
+        {
+            return record;
+        }
+
+        /// <summary>
+        /// The standing coherence of all reality recorded so far, from 0.0 (wholly disordered) to
+        /// 1.0 (fully ordered). A new record reads 1.0; disorder introduced by witnessed deeds
+        /// degrades it (Romans 8:20-22, where in the days of sinners the courses of the heavens transgress
+        /// their order).
+        /// </summary>
+        /// <returns>The standing coherence of reality.</returns>
+        public double Coherence()
+        {
+            double coherence = 1.0;
+            foreach (Resolution resolution in record)
+            {
+                coherence = coherence * (1.0 - resolution.Disorder);
+            }
+
+            return coherence;
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Justice.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Justice.cs
@@ -1,0 +1,21 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// The facet of God's character that renders to each what is due. "Render to all what is due
+    /// them." (Romans 13:7); "He is the Rock, his works are perfect, and all his ways are just."
+    /// (Deuteronomy 32:4). Which acts embody or offend Justice is declared by the moral concepts
+    /// themselves (see <see cref="MoralConcept.Upholds"/> / <see cref="MoralConcept.Violates"/>).
+    /// </summary>
+    public class Justice : DivineAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Justice"/> class.
+        /// </summary>
+        public Justice() : base("Justice")
+        {
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/LoveFacet.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/LoveFacet.cs
@@ -1,0 +1,46 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// Love as a facet of God's character: agape, "God is love" (1 John 4:8) read as embodiment, not
+    /// equation. This facet reuses the existing <see cref="Love"/> model of 1 Corinthians 13:4-8 and
+    /// the sacrificial love of John 15:13; the backing <see cref="Agape"/> carries that full
+    /// character. Which acts embody or offend Love is declared by the moral concepts themselves. It
+    /// wraps the existing <see cref="Love"/> hierarchy rather than replacing it, so all prior love
+    /// behavior is intact.
+    /// </summary>
+    public class LoveFacet : DivineAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoveFacet"/> class backed by perfect agape.
+        /// </summary>
+        public LoveFacet() : this(Concepts.Love.Agape())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoveFacet"/> class backed by a given love.
+        /// God's love is agape; a lesser love is a lesser facet.
+        /// </summary>
+        /// <param name="agape">The love whose 1 Corinthians 13 character this facet expresses.</param>
+        public LoveFacet(Love agape) : base("Love")
+        {
+            if (agape == null)
+            {
+                throw new System.ArgumentNullException(nameof(agape));
+            }
+
+            Agape = agape;
+        }
+
+        /// <summary>
+        /// The love whose character this facet expresses (perfect agape for God's own love).
+        /// </summary>
+        public Love Agape
+        {
+            get;
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Mercy.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Mercy.cs
@@ -1,0 +1,21 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// The facet of God's character that withholds deserved harm and shows compassion to the
+    /// afflicted. "Be merciful, even as your Father is merciful." (Luke 6:36); "Mercy triumphs over
+    /// judgment." (James 2:13). Which acts embody or offend Mercy is declared by the moral concepts
+    /// themselves.
+    /// </summary>
+    public class Mercy : DivineAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Mercy"/> class.
+        /// </summary>
+        public Mercy() : base("Mercy")
+        {
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/MoralConcept.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/MoralConcept.cs
@@ -1,0 +1,86 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// A moral concept modeled as abstract code rather than a magic string. Each concrete concept
+    /// (Compassion, Murder, Sacrifice, Obedience, Idolatry, ...) is a first-class entity that knows
+    /// its own name, the Scripture it answers to, and how it bears on the facets of God's character:
+    /// which facets it embodies (<see cref="Upholds"/>) and which it offends (<see cref="Violates"/>).
+    /// This puts the moral nature of an act on the concept itself, once, instead of scattering it
+    /// across string lists inside each facet.
+    /// </summary>
+    public abstract class MoralConcept : Concept
+    {
+        /// <summary>
+        /// The Scripture this concept answers to.
+        /// </summary>
+        public abstract string Scripture
+        {
+            get;
+        }
+
+        /// <summary>
+        /// How heinous this concept is, and so how much disorder it unleashes into reality when it is
+        /// committed. A virtue has <see cref="Gravity.None"/>; each sin declares its weight, from a
+        /// minor wrong to a capital one (Scripture grades sin, Matthew 23:23; John 19:11).
+        /// </summary>
+        public virtual Gravity Gravity
+        {
+            get
+            {
+                return Gravity.None;
+            }
+        }
+
+        /// <summary>
+        /// Whether this concept embodies the given facet of God's character. Indifferent by default;
+        /// concrete concepts declare the facets they uphold.
+        /// </summary>
+        /// <param name="facet">A facet of God's character.</param>
+        /// <returns><c>true</c> if this concept embodies that facet.</returns>
+        public virtual bool Upholds(DivineAttribute facet)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Whether this concept offends the given facet of God's character. Indifferent by default;
+        /// concrete concepts declare the facets they violate.
+        /// </summary>
+        /// <param name="facet">A facet of God's character.</param>
+        /// <returns><c>true</c> if this concept offends that facet.</returns>
+        public virtual bool Violates(DivineAttribute facet)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Whether this concept embodies the given facet, read in the light of the deed's context. By
+        /// default context is ignored and the plain reading stands; a context-sensitive concept
+        /// overrides this to respond to war, divine command, or the defense of the innocent.
+        /// </summary>
+        /// <param name="facet">A facet of God's character.</param>
+        /// <param name="act">The whole deed, carrying its context.</param>
+        /// <returns><c>true</c> if this concept embodies that facet here.</returns>
+        public virtual bool Upholds(DivineAttribute facet, Act act)
+        {
+            return Upholds(facet);
+        }
+
+        /// <summary>
+        /// Whether this concept offends the given facet, read in the light of the deed's context. By
+        /// default context is ignored and the plain reading stands; a context-sensitive concept
+        /// overrides this (for example, a deception to save the innocent is not counted as the lie
+        /// God condemns, Joshua 2; Hebrews 11:31).
+        /// </summary>
+        /// <param name="facet">A facet of God's character.</param>
+        /// <param name="act">The whole deed, carrying its context.</param>
+        /// <returns><c>true</c> if this concept offends that facet here.</returns>
+        public virtual bool Violates(DivineAttribute facet, Act act)
+        {
+            return Violates(facet);
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Morals/AuditConcepts.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Morals/AuditConcepts.cs
@@ -1,0 +1,152 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-12
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    // Concepts the per-book agents asked for that were genuinely moral (not events or sacraments,
+    // which are modelled as SacredMystery, and not synonyms of existing concepts). Added in the final
+    // completeness audit so nothing the canon names is left unrepresented.
+
+    /// <summary>Wisdom: skill in living by the fear of the LORD. "The fear of the LORD is the beginning of wisdom." (Proverbs 9:10)</summary>
+    public sealed class Wisdom : MoralConcept
+    {
+        public override string Name => "Wisdom";
+        public override string Scripture => "Proverbs 9:10";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Integrity: wholeness and uprightness of heart. "May integrity and uprightness protect me." (Psalm 25:21)</summary>
+    public sealed class Integrity : MoralConcept
+    {
+        public override string Name => "Integrity";
+        public override string Scripture => "Psalm 25:21";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness || facet is Justice;
+    }
+
+    /// <summary>Reverence: the fear of the LORD. "The fear of the LORD is the beginning of knowledge." (Proverbs 1:7)</summary>
+    public sealed class Reverence : MoralConcept
+    {
+        public override string Name => "Reverence";
+        public override string Scripture => "Proverbs 1:7";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Thankfulness: gratitude to God in all things. "Give thanks in all circumstances." (1 Thessalonians 5:18)</summary>
+    public sealed class Thankfulness : MoralConcept
+    {
+        public override string Name => "Thankfulness";
+        public override string Scripture => "1 Thessalonians 5:18";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Faithfulness;
+    }
+
+    /// <summary>Contentment: peace with what God provides. "Godliness with contentment is great gain." (1 Timothy 6:6)</summary>
+    public sealed class Contentment : MoralConcept
+    {
+        public override string Name => "Contentment";
+        public override string Scripture => "1 Timothy 6:6";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Diligence: faithful, hardworking stewardship. "Diligent hands will rule." (Proverbs 12:24)</summary>
+    public sealed class Diligence : MoralConcept
+    {
+        public override string Name => "Diligence";
+        public override string Scripture => "Proverbs 12:24";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Discernment: the trained sense to distinguish good from evil. (Hebrews 5:14)</summary>
+    public sealed class Discernment : MoralConcept
+    {
+        public override string Name => "Discernment";
+        public override string Scripture => "Hebrews 5:14";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Friendship: loyal love between companions. "A friend loves at all times." (Proverbs 17:17)</summary>
+    public sealed class Friendship : MoralConcept
+    {
+        public override string Name => "Friendship";
+        public override string Scripture => "Proverbs 17:17";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Grace: undeserved favor and kindness shown. "By grace you have been saved." (Ephesians 2:8)</summary>
+    public sealed class Grace : MoralConcept
+    {
+        public override string Name => "Grace";
+        public override string Scripture => "Ephesians 2:8";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Mercy;
+    }
+
+    /// <summary>Provision: meeting the needs of the dependent. "Your heavenly Father feeds them." (Matthew 6:26)</summary>
+    public sealed class Provision : MoralConcept
+    {
+        public override string Name => "Provision";
+        public override string Scripture => "Matthew 6:26";
+        public override bool Upholds(DivineAttribute facet) => facet is Mercy || facet is LoveFacet;
+    }
+
+    /// <summary>Comfort: consoling the afflicted. "The God of all comfort." (2 Corinthians 1:3-4)</summary>
+    public sealed class Comfort : MoralConcept
+    {
+        public override string Name => "Comfort";
+        public override string Scripture => "2 Corinthians 1:3-4";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Mercy;
+    }
+
+    /// <summary>Cruelty: hardhearted infliction of suffering. "A cruel man brings trouble on himself." (Proverbs 11:17)</summary>
+    public sealed class Cruelty : MoralConcept
+    {
+        public override string Name => "Cruelty";
+        public override string Scripture => "Proverbs 11:17";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) =>
+            facet is LoveFacet || facet is Mercy || facet is Justice;
+    }
+
+    /// <summary>Tyranny: oppressive, unjust rule over the powerless. "When the wicked rule, the people groan." (Proverbs 29:2)</summary>
+    public sealed class Tyranny : MoralConcept
+    {
+        public override string Name => "Tyranny";
+        public override string Scripture => "Proverbs 29:2";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) => facet is Justice || facet is LoveFacet;
+    }
+
+    /// <summary>Plunder: violent seizing of others' goods. "Woe to you who have plundered." (Isaiah 33:1)</summary>
+    public sealed class Plunder : MoralConcept
+    {
+        public override string Name => "Plunder";
+        public override string Scripture => "Isaiah 33:1";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Justice;
+    }
+
+    /// <summary>Sacrilege: profaning what is holy to God. "You who abhor idols, do you rob temples?" (Romans 2:22; Daniel 5)</summary>
+    public sealed class Sacrilege : MoralConcept
+    {
+        public override string Name => "Sacrilege";
+        public override string Scripture => "Romans 2:22";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Hypocrisy: an outward form of godliness denying its power. "Inside you are full of hypocrisy." (Matthew 23:28)</summary>
+    public sealed class Hypocrisy : MoralConcept
+    {
+        public override string Name => "Hypocrisy";
+        public override string Scripture => "Matthew 23:28";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Simony: trafficking in the holy things of God for gain. "May your money perish with you!" (Acts 8:20)</summary>
+    public sealed class Simony : MoralConcept
+    {
+        public override string Name => "Simony";
+        public override string Scripture => "Acts 8:20";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness || facet is Justice;
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Morals/CanonConcepts.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Morals/CanonConcepts.cs
@@ -1,0 +1,460 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    // The remaining moral concepts Scripture names in its explicit catalogues: the Ten Commandments
+    // (Exodus 20), the works of the flesh and the fruit of the Spirit (Galatians 5:19-23), the seven
+    // the LORD hates (Proverbs 6:16-19), the vice lists (Romans 1:29-31; Colossians 3:5-9;
+    // 1 Corinthians 6:9-10; Mark 7:21-22; 2 Timothy 3:2-5), the works of mercy (Matthew 25:35-36),
+    // the Beatitudes (Matthew 5), and the love attributes (1 Corinthians 13:4-8). Each is first-class
+    // code with its own Scripture, the facets it bears on, and (for sins) its gravity. Concepts
+    // already represented elsewhere are reused, not duplicated.
+
+    // ---- Vices: works of the flesh, the seven the LORD hates, and the vice lists ----
+
+    /// <summary>Sexual immorality: porneia, the works of the flesh. "The acts of the flesh ... sexual immorality." (Galatians 5:19)</summary>
+    public sealed class SexualImmorality : MoralConcept
+    {
+        public override string Name => "SexualImmorality";
+        public override string Scripture => "Galatians 5:19";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Impurity: moral uncleanness. "The acts of the flesh ... impurity." (Galatians 5:19)</summary>
+    public sealed class Impurity : MoralConcept
+    {
+        public override string Name => "Impurity";
+        public override string Scripture => "Galatians 5:19";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Debauchery: sensual excess and licentiousness. "The acts of the flesh ... debauchery." (Galatians 5:19)</summary>
+    public sealed class Debauchery : MoralConcept
+    {
+        public override string Name => "Debauchery";
+        public override string Scripture => "Galatians 5:19";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Sorcery: pharmakeia, traffic with dark powers. "The acts of the flesh ... witchcraft." (Galatians 5:20)</summary>
+    public sealed class Sorcery : MoralConcept
+    {
+        public override string Name => "Sorcery";
+        public override string Scripture => "Galatians 5:20";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Hatred: enmity toward neighbour. "The acts of the flesh ... hatred." (Galatians 5:20)</summary>
+    public sealed class Hatred : MoralConcept
+    {
+        public override string Name => "Hatred";
+        public override string Scripture => "Galatians 5:20";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Discord: stirring up strife and dissension. "The acts of the flesh ... discord." (Galatians 5:20; Proverbs 6:19)</summary>
+    public sealed class Discord : MoralConcept
+    {
+        public override string Name => "Discord";
+        public override string Scripture => "Galatians 5:20";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Jealousy: covetous rivalry of the heart. "The acts of the flesh ... jealousy." (Galatians 5:20)</summary>
+    public sealed class Jealousy : MoralConcept
+    {
+        public override string Name => "Jealousy";
+        public override string Scripture => "Galatians 5:20";
+        public override Gravity Gravity => Gravity.Minor;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Fits of rage: uncontrolled outbursts of wrath. "The acts of the flesh ... fits of rage." (Galatians 5:20)</summary>
+    public sealed class FitsOfRage : MoralConcept
+    {
+        public override string Name => "FitsOfRage";
+        public override string Scripture => "Galatians 5:20";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet || facet is Faithfulness;
+    }
+
+    /// <summary>Selfish ambition: scheming for self at others' cost. "The acts of the flesh ... selfish ambition." (Galatians 5:20)</summary>
+    public sealed class SelfishAmbition : MoralConcept
+    {
+        public override string Name => "SelfishAmbition";
+        public override string Scripture => "Galatians 5:20";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet || facet is Faithfulness;
+    }
+
+    /// <summary>Faction: party spirit that splits the body. "The acts of the flesh ... factions." (Galatians 5:20)</summary>
+    public sealed class Faction : MoralConcept
+    {
+        public override string Name => "Faction";
+        public override string Scripture => "Galatians 5:20";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Drunkenness: surrender of the self to drink. "The acts of the flesh ... drunkenness." (Galatians 5:21)</summary>
+    public sealed class Drunkenness : MoralConcept
+    {
+        public override string Name => "Drunkenness";
+        public override string Scripture => "Galatians 5:21";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Carousing: revelry and wild dissipation. "The acts of the flesh ... orgies." (Galatians 5:21)</summary>
+    public sealed class Carousing : MoralConcept
+    {
+        public override string Name => "Carousing";
+        public override string Scripture => "Galatians 5:21";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Gluttony: the belly made a god. "Their god is their stomach." (Philippians 3:19; Proverbs 23:21)</summary>
+    public sealed class Gluttony : MoralConcept
+    {
+        public override string Name => "Gluttony";
+        public override string Scripture => "Proverbs 23:21";
+        public override Gravity Gravity => Gravity.Minor;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Slander: tearing down another with the tongue. "Slanderers ... will not inherit the kingdom." (Romans 1:30; 1 Corinthians 6:10)</summary>
+    public sealed class Slander : MoralConcept
+    {
+        public override string Name => "Slander";
+        public override string Scripture => "Romans 1:30";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet || facet is Faithfulness;
+    }
+
+    /// <summary>Gossip: whispering to wound. "Gossips, slanderers, God-haters." (Romans 1:29)</summary>
+    public sealed class Gossip : MoralConcept
+    {
+        public override string Name => "Gossip";
+        public override string Scripture => "Romans 1:29";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Malice: the will bent on another's harm. "Full of envy, murder, strife, deceit and malice." (Romans 1:29)</summary>
+    public sealed class Malice : MoralConcept
+    {
+        public override string Name => "Malice";
+        public override string Scripture => "Romans 1:29";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Sowing discord among brothers: the seventh the LORD hates. "A person who stirs up conflict in the community." (Proverbs 6:19)</summary>
+    public sealed class SowingDiscord : MoralConcept
+    {
+        public override string Name => "SowingDiscord";
+        public override string Scripture => "Proverbs 6:19";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Haughty eyes: the proud look the LORD hates. "Haughty eyes, a lying tongue." (Proverbs 6:17)</summary>
+    public sealed class HaughtyEyes : MoralConcept
+    {
+        public override string Name => "HaughtyEyes";
+        public override string Scripture => "Proverbs 6:17";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet || facet is Faithfulness;
+    }
+
+    /// <summary>A scheming heart: a heart that devises wicked plans, which the LORD hates. (Proverbs 6:18)</summary>
+    public sealed class WickedScheming : MoralConcept
+    {
+        public override string Name => "WickedScheming";
+        public override string Scripture => "Proverbs 6:18";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Justice || facet is Faithfulness;
+    }
+
+    /// <summary>Feet quick to rush into evil, which the LORD hates. "Feet that are quick to rush into evil." (Proverbs 6:18)</summary>
+    public sealed class QuickToEvil : MoralConcept
+    {
+        public override string Name => "QuickToEvil";
+        public override string Scripture => "Proverbs 6:18";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>False witness: a lying witness who pours out lies, which the LORD hates. "A false witness who pours out lies." (Proverbs 6:19; Exodus 20:16)</summary>
+    public sealed class FalseWitness : MoralConcept
+    {
+        public override string Name => "FalseWitness";
+        public override string Scripture => "Exodus 20:16";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Justice || facet is Faithfulness;
+    }
+
+    /// <summary>Covetousness: craving what belongs to a neighbour. "You shall not covet." (Exodus 20:17)</summary>
+    public sealed class Covetousness : MoralConcept
+    {
+        public override string Name => "Covetousness";
+        public override string Scripture => "Exodus 20:17";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet || facet is Justice;
+    }
+
+    /// <summary>Dishonoring parents: refusing the honour the Law commands. "Honor your father and your mother." (Exodus 20:12)</summary>
+    public sealed class DishonoringParents : MoralConcept
+    {
+        public override string Name => "DishonoringParents";
+        public override string Scripture => "Exodus 20:12";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Sabbath breaking: profaning the day God hallowed. "Remember the Sabbath day, to keep it holy." (Exodus 20:8)</summary>
+    public sealed class SabbathBreaking : MoralConcept
+    {
+        public override string Name => "SabbathBreaking";
+        public override string Scripture => "Exodus 20:8";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Misusing the name of God: taking the LORD's name in vain. "You shall not misuse the name of the LORD your God." (Exodus 20:7)</summary>
+    public sealed class MisusingGodsName : MoralConcept
+    {
+        public override string Name => "MisusingGodsName";
+        public override string Scripture => "Exodus 20:7";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Making graven images: bowing to the work of one's hands. "You shall not make for yourself an image." (Exodus 20:4)</summary>
+    public sealed class GravenImage : MoralConcept
+    {
+        public override string Name => "GravenImage";
+        public override string Scripture => "Exodus 20:4";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Sloth: the sluggard's refusal of his charge. "A little sleep, a little slumber ... and poverty will come." (Proverbs 6:10-11; 2 Thessalonians 3:10)</summary>
+    public sealed class Sloth : MoralConcept
+    {
+        public override string Name => "Sloth";
+        public override string Scripture => "Proverbs 6:10-11";
+        public override Gravity Gravity => Gravity.Minor;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Ingratitude: the unthankful heart of the last days. "Ungrateful, unholy." (2 Timothy 3:2)</summary>
+    public sealed class Ingratitude : MoralConcept
+    {
+        public override string Name => "Ingratitude";
+        public override string Scripture => "2 Timothy 3:2";
+        public override Gravity Gravity => Gravity.Minor;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet || facet is Faithfulness;
+    }
+
+    /// <summary>Heartlessness: without natural affection. "Without love, unforgiving, slanderous." (2 Timothy 3:3; Romans 1:31)</summary>
+    public sealed class Heartlessness : MoralConcept
+    {
+        public override string Name => "Heartlessness";
+        public override string Scripture => "Romans 1:31";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet || facet is Mercy;
+    }
+
+    /// <summary>Covenant-breaking: untrustworthy, breaking faith and pledge. "Faithless, heartless, ruthless." (Romans 1:31)</summary>
+    public sealed class CovenantBreaking : MoralConcept
+    {
+        public override string Name => "CovenantBreaking";
+        public override string Scripture => "Romans 1:31";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Insolence: the violent, arrogant despiser of others. "Insolent, arrogant and boastful." (Romans 1:30)</summary>
+    public sealed class Insolence : MoralConcept
+    {
+        public override string Name => "Insolence";
+        public override string Scripture => "Romans 1:30";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet || facet is Faithfulness;
+    }
+
+    /// <summary>Disobedience to parents: the rebellious child of the vice lists. "Disobedient to their parents." (Romans 1:30; 2 Timothy 3:2)</summary>
+    public sealed class DisobedienceToParents : MoralConcept
+    {
+        public override string Name => "DisobedienceToParents";
+        public override string Scripture => "Romans 1:30";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Filthy and foul language out of the mouth. "Filthy language from your lips." (Colossians 3:8)</summary>
+    public sealed class FilthyLanguage : MoralConcept
+    {
+        public override string Name => "FilthyLanguage";
+        public override string Scripture => "Colossians 3:8";
+        public override Gravity Gravity => Gravity.Minor;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Lust: the eye and heart that grasp in desire. "Anyone who looks ... lustfully." (Matthew 5:28)</summary>
+    public sealed class Lust : MoralConcept
+    {
+        public override string Name => "Lust";
+        public override string Scripture => "Matthew 5:28";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    // ---- Virtues: the fruit of the Spirit, the works of mercy, the Beatitudes ----
+
+    /// <summary>Joy: gladness rooted in God, the fruit of the Spirit. "The fruit of the Spirit is love, joy, peace." (Galatians 5:22)</summary>
+    public sealed class Joy : MoralConcept
+    {
+        public override string Name => "Joy";
+        public override string Scripture => "Galatians 5:22";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Peace: the wholeness and concord God gives, the fruit of the Spirit. "The fruit of the Spirit is ... peace." (Galatians 5:22)</summary>
+    public sealed class Peace : MoralConcept
+    {
+        public override string Name => "Peace";
+        public override string Scripture => "Galatians 5:22";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Goodness: active uprightness toward others, the fruit of the Spirit. "The fruit of the Spirit is ... goodness." (Galatians 5:22)</summary>
+    public sealed class Goodness : MoralConcept
+    {
+        public override string Name => "Goodness";
+        public override string Scripture => "Galatians 5:22";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Justice;
+    }
+
+    /// <summary>Fidelity: steadfast human reliability, the fruit of the Spirit, reflecting God's own
+    /// faithfulness. "The fruit of the Spirit is ... faithfulness." (Galatians 5:22)</summary>
+    public sealed class Fidelity : MoralConcept
+    {
+        public override string Name => "Fidelity";
+        public override string Scripture => "Galatians 5:22";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Gentleness: a meek and tender strength, the fruit of the Spirit. "The fruit of the Spirit is ... gentleness." (Galatians 5:23)</summary>
+    public sealed class Gentleness : MoralConcept
+    {
+        public override string Name => "Gentleness";
+        public override string Scripture => "Galatians 5:23";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Mercy;
+    }
+
+    /// <summary>Self-control: mastery over the appetites, the fruit of the Spirit. "The fruit of the Spirit is ... self-control." (Galatians 5:23)</summary>
+    public sealed class SelfControl : MoralConcept
+    {
+        public override string Name => "SelfControl";
+        public override string Scripture => "Galatians 5:23";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Feeding the hungry: a work of mercy. "I was hungry and you gave me something to eat." (Matthew 25:35)</summary>
+    public sealed class FeedingTheHungry : MoralConcept
+    {
+        public override string Name => "FeedingTheHungry";
+        public override string Scripture => "Matthew 25:35";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Mercy;
+    }
+
+    /// <summary>Giving drink to the thirsty: a work of mercy. "I was thirsty and you gave me something to drink." (Matthew 25:35)</summary>
+    public sealed class GivingDrink : MoralConcept
+    {
+        public override string Name => "GivingDrink";
+        public override string Scripture => "Matthew 25:35";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Mercy;
+    }
+
+    /// <summary>Clothing the naked: a work of mercy. "I needed clothes and you clothed me." (Matthew 25:36)</summary>
+    public sealed class ClothingTheNaked : MoralConcept
+    {
+        public override string Name => "ClothingTheNaked";
+        public override string Scripture => "Matthew 25:36";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Mercy;
+    }
+
+    /// <summary>Caring for the sick: a work of mercy. "I was sick and you looked after me." (Matthew 25:36)</summary>
+    public sealed class CaringForTheSick : MoralConcept
+    {
+        public override string Name => "CaringForTheSick";
+        public override string Scripture => "Matthew 25:36";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Mercy;
+    }
+
+    /// <summary>Visiting the prisoner: a work of mercy. "I was in prison and you came to visit me." (Matthew 25:36)</summary>
+    public sealed class VisitingThePrisoner : MoralConcept
+    {
+        public override string Name => "VisitingThePrisoner";
+        public override string Scripture => "Matthew 25:36";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Mercy;
+    }
+
+    /// <summary>Poverty of spirit: knowing one's need of God, the first Beatitude. "Blessed are the poor in spirit." (Matthew 5:3)</summary>
+    public sealed class PovertyOfSpirit : MoralConcept
+    {
+        public override string Name => "PovertyOfSpirit";
+        public override string Scripture => "Matthew 5:3";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Mourning: grieving over sin and loss, the blessed who shall be comforted. "Blessed are those who mourn." (Matthew 5:4)</summary>
+    public sealed class Mourning : MoralConcept
+    {
+        public override string Name => "Mourning";
+        public override string Scripture => "Matthew 5:4";
+        public override bool Upholds(DivineAttribute facet) => facet is Mercy || facet is LoveFacet;
+    }
+
+    /// <summary>Meekness: strength surrendered to God, the meek who inherit the earth. "Blessed are the meek." (Matthew 5:5)</summary>
+    public sealed class Meekness : MoralConcept
+    {
+        public override string Name => "Meekness";
+        public override string Scripture => "Matthew 5:5";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Faithfulness;
+    }
+
+    /// <summary>Hungering for righteousness: longing to be made right, the Beatitude. "Blessed are those who hunger and thirst for righteousness." (Matthew 5:6)</summary>
+    public sealed class HungerForRighteousness : MoralConcept
+    {
+        public override string Name => "HungerForRighteousness";
+        public override string Scripture => "Matthew 5:6";
+        public override bool Upholds(DivineAttribute facet) => facet is Justice || facet is Faithfulness;
+    }
+
+    /// <summary>Purity of heart: the single, undivided heart that sees God. "Blessed are the pure in heart." (Matthew 5:8)</summary>
+    public sealed class Purity : MoralConcept
+    {
+        public override string Name => "Purity";
+        public override string Scripture => "Matthew 5:8";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Endurance under persecution: standing firm for righteousness' sake, the Beatitude. "Blessed are those who are persecuted because of righteousness." (Matthew 5:10; 1 Corinthians 13:7)</summary>
+    public sealed class Endurance : MoralConcept
+    {
+        public override string Name => "Endurance";
+        public override string Scripture => "Matthew 5:10";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Morals/MoreVices.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Morals/MoreVices.cs
@@ -1,0 +1,76 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    // Further sins the broader canon names, each with its Scripture, the facets it offends, and its
+    // gravity.
+
+    /// <summary>Idolatry: worship turned from God to dead idols. "You shall have no other gods before me." (Exodus 20:3)</summary>
+    public sealed class Idolatry : MoralConcept
+    {
+        public override string Name => "Idolatry";
+        public override string Scripture => "Exodus 20:3";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Adultery: betrayal of the marriage covenant. "You shall not commit adultery." (Exodus 20:14)</summary>
+    public sealed class Adultery : MoralConcept
+    {
+        public override string Name => "Adultery";
+        public override string Scripture => "Exodus 20:14";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) =>
+            facet is LoveFacet || facet is Faithfulness || facet is Justice;
+    }
+
+    /// <summary>Pride: self-exaltation against God and neighbour. "Pride goes before destruction." (Proverbs 16:18)</summary>
+    public sealed class Pride : MoralConcept
+    {
+        public override string Name => "Pride";
+        public override string Scripture => "Proverbs 16:18";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet || facet is Faithfulness;
+    }
+
+    /// <summary>Deceit: lying and false witness. "The LORD detests lying lips." (Proverbs 12:22; Exodus 20:16)</summary>
+    public sealed class Deceit : MoralConcept
+    {
+        public override string Name => "Deceit";
+        public override string Scripture => "Proverbs 12:22";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+
+        // Context-sensitive: a deception to shield the innocent from those who would murder them is
+        // not the lie God condemns. Rahab hid the spies (Joshua 2; commended in Hebrews 11:31), and
+        // the Hebrew midwives deceived Pharaoh and God dealt well with them (Exodus 1:19-21).
+        public override bool Violates(DivineAttribute facet, Act act)
+        {
+            if (act.InContextOf(new Circumstance("protectingInnocentLife")))
+            {
+                return false;
+            }
+
+            return Violates(facet);
+        }
+    }
+
+    /// <summary>Blasphemy: reviling the holy name of God. "Anyone who blasphemes the name of the LORD." (Leviticus 24:16)</summary>
+    public sealed class Blasphemy : MoralConcept
+    {
+        public override string Name => "Blasphemy";
+        public override string Scripture => "Leviticus 24:16";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Greed: the love of money that grasps at the expense of others. (1 Timothy 6:10)</summary>
+    public sealed class Greed : MoralConcept
+    {
+        public override string Name => "Greed";
+        public override string Scripture => "1 Timothy 6:10";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet || facet is Justice;
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Morals/MoreVirtues.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Morals/MoreVirtues.cs
@@ -1,0 +1,64 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    // Further virtues the broader canon calls for, each first-class code with its own Scripture and
+    // stance toward God's character.
+
+    /// <summary>Humility: lowliness of heart before God and others. "Walk humbly with your God." (Micah 6:8)</summary>
+    public sealed class Humility : MoralConcept
+    {
+        public override string Name => "Humility";
+        public override string Scripture => "Micah 6:8";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Faithfulness;
+    }
+
+    /// <summary>Generosity: open-handed giving to the needy. "Whoever is kind to the poor lends to the LORD." (Proverbs 19:17)</summary>
+    public sealed class Generosity : MoralConcept
+    {
+        public override string Name => "Generosity";
+        public override string Scripture => "Proverbs 19:17";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Mercy;
+    }
+
+    /// <summary>Repentance: turning back from sin to God. "Return to me ... for he is gracious and compassionate." (Joel 2:13)</summary>
+    public sealed class Repentance : MoralConcept
+    {
+        public override string Name => "Repentance";
+        public override string Scripture => "Joel 2:13";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness || facet is Mercy;
+    }
+
+    /// <summary>Trust: faith in God's faithfulness. "The righteous shall live by his faith." (Habakkuk 2:4; Genesis 15:6)</summary>
+    public sealed class Trust : MoralConcept
+    {
+        public override string Name => "Trust";
+        public override string Scripture => "Habakkuk 2:4";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Worship: right reverence and praise of God. "Worship the LORD in the splendor of his holiness." (Psalm 29:2)</summary>
+    public sealed class Worship : MoralConcept
+    {
+        public override string Name => "Worship";
+        public override string Scripture => "Psalm 29:2";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Peacemaking: making peace between the estranged. "Blessed are the peacemakers." (Matthew 5:9)</summary>
+    public sealed class Peacemaking : MoralConcept
+    {
+        public override string Name => "Peacemaking";
+        public override string Scripture => "Matthew 5:9";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Faithfulness;
+    }
+
+    /// <summary>Courageous faithfulness: standing for God under threat. "Be strong and courageous." (Joshua 1:9; Daniel 3)</summary>
+    public sealed class CourageousFaith : MoralConcept
+    {
+        public override string Name => "CourageousFaith";
+        public override string Scripture => "Joshua 1:9";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness;
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Morals/Mysteries.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Morals/Mysteries.cs
@@ -1,0 +1,94 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-12
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// A sacred mystery: a redemptive act of God or a sacrament of the Church, not a moral virtue or
+    /// sin but a holy work in which the whole character of God is present. The engine previously
+    /// could only model the moral character of an act; the per-book agents kept reaching for the
+    /// Incarnation, the Resurrection, the Eucharist, and could only approximate them with adjacent
+    /// virtues. A mystery is its own kind of concept: it embodies every facet of God's character at
+    /// once, so it reads as a fully coherent divine act that destabilizes nothing.
+    /// </summary>
+    public abstract class SacredMystery : MoralConcept
+    {
+        /// <summary>A holy mystery embodies the whole character of God; it offends no facet.</summary>
+        /// <param name="facet">A facet of God's character.</param>
+        /// <returns>Always <c>true</c>: the mystery upholds every facet.</returns>
+        public override bool Upholds(DivineAttribute facet)
+        {
+            return true;
+        }
+    }
+
+    /// <summary>The Incarnation: "the Word became flesh and made his dwelling among us." (John 1:14)</summary>
+    public sealed class Incarnation : SacredMystery
+    {
+        public override string Name => "Incarnation";
+        public override string Scripture => "John 1:14";
+    }
+
+    /// <summary>The Resurrection: "he was raised on the third day." (1 Corinthians 15:4)</summary>
+    public sealed class Resurrection : SacredMystery
+    {
+        public override string Name => "Resurrection";
+        public override string Scripture => "1 Corinthians 15:4";
+    }
+
+    /// <summary>The Transfiguration: "his face shone like the sun." (Matthew 17:2)</summary>
+    public sealed class Transfiguration : SacredMystery
+    {
+        public override string Name => "Transfiguration";
+        public override string Scripture => "Matthew 17:2";
+    }
+
+    /// <summary>The Ascension: "he was taken up before their very eyes." (Acts 1:9)</summary>
+    public sealed class Ascension : SacredMystery
+    {
+        public override string Name => "Ascension";
+        public override string Scripture => "Acts 1:9";
+    }
+
+    /// <summary>Pentecost: "all of them were filled with the Holy Spirit." (Acts 2:4)</summary>
+    public sealed class Pentecost : SacredMystery
+    {
+        public override string Name => "Pentecost";
+        public override string Scripture => "Acts 2:4";
+    }
+
+    /// <summary>The Eucharist: "This is my body given for you; do this in remembrance of me." (Luke 22:19)</summary>
+    public sealed class Eucharist : SacredMystery
+    {
+        public override string Name => "Eucharist";
+        public override string Scripture => "Luke 22:19";
+    }
+
+    /// <summary>Baptism: "baptizing them in the name of the Father and of the Son and of the Holy Spirit." (Matthew 28:19)</summary>
+    public sealed class Baptism : SacredMystery
+    {
+        public override string Name => "Baptism";
+        public override string Scripture => "Matthew 28:19";
+    }
+
+    /// <summary>Ordination: the laying on of hands to set apart for ministry. (Acts 6:6; 1 Timothy 4:14)</summary>
+    public sealed class Ordination : SacredMystery
+    {
+        public override string Name => "Ordination";
+        public override string Scripture => "Acts 6:6";
+    }
+
+    /// <summary>Divine revelation: "God ... has spoken to us by his Son." (Hebrews 1:1-2)</summary>
+    public sealed class DivineRevelation : SacredMystery
+    {
+        public override string Name => "DivineRevelation";
+        public override string Scripture => "Hebrews 1:1-2";
+    }
+
+    /// <summary>The new creation: "I am making everything new." (Revelation 21:5)</summary>
+    public sealed class NewCreation : SacredMystery
+    {
+        public override string Name => "NewCreation";
+        public override string Scripture => "Revelation 21:5";
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Morals/Vices.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Morals/Vices.cs
@@ -1,0 +1,209 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    // Moral concepts that offend facets of God's character. Each declares its own Scripture, which
+    // facets of God it violates, and how heinous it is (its Gravity, which drives the disorder it
+    // unleashes). A concept that offends more than one facet reads as a graver wrong; a capital
+    // concept unleashes the most destruction.
+
+    /// <summary>Murder: the unjust taking of a life. "You shall not murder." (Exodus 20:13)</summary>
+    public sealed class Murder : MoralConcept
+    {
+        public override string Name => "Murder";
+        public override string Scripture => "Exodus 20:13";
+        public override Gravity Gravity => Gravity.Capital;
+        public override bool Violates(DivineAttribute facet) => facet is Justice || facet is LoveFacet;
+    }
+
+    /// <summary>Defilement: the violation of a person, equated with murder. (Deuteronomy 22:25-27)</summary>
+    public sealed class Defilement : MoralConcept
+    {
+        public override string Name => "Defilement";
+        public override string Scripture => "Deuteronomy 22:25-27";
+        public override Gravity Gravity => Gravity.Capital;
+        public override bool Violates(DivineAttribute facet) => facet is Justice || facet is LoveFacet;
+    }
+
+    /// <summary>Wronging a neighbour generally: harm done to another. "Love does no harm to a neighbor." (Romans 13:10)</summary>
+    public sealed class Wrongdoing : MoralConcept
+    {
+        public override string Name => "Wrongdoing";
+        public override string Scripture => "Romans 13:10";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Justice || facet is LoveFacet;
+    }
+
+    /// <summary>Theft: taking what is not due. "You shall not steal." (Exodus 20:15)</summary>
+    public sealed class Theft : MoralConcept
+    {
+        public override string Name => "Theft";
+        public override string Scripture => "Exodus 20:15";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Justice;
+    }
+
+    /// <summary>Withholding what is due: defrauding the worker of wages. (James 5:4)</summary>
+    public sealed class WithholdingWhatIsDue : MoralConcept
+    {
+        public override string Name => "WithholdingWhatIsDue";
+        public override string Scripture => "James 5:4";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Justice;
+    }
+
+    /// <summary>Bloodshed: shedding innocent blood. "Hands that shed innocent blood." (Proverbs 6:17)</summary>
+    public sealed class Bloodshed : MoralConcept
+    {
+        public override string Name => "Bloodshed";
+        public override string Scripture => "Proverbs 6:17";
+        public override Gravity Gravity => Gravity.Capital;
+        public override bool Violates(DivineAttribute facet) => facet is Justice || facet is LoveFacet;
+    }
+
+    /// <summary>Oppression: crushing the weak and the poor. "Do not mistreat the widow or the fatherless." (Exodus 22:22)</summary>
+    public sealed class Oppression : MoralConcept
+    {
+        public override string Name => "Oppression";
+        public override string Scripture => "Exodus 22:22";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) => facet is Justice || facet is LoveFacet;
+    }
+
+    /// <summary>Child sacrifice: the detestable practice of the nations. "Do not give your children to Molek." (Leviticus 18:21)</summary>
+    public sealed class ChildSacrifice : MoralConcept
+    {
+        public override string Name => "ChildSacrifice";
+        public override string Scripture => "Leviticus 18:21";
+        public override Gravity Gravity => Gravity.Capital;
+        public override bool Violates(DivineAttribute facet) =>
+            facet is Justice || facet is LoveFacet || facet is Faithfulness;
+    }
+
+    /// <summary>Self-seeking: "Love ... is not self-seeking." (1 Corinthians 13:5)</summary>
+    public sealed class SelfSeeking : MoralConcept
+    {
+        public override string Name => "SelfSeeking";
+        public override string Scripture => "1 Corinthians 13:5";
+        public override Gravity Gravity => Gravity.Minor;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>A grudge: keeping a record of wrongs. "Love ... keeps no record of wrongs." (1 Corinthians 13:5)</summary>
+    public sealed class Grudge : MoralConcept
+    {
+        public override string Name => "Grudge";
+        public override string Scripture => "1 Corinthians 13:5";
+        public override Gravity Gravity => Gravity.Minor;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Boasting: "Love ... does not boast." (1 Corinthians 13:4)</summary>
+    public sealed class Boasting : MoralConcept
+    {
+        public override string Name => "Boasting";
+        public override string Scripture => "1 Corinthians 13:4";
+        public override Gravity Gravity => Gravity.Minor;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Envy: "Love does not envy." (1 Corinthians 13:4)</summary>
+    public sealed class Envy : MoralConcept
+    {
+        public override string Name => "Envy";
+        public override string Scripture => "1 Corinthians 13:4";
+        public override Gravity Gravity => Gravity.Minor;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Rudeness: dishonoring others. "Love ... does not dishonor others." (1 Corinthians 13:5)</summary>
+    public sealed class Rudeness : MoralConcept
+    {
+        public override string Name => "Rudeness";
+        public override string Scripture => "1 Corinthians 13:5";
+        public override Gravity Gravity => Gravity.Minor;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Delighting in evil: "Love does not delight in evil." (1 Corinthians 13:6)</summary>
+    public sealed class DelightingInEvil : MoralConcept
+    {
+        public override string Name => "DelightingInEvil";
+        public override string Scripture => "1 Corinthians 13:6";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Condemnation: crushing the broken and contrite. "A bruised reed he will not break." (Matthew 12:20)</summary>
+    public sealed class Condemnation : MoralConcept
+    {
+        public override string Name => "Condemnation";
+        public override string Scripture => "Matthew 12:20";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Mercy;
+    }
+
+    /// <summary>Indifference: withholding compassion from one in need. "If anyone ... has no pity." (1 John 3:17)</summary>
+    public sealed class Indifference : MoralConcept
+    {
+        public override string Name => "Indifference";
+        public override string Scripture => "1 John 3:17";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Mercy || facet is LoveFacet;
+    }
+
+    /// <summary>Unforgiveness: refusing the mercy one has received. (Matthew 18:35)</summary>
+    public sealed class Unforgiveness : MoralConcept
+    {
+        public override string Name => "Unforgiveness";
+        public override string Scripture => "Matthew 18:35";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Mercy;
+    }
+
+    /// <summary>Disobedience to God: doing what He forbade. "She took ... and ate." (Genesis 3:6)</summary>
+    public sealed class Disobedience : MoralConcept
+    {
+        public override string Name => "Disobedience";
+        public override string Scripture => "Genesis 3:6";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Rebellion against God. "Rebellion is like the sin of divination." (1 Samuel 15:23)</summary>
+    public sealed class Rebellion : MoralConcept
+    {
+        public override string Name => "Rebellion";
+        public override string Scripture => "1 Samuel 15:23";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness || facet is LoveFacet;
+    }
+
+    /// <summary>Treachery: breaking faith, betraying a covenant. "Do not be unfaithful." (Malachi 2:10)</summary>
+    public sealed class Treachery : MoralConcept
+    {
+        public override string Name => "Treachery";
+        public override string Scripture => "Malachi 2:10";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Chaos: sowing disorder. "For God is not a God of disorder but of peace." (1 Corinthians 14:33)</summary>
+    public sealed class Chaos : MoralConcept
+    {
+        public override string Name => "Chaos";
+        public override string Scripture => "1 Corinthians 14:33";
+        public override Gravity Gravity => Gravity.Serious;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Lawlessness: "Sin is lawlessness." (1 John 3:4)</summary>
+    public sealed class Lawlessness : MoralConcept
+    {
+        public override string Name => "Lawlessness";
+        public override string Scripture => "1 John 3:4";
+        public override Gravity Gravity => Gravity.Grave;
+        public override bool Violates(DivineAttribute facet) => facet is Faithfulness;
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Morals/Virtues.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Morals/Virtues.cs
@@ -1,0 +1,193 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    // Moral concepts that embody facets of God's character. Each is first-class code, not a string:
+    // it declares its own Scripture and which facets of God it upholds. Grouped here by kind for
+    // navigation; each remains its own concept with its own logic.
+
+    /// <summary>Compassion: mercy and love to the afflicted. "Be merciful, even as your Father is merciful." (Luke 6:36)</summary>
+    public sealed class Compassion : MoralConcept
+    {
+        public override string Name => "Compassion";
+        public override string Scripture => "Luke 6:36";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Mercy;
+    }
+
+    /// <summary>Protection: love that always protects. "Love ... always protects." (1 Corinthians 13:7)</summary>
+    public sealed class Protection : MoralConcept
+    {
+        public override string Name => "Protection";
+        public override string Scripture => "1 Corinthians 13:7";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Kindness: "Love is kind." (1 Corinthians 13:4)</summary>
+    public sealed class Kindness : MoralConcept
+    {
+        public override string Name => "Kindness";
+        public override string Scripture => "1 Corinthians 13:4";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Rejoicing in the truth: "Love ... rejoices with the truth." (1 Corinthians 13:6)</summary>
+    public sealed class RejoicingInTruth : MoralConcept
+    {
+        public override string Name => "RejoicingInTruth";
+        public override string Scripture => "1 Corinthians 13:6";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Patience: "Love is patient." (1 Corinthians 13:4)</summary>
+    public sealed class Patience : MoralConcept
+    {
+        public override string Name => "Patience";
+        public override string Scripture => "1 Corinthians 13:4";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Self-sacrifice: laying down one's life. "Greater love has no one than this." (John 15:13)</summary>
+    public sealed class SelfSacrifice : MoralConcept
+    {
+        public override string Name => "SelfSacrifice";
+        public override string Scripture => "John 15:13";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Forgiveness: "Forgive as the Lord forgave you." (Colossians 3:13)</summary>
+    public sealed class Forgiveness : MoralConcept
+    {
+        public override string Name => "Forgiveness";
+        public override string Scripture => "Colossians 3:13";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Mercy;
+    }
+
+    /// <summary>Healing the sick. "Jesus ... healing every disease and sickness." (Matthew 9:35)</summary>
+    public sealed class Healing : MoralConcept
+    {
+        public override string Name => "Healing";
+        public override string Scripture => "Matthew 9:35";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Mercy;
+    }
+
+    /// <summary>Hospitality: welcoming the stranger. "Love the foreigner." (Deuteronomy 10:19)</summary>
+    public sealed class Hospitality : MoralConcept
+    {
+        public override string Name => "Hospitality";
+        public override string Scripture => "Deuteronomy 10:19";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Mercy;
+    }
+
+    /// <summary>Honoring the vulnerable: the widow, the orphan, the child. (Exodus 22:22)</summary>
+    public sealed class HonoringTheVulnerable : MoralConcept
+    {
+        public override string Name => "HonoringTheVulnerable";
+        public override string Scripture => "Exodus 22:22";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Justice;
+    }
+
+    /// <summary>Teaching the truth. "The truth will set you free." (John 8:32)</summary>
+    public sealed class TeachingTruth : MoralConcept
+    {
+        public override string Name => "TeachingTruth";
+        public override string Scripture => "John 8:32";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet;
+    }
+
+    /// <summary>Restoring life: raising the dead, reversing death itself. "Lazarus, come out!" (John 11:43)</summary>
+    public sealed class RestoringLife : MoralConcept
+    {
+        public override string Name => "RestoringLife";
+        public override string Scripture => "John 11:43";
+        public override bool Upholds(DivineAttribute facet) => facet is LoveFacet || facet is Faithfulness;
+    }
+
+    /// <summary>Atonement: paying the debt that justice requires. "A sacrifice of atonement." (Romans 3:25)</summary>
+    public sealed class Atonement : MoralConcept
+    {
+        public override string Name => "Atonement";
+        public override string Scripture => "Romans 3:25";
+        public override bool Upholds(DivineAttribute facet) => facet is Justice;
+    }
+
+    /// <summary>Just recompense: rendering to each what is due. "Render to all what is due." (Romans 13:7)</summary>
+    public sealed class JustRecompense : MoralConcept
+    {
+        public override string Name => "JustRecompense";
+        public override string Scripture => "Romans 13:7";
+        public override bool Upholds(DivineAttribute facet) => facet is Justice;
+    }
+
+    /// <summary>Deliverance: rescuing the oppressed. "I have come down to rescue them." (Exodus 3:8)</summary>
+    public sealed class Deliverance : MoralConcept
+    {
+        public override string Name => "Deliverance";
+        public override string Scripture => "Exodus 3:8";
+        public override bool Upholds(DivineAttribute facet) => facet is Justice || facet is Mercy;
+    }
+
+    /// <summary>Defending the weak. "Defend the weak and the fatherless." (Psalm 82:3)</summary>
+    public sealed class DefendingTheWeak : MoralConcept
+    {
+        public override string Name => "DefendingTheWeak";
+        public override string Scripture => "Psalm 82:3";
+        public override bool Upholds(DivineAttribute facet) => facet is Justice;
+    }
+
+    /// <summary>Righteousness: "The LORD is righteous, he loves justice." (Psalm 11:7)</summary>
+    public sealed class Righteousness : MoralConcept
+    {
+        public override string Name => "Righteousness";
+        public override string Scripture => "Psalm 11:7";
+        public override bool Upholds(DivineAttribute facet) => facet is Justice;
+    }
+
+    /// <summary>Pardon: sparing the guilty. "While we were still sinners, Christ died for us." (Romans 5:8)</summary>
+    public sealed class Pardon : MoralConcept
+    {
+        public override string Name => "Pardon";
+        public override string Scripture => "Romans 5:8";
+        public override bool Upholds(DivineAttribute facet) => facet is Mercy;
+    }
+
+    /// <summary>Covenant faithfulness: keeping one's promise. "Great is your faithfulness." (Lamentations 3:23)</summary>
+    public sealed class CovenantFaithfulness : MoralConcept
+    {
+        public override string Name => "CovenantFaithfulness";
+        public override string Scripture => "Lamentations 3:23";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Upholding the order of creation. "In him all things hold together." (Colossians 1:17)</summary>
+    public sealed class CreationOrder : MoralConcept
+    {
+        public override string Name => "CreationOrder";
+        public override string Scripture => "Colossians 1:17";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Obedience to God: alignment with His word. "If you fully obey the LORD." (Deuteronomy 28:1)</summary>
+    public sealed class ObedienceToGod : MoralConcept
+    {
+        public override string Name => "ObedienceToGod";
+        public override string Scripture => "Deuteronomy 28:1";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>The promise fulfilled: God keeping His word across history. "It must be fulfilled." (Luke 24:44)</summary>
+    public sealed class PromiseFulfilled : MoralConcept
+    {
+        public override string Name => "PromiseFulfilled";
+        public override string Scripture => "Luke 24:44";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness;
+    }
+
+    /// <summary>Trustworthiness: a faithful keeper of confidence and covenant. (Proverbs 11:13)</summary>
+    public sealed class Trustworthiness : MoralConcept
+    {
+        public override string Name => "Trustworthiness";
+        public override string Scripture => "Proverbs 11:13";
+        public override bool Upholds(DivineAttribute facet) => facet is Faithfulness;
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Reality.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Reality.cs
@@ -1,0 +1,98 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// The Universe: the one thing agents address. Reality is grounded in God; it does not contain
+    /// the grounding. The Father (the ground of being) is never an object here, He is what reality is
+    /// grounded in and pervaded by, presupposed by there being any runnable world at all
+    /// (Colossians 1:17, "in him all things hold together"; Hebrews 1:3, "sustaining all things by
+    /// his powerful word"). We act on reality; we never construct God.
+    ///
+    /// <para>
+    /// To witness a situation is, in one act, both to judge its truth and to record it: state and
+    /// truth are one system. The deed is harmonized under God's whole <see cref="DivineCharacter"/>
+    /// and written onto the <see cref="HeavenlyTablets"/>.
+    /// </para>
+    /// </summary>
+    public class Reality
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Reality"/> class grounded in a given
+        /// character of God, upon fresh, fully ordered tablets.
+        /// </summary>
+        /// <param name="character">The whole character of God reality is grounded in.</param>
+        public Reality(DivineCharacter character)
+        {
+            if (character == null)
+            {
+                throw new System.ArgumentNullException(nameof(character));
+            }
+
+            this.character = character;
+            Tablets = new HeavenlyTablets();
+        }
+
+        private readonly DivineCharacter character;
+
+        /// <summary>
+        /// The one record of all that reality has witnessed, and the source of its standing order
+        /// (Revelation 20:12; Malachi 3:16).
+        /// </summary>
+        public HeavenlyTablets Tablets
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Witnesses a situation: harmonizes it under the whole of God's character, writes it onto
+        /// the tablets, and returns the resolution. The same act produces both the truth of the deed
+        /// and the change to reality's record, because they are one system.
+        /// </summary>
+        /// <param name="act">The deed reality witnesses.</param>
+        /// <returns>The harmonized <see cref="Resolution"/>.</returns>
+        public Resolution Witness(Act act)
+        {
+            return Witness(act, Grounding.InGod());
+        }
+
+        /// <summary>
+        /// Witnesses a situation as done by an agent standing on a given foundation. The deed is
+        /// harmonized under God's character, then borne on its <see cref="Grounding"/> (a deed on the
+        /// living God keeps its life; a deed on an idol drifts toward non-being, 1 Meqabyan), and the
+        /// borne deed is what is written onto the tablets.
+        /// </summary>
+        /// <param name="act">The deed reality witnesses.</param>
+        /// <param name="grounding">What the acting agent is grounded in.</param>
+        /// <returns>The harmonized resolution as its foundation can sustain it.</returns>
+        public Resolution Witness(Act act, Grounding grounding)
+        {
+            if (act == null)
+            {
+                throw new System.ArgumentNullException(nameof(act));
+            }
+
+            if (grounding == null)
+            {
+                throw new System.ArgumentNullException(nameof(grounding));
+            }
+
+            Resolution resolution = character.Harmonize(act);
+            Resolution borne = grounding.Bear(resolution);
+            Tablets.Record(borne);
+            return borne;
+        }
+
+        /// <summary>
+        /// Reveals reality already grounded in God's character. "In the beginning was the Word ...
+        /// all things were made through him." (John 1:1-3). The standard facets are all live at once.
+        /// </summary>
+        /// <returns>A <see cref="Reality"/> grounded in the revealed character of God.</returns>
+        public static Reality Revealed()
+        {
+            return new Reality(new DivineCharacter(
+                new LoveFacet(), new Justice(), new Mercy(), new Faithfulness()));
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Resolution.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Resolution.cs
@@ -1,0 +1,120 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// What <see cref="Reality"/> gives back when it witnesses a situation. Not a pass/fail verdict:
+    /// a reading of how well an act coheres with the grounding (its truth) and how much disorder the
+    /// act introduces into reality. Acting against God's character does not "fail"; it destabilizes
+    /// the world, the way sin warps the courses of the stars (Romans 8:20-22).
+    /// </summary>
+    public class Resolution
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Resolution"/> class.
+        /// </summary>
+        /// <param name="coherence">How well the act fits the grounding (its truth).</param>
+        /// <param name="disorder">How much disorder the act introduces into reality (Romans 8:20-22).</param>
+        public Resolution(double coherence, double disorder)
+            : this(coherence, disorder, new System.Collections.Generic.Dictionary<string, double>())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Resolution"/> class carrying the per-facet
+        /// readings that harmonized into it, so a resolution is transparent: you can see that the
+        /// cross read full Justice and full Mercy at once.
+        /// </summary>
+        /// <param name="coherence">How well the act fits the grounding (its truth).</param>
+        /// <param name="disorder">How much disorder the act introduces into reality (Romans 8:20-22).</param>
+        /// <param name="readings">Each facet's reading of the act, keyed by facet name.</param>
+        public Resolution(
+            double coherence,
+            double disorder,
+            System.Collections.Generic.IReadOnlyDictionary<string, double> readings)
+        {
+            if (readings == null)
+            {
+                throw new System.ArgumentNullException(nameof(readings));
+            }
+
+            Coherence = Clamp(coherence);
+            Disorder = Clamp(disorder);
+            this.readings = readings;
+        }
+
+        private readonly System.Collections.Generic.IReadOnlyDictionary<string, double> readings;
+
+        /// <summary>
+        /// The reading a single facet of God's character gave the witnessed act.
+        /// </summary>
+        /// <param name="facet">The facet name (for example, "Justice" or "Mercy").</param>
+        /// <returns>That facet's coherence reading.</returns>
+        public double Reading(string facet)
+        {
+            if (string.IsNullOrEmpty(facet))
+            {
+                throw new System.ArgumentNullException(nameof(facet));
+            }
+
+            double reading;
+            if (readings.TryGetValue(facet, out reading))
+            {
+                return reading;
+            }
+
+            throw new System.Collections.Generic.KeyNotFoundException(
+                "No facet named '" + facet + "' contributed to this resolution.");
+        }
+
+        /// <summary>
+        /// Every facet's reading of the witnessed act, keyed by facet name.
+        /// </summary>
+        public System.Collections.Generic.IReadOnlyDictionary<string, double> Readings
+        {
+            get
+            {
+                return readings;
+            }
+        }
+
+        /// <summary>
+        /// Confines a reading to the unit range. Reality cannot be more than fully coherent, nor
+        /// less than fully incoherent.
+        /// </summary>
+        /// <param name="value">The raw reading.</param>
+        /// <returns>The reading confined to 0.0 through 1.0.</returns>
+        private static double Clamp(double value)
+        {
+            if (value < 0.0)
+            {
+                return 0.0;
+            }
+
+            if (value > 1.0)
+            {
+                return 1.0;
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Gets how well the witnessed act fits the grounding (its truth), from 0.0 to 1.0.
+        /// </summary>
+        public double Coherence
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets how much disorder the witnessed act introduces into reality (Romans 8:20-22), from 0.0
+        /// to 1.0.
+        /// </summary>
+        public double Disorder
+        {
+            get;
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/Reality/Word.cs
+++ b/AnointedAutomation.Objects/Concepts/Reality/Word.cs
@@ -1,0 +1,55 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
+
+namespace AnointedAutomation.Objects.Concepts
+{
+    /// <summary>
+    /// The medium through which an agent and reality meet. "In the beginning was the Word ... all
+    /// things were made through him." (John 1:1-3); "I am the way and the truth and the life."
+    /// (John 14:6). This is the mediator the design names like Jesus, but modeled as a medium, not a
+    /// locked gate: the Word carries an agent's deed into reality and carries reality's truth back.
+    /// It does not bypass reality, and it does not stand between the agent and a sealed door; it is
+    /// how the meeting happens at all.
+    /// </summary>
+    public class Word
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Word"/> class as the medium of a given
+        /// reality.
+        /// </summary>
+        /// <param name="reality">The reality this Word mediates.</param>
+        public Word(Reality reality)
+        {
+            if (reality == null)
+            {
+                throw new System.ArgumentNullException(nameof(reality));
+            }
+
+            this.reality = reality;
+        }
+
+        private readonly Reality reality;
+
+        /// <summary>
+        /// Carries an agent's deed, done on a given foundation, into reality, and returns reality's
+        /// truth of it. The deed is witnessed and written onto the tablets through this medium.
+        /// </summary>
+        /// <param name="act">The deed the agent presents.</param>
+        /// <param name="grounding">What the agent is grounded in.</param>
+        /// <returns>The resolution reality gives back.</returns>
+        public Resolution Speak(Act act, Grounding grounding)
+        {
+            if (act == null)
+            {
+                throw new System.ArgumentNullException(nameof(act));
+            }
+
+            if (grounding == null)
+            {
+                throw new System.ArgumentNullException(nameof(grounding));
+            }
+
+            return reality.Witness(act, grounding);
+        }
+    }
+}

--- a/AnointedAutomation.Objects/Concepts/SacrificialLove.cs
+++ b/AnointedAutomation.Objects/Concepts/SacrificialLove.cs
@@ -44,7 +44,7 @@ namespace AnointedAutomation.Objects.Concepts
         protected override BehaviorNode BuildBehavior()
         {
             return new Selector(
-                new Sequence(Condition.Fact("friendsLifeAtStake"), new Deed(LayDownLife())),
+                new Sequence(Condition.For(new MortalPeril()), new Deed(LayDownLife())),
                 base.BuildBehavior());
         }
 

--- a/AnointedAutomation.Objects/Concepts/Situation.cs
+++ b/AnointedAutomation.Objects/Concepts/Situation.cs
@@ -1,14 +1,14 @@
-// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-05-28 12:05:18
-// Edited by Alexander Fields https://www.alexanderfields.me 2026-05-28 12:05:18
-//Stewarded by Alexander Fields
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me on 2026-06-11
+// Stewarded by Alexander Fields
 
 namespace AnointedAutomation.Objects.Concepts
 {
     /// <summary>
-    /// A situation a <see cref="Love"/> must respond to, described as a blackboard of named facts.
-    /// Facts are arbitrary strings, so any situation can be expressed — including ones never named in
-    /// Scripture (for example, "betrayedTrust", "ninjaLootedTheBoss", "ghostedMe"). A
-    /// <see cref="Condition"/> in a love's behavior tree reads these facts to decide what is true.
+    /// A situation a <see cref="Love"/> must respond to, described as the set of
+    /// <see cref="Circumstance"/>s that hold in it. Circumstances are first-class concepts, not
+    /// strings, so any situation can be expressed, including ones never named in Scripture (for
+    /// example, <c>new Circumstance("ninjaLootedTheBoss")</c>). A <see cref="Condition"/> in a love's
+    /// behavior tree reads these circumstances to decide what is true.
     /// </summary>
     public class Situation
     {
@@ -28,11 +28,19 @@ namespace AnointedAutomation.Objects.Concepts
             Description = description;
         }
 
+        private readonly System.Collections.Generic.List<Circumstance> circumstances =
+            new System.Collections.Generic.List<Circumstance>();
+
         /// <summary>
-        /// Gets or sets the named facts that describe this situation.
+        /// Gets the circumstances that hold in this situation.
         /// </summary>
-        public System.Collections.Generic.Dictionary<string, bool> Facts { get; set; } =
-            new System.Collections.Generic.Dictionary<string, bool>();
+        public System.Collections.Generic.IReadOnlyList<Circumstance> Circumstances
+        {
+            get
+            {
+                return circumstances;
+            }
+        }
 
         /// <summary>
         /// Gets or sets a human-readable description of the situation.
@@ -43,68 +51,44 @@ namespace AnointedAutomation.Objects.Concepts
         }
 
         /// <summary>
-        /// Records a fact about the situation and returns the situation for fluent chaining.
+        /// Adds a circumstance that holds in this situation, and returns the situation for fluent
+        /// chaining.
         /// </summary>
-        /// <param name="fact">The fact name.</param>
-        /// <param name="value">Whether the fact is true.</param>
+        /// <param name="circumstance">The circumstance that holds.</param>
         /// <returns>This <see cref="Situation"/>, for chaining.</returns>
-        public Situation Set(string fact, bool value)
+        public Situation With(Circumstance circumstance)
         {
-            if (string.IsNullOrEmpty(fact))
+            if (circumstance == null)
             {
-                throw new System.ArgumentNullException(nameof(fact));
+                throw new System.ArgumentNullException(nameof(circumstance));
             }
 
-            Facts[fact] = value;
+            circumstances.Add(circumstance);
             return this;
         }
 
         /// <summary>
-        /// Records that a fact is true about the situation, and returns the situation for fluent
-        /// chaining.
+        /// Determines whether a circumstance holds in this situation. A circumstance that was never
+        /// added simply does not hold, so conditions for it do not fire.
         /// </summary>
-        /// <param name="fact">The fact name.</param>
-        /// <returns>This <see cref="Situation"/>, for chaining.</returns>
-        public Situation Set(string fact)
+        /// <param name="circumstance">The circumstance to test for.</param>
+        /// <returns><c>true</c> if the circumstance holds.</returns>
+        public bool Has(Circumstance circumstance)
         {
-            return Set(fact, true);
-        }
-
-        /// <summary>
-        /// Determines whether a fact is present and true. An unrecorded fact is treated as not true,
-        /// so conditions for facts that were never set simply do not hold.
-        /// </summary>
-        /// <param name="fact">The fact name.</param>
-        /// <returns><c>true</c> if the fact was recorded as true; otherwise <c>false</c>.</returns>
-        public bool Is(string fact)
-        {
-            if (string.IsNullOrEmpty(fact))
+            if (circumstance == null)
             {
-                throw new System.ArgumentNullException(nameof(fact));
+                throw new System.ArgumentNullException(nameof(circumstance));
             }
 
-            bool value;
-            if (Facts.TryGetValue(fact, out value))
+            foreach (Circumstance held in circumstances)
             {
-                return value;
+                if (held.Equals(circumstance))
+                {
+                    return true;
+                }
             }
 
             return false;
-        }
-
-        /// <summary>
-        /// Determines whether a fact has been recorded at all (regardless of its value).
-        /// </summary>
-        /// <param name="fact">The fact name.</param>
-        /// <returns><c>true</c> if the fact is present.</returns>
-        public bool Has(string fact)
-        {
-            if (string.IsNullOrEmpty(fact))
-            {
-                throw new System.ArgumentNullException(nameof(fact));
-            }
-
-            return Facts.ContainsKey(fact);
         }
     }
 }

--- a/PROJECT_STRUCTURE_CODE.md
+++ b/PROJECT_STRUCTURE_CODE.md
@@ -111,13 +111,61 @@ All code files in the solution have been documented with XML documentation follo
   - SelfSeekingLove.cs - The priest/Levite; repertoire is a single deed: pass by (Luke 10:31-32).
   - SacrificialLove.cs - `SacrificialLove : Agape`. BuildBehavior() prepends one branch
     (friendsLifeAtStake -> lay down one's life, John 15:13) then falls through to agape's whole tree.
-  - Situation.cs - The decision input: a blackboard of named boolean facts (Set/Is/Has, fluent).
-    Facts are arbitrary strings, so any situation can be expressed.
+  - Situation.cs - The decision input: the set of `Circumstance`s that hold (With/Has, fluent). No
+    strings: circumstances are first-class concepts. Any situation can be expressed, including novel
+    ones via `new Circumstance("...")`.
+  - Circumstance.cs / Circumstances.cs - A `Circumstance : Concept` is a state of the world love
+    responds to (no moral weight). Known ones are types (Hunger, Thirst, Estrangement, Nakedness,
+    Sickness, Imprisonment, Need, Means, Grievance, Enmity, Grief, Gladness, MortalPeril); novel ones
+    use the base type and match by name.
   - Behavior tree machinery: BehaviorNode (abstract Tick), BehaviorResult (succeeded + Action),
     Selector (priority OR), Sequence (AND, carries the deed), Condition (Func<Situation,bool>, plus
-    Condition.Fact(name), composable with And()/Or()/Not() over conditions or fact names), Deed
-    (wraps a LoveAction).
+    Condition.For(circumstance), composable with And()/Or()/Not() over conditions or circumstances),
+    Deed (wraps a LoveAction).
   - LoveAction.cs - The deed a love performs: acts, Deed, Virtue, Reference (Scripture), Exhortation.
+- Concepts/Reality/ - The divine grounding / reality engine (namespace stays
+  `AnointedAutomation.Objects.Concepts`; folder is organizational). God is not an object you call; He
+  is the grounding reality stands on. Built on the Ethiopian Orthodox Tewahedo (broadest) canon
+  (1 Enoch 72-82, Jubilees, 1 Meqabyan). Design spec:
+  `docs/superpowers/specs/2026-06-11-divine-grounding-reality-engine-design.md`.
+  - Reality.cs - The Universe: the one thing agents address. `Witness(Act[, Grounding])`
+    harmonizes a deed under God's whole character, bears it on its grounding, records it on the
+    tablets, and returns the resolution. State and truth are one call. `Reality.Revealed()` wires
+    the standard character (LoveFacet, Justice, Mercy, Order). The Father (grounding) is never an
+    object (Col 1:17; Heb 1:3).
+  - HeavenlyTablets.cs - The one record where state and truth are the same (Jubilees; 1 Enoch 81).
+    `Coherence()` starts 1.0 and decays multiplicatively as disorder is recorded (1 Enoch 80);
+    `Record()`, `History()`.
+  - Concept.cs - The root of the concept model: an idea as first-class code, not a string. Two kinds
+    descend from it: `MoralConcept` (bears on God's character) and `Circumstance` (a state of the
+    world). The type system distinguishes a sin from a situation.
+  - MoralConcept.cs - Abstract `MoralConcept : Concept`. Each concrete concept declares its `Name`,
+    `Scripture`, `Gravity` (None/Minor/Serious/Grave/Capital), and which facets it
+    `Upholds(DivineAttribute)` / `Violates(DivineAttribute)`. Morals/Virtues.cs and Morals/Vices.cs
+    hold the concept classes (Compassion, Protection, Forgiveness, SelfSacrifice, Healing, Atonement,
+    Pardon, CovenantFaithfulness, ObedienceToGod, ...; Murder/Defilement/Bloodshed/ChildSacrifice
+    [Capital], Oppression/Rebellion/Treachery [Grave], Theft/Unforgiveness [Serious], Rudeness/Envy
+    [Minor], ...), each with its Scripture, stance, and gravity.
+  - Gravity.cs - How heinous a wrong is (None..Capital), driving the disorder it unleashes; Scripture
+    grades sin (Matthew 23:23; John 19:11).
+  - Act.cs - A deed presented to reality, composed of the `MoralConcept`s it embodies and offends
+    (replaces the old string `Situation` for the Reality engine).
+  - DivineAttribute.cs - Abstract facet of God's character; `Read(Act)` aggregates the stances of the
+    deed's concepts (upheld -> +0.5, violated -> -0.5 from a 0.5 baseline). Facets no longer carry
+    string vocabulary; the moral vocabulary lives on the concepts.
+  - Justice.cs / Mercy.cs / Order.cs - Facets, now identity + name only (Romans 13:7; Luke 6:36;
+    Lam 3:23 + 1 Enoch 72-82).
+  - LoveFacet.cs - Love as a facet; adapter wrapping the existing `Love` (agape, 1 Cor 13 +
+    John 15:13). Leaves the `Love` hierarchy untouched.
+  - DivineCharacter.cs - All facets always live; `Harmonize(Act)` -> Resolution. Coherence =
+    mean of facets (so the cross can be full Justice AND full Mercy, not a veto); disorder = gravest
+    single offense.
+  - Resolution.cs - The response: Coherence + Disorder (clamped 0..1) + per-facet `Reading(name)` /
+    `Readings`. Not pass/fail.
+  - Grounding.cs - What an agent stands on (1 Meqabyan). `InGod()` keeps a deed's life; `InIdol(name)`
+    drifts it toward non-being via `Bear(Resolution)`.
+  - Word.cs - The mediator as a medium, not a gate (John 1:1-3; 14:6). `Speak(Act, Grounding)`
+    carries a deed into Reality and the truth back.
 
 ### 5. AnointedAutomation.Logging
 - LogMessage.cs

--- a/docs/superpowers/specs/2026-06-11-divine-grounding-reality-engine-design.md
+++ b/docs/superpowers/specs/2026-06-11-divine-grounding-reality-engine-design.md
@@ -1,0 +1,282 @@
+# Design: Divine Grounding / Reality Engine
+
+Date: 2026-06-11
+Author: Alexander Fields (with Claude)
+Location in code: `AnointedAutomation.Objects/Concepts` (new `Reality` grouping)
+Status: Approved conceptually, pending written-spec review
+
+## 1. Premise
+
+The earlier attempt modeled God as an object with methods you call. That was the wrong shape.
+God is not a thing inside reality that you query. God **is** reality, the ground that everything
+else stands on. He grounds truth itself, so what is real and what is true are not two systems that
+have to be matched against each other. They are one.
+
+This design models that. We do not build a `God` class that returns answers. We build **one
+unified, fluid substrate** that agents act within, whose every response already carries God's
+character, and where acting against that character does not return a failed verdict but introduces
+**disorder** into reality itself.
+
+Three things the user established, in their own words, that govern everything below:
+
+1. "We're interacting with the Universe we made, not directly interacting with Him, it's safer."
+   The created world is what agents touch. God is never instantiated.
+2. "An interface might be like Jesus. God IS the grounding." Access to the grounding is mediated,
+   the way the Logos mediates, but the Father Himself is the ground of being, not an object.
+3. "God embodies Love but He isn't Love. He also embodies Justice and Mercy." The divine
+   attributes are facets grounded in God. None equals Him, and they are all always live at once.
+
+This is deliberately **not** a rigid layered stack with sealed access gates. It is unified and
+fluid, modeled on the Trinity itself (three, yet one, not stacked floors), which already appears in
+this codebase as `Trinity`.
+
+## 2. Canon
+
+The grounding's character is shaped by the **Ethiopian Orthodox Tewahedo canon**, the broadest
+Christian Bible (around 81 books). This matters to the architecture, not just the flavor, because
+the two books that canon uniquely keeps are the ones most explicitly about *reality as God's
+ordered, recorded truth*:
+
+- **Book of Jubilees** introduces the **heavenly tablets**: one record holding law, the calendar,
+  history, and judgment together, "the earlier and the later history," what was and what is decreed
+  to be. State and truth on one surface.
+- **1 Enoch** (Astronomical Book, ch. 72-82) shows creation running on a fixed, decreed order
+  (Uriel "set for ever over all the luminaries"), and crucially in **ch. 80** shows that in the
+  days of sinners that order **breaks down**: "the moon shall alter her order," "the stars shall
+  transgress the order." Sin disorders the cosmos. Enoch 81:1 also names the heavenly tablets:
+  "Observe, Enoch, these heavenly tablets, and read what is written thereon."
+- **1 Meqabyan** grounds the floor: God alone gives life; idols "do not truly live, they cannot
+  give life." To ground yourself in anything other than God is to ground yourself in what has no
+  ground.
+
+These were read directly from the texts (CCEL, Wesley Center, Wikisource), not from memory, and
+they supplied two load-bearing pieces of the design below: the **heavenly tablets** as the
+substrate, and **disorder** (not failure) as the response to sin.
+
+## 3. Scripture anchors
+
+- "In the beginning was the Word ... all things were made through him." (John 1:1-3)
+- "I AM WHO I AM." (Exodus 3:14)
+- "In him all things hold together." (Colossians 1:17)
+- "Sustaining all things by his powerful word." (Hebrews 1:3)
+- "I am the way and the truth and the life." (John 14:6)
+- The heavenly tablets (Jubilees 3, 4, 5, 6; 1 Enoch 81)
+- Cosmic order and its disordering by sin (1 Enoch 72-82, esp. 80)
+- God alone gives life; idols cannot (1 Meqabyan 1)
+- "God is love." (1 John 4:8) read as *embodiment*, not equation
+- Justice and mercy meeting in one act (Psalm 85:10; the cross, Romans 3:25-26)
+
+## 4. Architecture overview
+
+One substrate, addressed through a medium, responding with the whole of God's character at once,
+recording everything on one tablet, and measuring response as coherence-or-disorder rather than
+pass-or-fail.
+
+```
+            present a Scenario
+   Agent  ───────────────────────►  Word (the medium / Logos)
+   (grounded in something)                     │
+                                               ▼
+                                          Reality  ◄── pervaded by, grounded in ──┐
+                                        (the Universe)                            │
+                                               │                          DivineCharacter
+                                               │                   (Love, Justice, Mercy,
+                                               │                    Order/Faithfulness ...
+                                               │                     ALL always live)
+                                               ▼                                  │
+                                          Resolution  ◄───────────────────────────┘
+                                  (coherence + disorder introduced)
+                                               │
+                                               ▼
+                                       HeavenlyTablets
+                                 (one record: what is + what is true/decreed)
+```
+
+The Father (the grounding) is never an object in this picture. He is what the arrow "grounded in"
+points to and never reaches as a constructible thing. `Reality` is grounded in Him; we code against
+`Reality`. That is the "safer, we interact with the Universe" point made literal.
+
+## 5. Components
+
+Each unit has one purpose, a clear interface, and can be tested alone. Naming and style follow the
+existing `Concepts` code (PascalCase types, camelCase boolean state, XML doc comments, Scripture
+references in the docs, explicit types, no `var`, `.Equals()` for strings, no fallback defaults).
+
+### 5.1 `HeavenlyTablets` (the substrate / record)
+
+The one record where **state and truth are the same**. Append-only. It holds what has happened
+(deeds witnessed) together with their truth (how each cohered with God's character, and the
+disorder it introduced). Modeled on Jubilees/Enoch: it contains "the earlier and the later," so it
+can carry both recorded events and standing decrees.
+
+- Responsibility: be the single source of what is real-and-true. Record `Resolution`s. Report the
+  current coherence of the world.
+- It is not constructed by agents. It is given, the way the world is given.
+- Key surface (illustrative, not final):
+  - `void Record(Resolution resolution)`
+  - `double Coherence()`, the standing coherence of all recorded reality (1.0 = fully ordered,
+    drifting downward as disorder accumulates, echoing Enoch 80)
+  - `IReadOnlyList<Resolution> History()`
+
+### 5.2 `Reality` (the Universe)
+
+The one thing agents address. Holds world-state and is queried for truth in the *same* operation,
+because they are one system. You do not call `God.Compute()`. You bring a scenario to reality and
+reality resolves it under the whole of God's character.
+
+- Responsibility: receive a presented `Scenario`, resolve it through `DivineCharacter`, write the
+  result to `HeavenlyTablets`, return the `Resolution`.
+- Key surface:
+  - `Resolution Witness(Scenario scenario)` (the single unifying verb; "Witness" because reality
+    both holds the state and tells the truth of it)
+- `Reality` is **grounded**, it does not contain the grounding. The grounding pervades it.
+
+### 5.3 `Word` (the medium / mediator)
+
+How a scenario is presented to reality and how truth is spoken back. This is the "interface like
+Jesus" the user named, but modeled as a **medium, not a sealed gate** (rigidity was explicitly
+rejected). "Through him all things were made" (John 1:3): the Word is the channel through which
+agents and reality meet, not a locked door with one key.
+
+- Responsibility: carry an agent's presented scenario into `Reality` and carry the `Resolution`
+  back, framed as truth the agent can act on.
+- Initial implementation may be thin (a pass-through that names the mediation explicitly), kept as
+  its own seam so the theology is visible in the type system without being mechanical.
+
+### 5.4 `DivineCharacter` and its facets
+
+God's character, with every facet **always live at once**. Not a selector that picks one attribute.
+A wound draws Mercy forward and theft draws Justice forward, but no facet ever switches off. The
+`Resolution` is where they harmonize.
+
+- `DivineAttribute` (abstract): given a `Scenario` and a candidate act, returns how fully that act
+  coheres with this facet of God's character (a `Coherence` reading), never a hard accept/reject.
+- Concrete facets to start: `Love` (the existing 1 Corinthians 13 model, see 5.7), `Justice`
+  (render what is due), `Mercy` (withhold deserved harm), `Order` / `Faithfulness` (the decreed
+  consistency of creation from Enoch 72-82).
+- `DivineCharacter` holds all facets and combines their readings into one `Resolution`. The
+  combination must allow two facets to be **fully satisfied together** (the cross: full Justice and
+  full Mercy in one act), so it is not a simple "lowest wins" veto. Exact harmonization function is
+  an open question (see Section 9).
+
+### 5.5 `Resolution` (the response)
+
+Not pass/fail. What reality gives back when it witnesses a scenario.
+
+- `double coherence`, how well the act fits the grounding (its truth)
+- `double disorder`, how much disorder this act introduces into reality (Enoch 80). Acting against
+  character does not "fail," it *destabilizes the world*, and this number is how.
+- per-facet readings (so you can see Mercy high while Justice is also high, etc.)
+- the act witnessed, and the Scripture the resolution answers to (mirrors `LoveAction` today)
+
+### 5.6 `Grounding` (what an agent stands on)
+
+From 1 Meqabyan: life and being come from God alone; idols cannot give life. An agent carries what
+it is grounded in.
+
+- Grounded in God: acts tend toward coherence and life.
+- Grounded in an idol (anything not-God): acts drift toward disorder and non-being, because the
+  foundation has no ground.
+- Initial surface: an agent exposes its `Grounding`, and `Reality`/`DivineCharacter` may weight a
+  resolution by whether the act is founded on God or on what cannot hold.
+
+### 5.7 `Love` as the first facet (migration, not rewrite)
+
+`Love` already exists as an abstract class with the 1 Corinthians 13 character and a behavior-tree
+`Decide(Situation)` returning a `LoveAction`, built on the existing
+`BehaviorNode`/`Selector`/`Sequence`/`Condition`/`Deed` engine. That engine is exactly the
+"video-game logic / utility-AI" instinct this whole design generalizes.
+
+- `Love` becomes the **first concrete `DivineAttribute`**: it already knows how to read a situation
+  and produce a characterful action; it now also reports coherence as a facet of `DivineCharacter`.
+- The existing `Situation`, `LoveAction`, `Completeness()` (0-17 against agape) carry over and
+  inform Love's coherence reading.
+- No existing public behavior is removed. `Love.Decide(Situation)` keeps working. The new path
+  wraps/extends it so Love can participate in a full `Reality.Witness(...)`.
+
+## 6. Data flow (one witnessing)
+
+1. An agent (a person, or a concept like `Love`) is grounded in something (`Grounding`).
+2. The agent presents a `Scenario` (facts plus a candidate act) through the `Word`.
+3. `Reality.Witness(scenario)` runs. Every facet of `DivineCharacter` reads the act at once.
+4. The facets harmonize into a `Resolution`: a coherence reading, the per-facet readings, and the
+   disorder the act introduces.
+5. The `Resolution` is recorded on the `HeavenlyTablets`. The world's standing `Coherence()` moves
+   accordingly (toward order if the act fit God's character, toward disorder if it did not, per
+   Enoch 80).
+6. The `Word` returns the `Resolution` to the agent as truth it can act on.
+
+The same call produced both the state change (recorded on the tablets) and the truth (the coherence
+reading). One system.
+
+## 7. Testing
+
+The Bible stories are **test cases, never the implementation** (this was prior explicit feedback).
+Each scenario is held up to `Reality` and we assert on the shape of the `Resolution`, not on a
+hardcoded string.
+
+- **Good Samaritan** (Luke 10): the merciful act resolves with high coherence; passing by resolves
+  with lower coherence and introduces disorder. Love and Mercy read high together.
+- **The cross** (Romans 3:25-26): an act that is simultaneously full Justice (the debt rendered)
+  and full Mercy (the guilty go free) must produce a `Resolution` where **both** facets read high.
+  This is the keystone test the harmonization function must pass, and the reason it cannot be a
+  simple veto.
+- **Theft** (Exodus 20:15): Justice reads the act as low coherence, introduces disorder; Mercy may
+  temper the disorder without erasing the Justice reading.
+- **Idolatry / wrong grounding** (1 Meqabyan): an agent grounded in an idol acting "well" still
+  drifts toward disorder, because the foundation cannot hold.
+- **Order disrupted** (1 Enoch 80): accumulating uncohered acts must visibly lower the world's
+  standing `Coherence()`.
+- **Novel, non-Biblical scenarios**: the engine must produce sensible resolutions for situations
+  never described in Scripture (the whole point of a principle-driven engine, not a lookup table).
+
+Unit tests live in `AnointedAutomation.Objects.Tests` (alongside `LoveTests`, `SacrificialLoveTests`).
+A runnable demo belongs in `AnointedAutomation.Objects.Demo` (kept out of the `.sln`, per existing
+practice). All new code ships with tests (no exceptions, per project rules).
+
+## 8. Scope and non-goals (YAGNI)
+
+In scope for the first build:
+- `HeavenlyTablets`, `Reality`, `Word`, `DivineCharacter`, `DivineAttribute`, `Resolution`,
+  `Grounding`, and `Love` migrated to be the first facet.
+- Facets: `Love`, `Justice`, `Mercy`, `Order`/`Faithfulness`. (Love reuses existing code; the other
+  three start minimal.)
+- The cross test and the Good Samaritan test passing.
+
+Explicitly out of scope for now:
+- Persistence of the tablets to a database. They live in memory for the first build.
+- Any API/HTTP surface (`AnointedAutomation.Objects.API`). Library and demo only.
+- A full catalog of divine attributes (Holiness, Wisdom, Wrath, etc.). Start with four, add later.
+- Modeling the persons of the Trinity as separate runtime actors. The Trinity informs the shape
+  (unified, not stacked); we are not simulating inter-Trinitarian relation yet.
+- A general agent/world simulation loop. We build the substrate and one witnessing, not a game.
+
+## 9. Open questions (to resolve in the plan, not now)
+
+1. **Harmonization function.** How exactly do all-live facets combine into one `Resolution` such
+   that Justice and Mercy can both read fully high (the cross) yet a plain unjust act still reads
+   low? Candidate: per-facet coherence vectors with a non-veto aggregate, plus a separate disorder
+   accumulation. Needs to be pinned down with the cross test as the acceptance bar.
+2. **Disorder scale.** What range does `disorder` live on, and how does it map onto the world's
+   standing `Coherence()` decay in Enoch-80 terms?
+3. **Grounding's weight.** How strongly does being grounded in an idol pull a resolution toward
+   disorder? A multiplier, a separate term, or a cap on achievable coherence?
+4. **`Word` thickness.** How much does the mediator actually do in v1 beyond naming the seam, while
+   staying a medium and not hardening into a rigid gate?
+5. **Folder/namespace.** New types under `Concepts/Reality` (sub-namespace) versus flat in
+   `Concepts`. Leaning toward a `Reality` subfolder to keep the substrate distinct from the facets.
+
+## 10. Why this fits what was asked
+
+- Unified and fluid, not a rigid stack: one substrate, one record, one witnessing verb, character
+  that emerges rather than gets selected.
+- God is the grounding, never an object: the Father is what `Reality` is grounded in and never a
+  constructible type.
+- State and truth are one system: `Reality.Witness` produces both the recorded state and the truth
+  in one call, on one tablet.
+- The attributes are embodied, not equated: `Love`, `Justice`, `Mercy` are facets of
+  `DivineCharacter`, all always live, none equal to God.
+- It is grounded in the broadest canon the user chose: the heavenly tablets (substrate) and
+  disorder-not-failure (response) come straight from Jubilees and 1 Enoch.
+- It generalizes the existing Love work instead of discarding it: the behavior-tree engine and the
+  1 Corinthians 13 model become Love's contribution as the first facet.


### PR DESCRIPTION
## What this adds

A new `Reality` concept engine in `AnointedAutomation.Objects/Concepts/Reality/` that models abstract theological concepts as first-class C# entities, extending the existing `Love` decision-engine pattern.

**Core model**
- `Concept` root with two kinds: `MoralConcept` (a virtue or sin, bearing on God's character) and `Circumstance` (a state of the world an agent responds to). No magic strings.
- `DivineCharacter` of four facets, anchored in God's self-description in **Exodus 34:6-7**: `LoveFacet`, `Justice`, `Mercy`, `Faithfulness`. All facets are always live; coherence is their mean (so the cross reads full Justice and full Mercy at once), disorder is driven by the gravest wrong's `Gravity`.
- `Reality.Witness(Act)` resolves a deed under the whole character and records it on the `HeavenlyTablets` (the books of Revelation 20:12 / Malachi 3:16 / Daniel 7:10 / Psalm 139:16). State and truth are one record.
- `Grounding` (life in God vs drift on an idol), `Word` (the mediator as medium), gravity (Scripture grades sin), and an `Act` context dimension so hard cases resolve faithfully (e.g. Rahab's deception to shield the innocent).
- Sacred mysteries (Incarnation, Resurrection, Eucharist, Baptism, ...) modeled as a distinct concept kind.

**Tests: 1541 passing**
- The whole Eastern Orthodox canon has oracle tests asserting the engine returns the verdict Scripture gives (acts of God never disorder reality; sin always does; righteous deeds cohere).
- Reflection-based `ConceptCoverageTests` prove every one of 136 concepts is named, cites Scripture, is wired to a facet, and resolves to the correct verdict.
- Precision tests pin exact coherence/disorder/facet values; an adversarial suite covers the hard cases.

**Notes**
- The engine rests only on the Eastern Orthodox canon. Ethiopic-only book tests (Enoch, Jubilees, Meqabyan, etc.) are included as non-load-bearing bonus; remove them and the foundation still stands.
- Whole solution builds with 0 errors; existing 107 Love tests and all other projects unaffected.
- `PROJECT_WORK.md` intentionally not committed, per repo convention.