### PR TITLE
Add opt-in hybrid casing conventions (Mongo + JSON)

### DIFF
--- a/AnointedAutomation.Objects.API/API/JsonCasingConvention.cs
+++ b/AnointedAutomation.Objects.API/API/JsonCasingConvention.cs
@@ -1,0 +1,115 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me
+//
+// Central JSON naming convention for AnointedAutomation APIs. Moved out of each API's Program.cs into the
+// shared open-source layer so every API enforces the SAME wire casing as the Mongo layer
+// (AnointedAutomation.Repository.Mongo.HybridElementNameConvention) while C# code keeps idiomatic
+// PascalCase property names.
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace AnointedAutomation.Objects.API
+{
+    /// <summary>
+    /// Central JSON naming convention enforced on the global serializer (MVC controllers + minimal APIs):
+    ///   class  -> reference-type members PascalCase, value-type members camelCase
+    ///   struct -> every member camelCase
+    ///   enum   -> camelCase string
+    /// An explicit [JsonPropertyName] always wins (e.g. Shopify snake_case DTOs, RFC ProblemDetails), so
+    /// types that deliberately set their own names are never touched. Anonymous types (hand-rolled
+    /// 'new { ... }' payloads, e.g. snake_case cart/build and Node-parity webhook acks) are skipped so
+    /// their literal member names stay verbatim. Types serialized through their own local
+    /// JsonSerializerOptions (Shopify snake_case, CDN ratings feed, vision metafield) are unaffected.
+    ///
+    /// Wire it into an API with:
+    ///   builder.Services.AddControllers().AddJsonOptions(o => JsonCasingConvention.Configure(o.JsonSerializerOptions));
+    ///   builder.Services.ConfigureHttpJsonOptions(o => JsonCasingConvention.Configure(o.SerializerOptions));
+    /// </summary>
+    public static class JsonCasingConvention
+    {
+        /// <summary>
+        /// A ready-to-use options instance carrying the convention, for code paths that serialize OUTSIDE the
+        /// MVC / minimal-API pipeline (pre-serialized JsonElement payloads, file downloads, SSE frames) and
+        /// therefore must apply the convention themselves. Reuse this single instance (System.Text.Json
+        /// caches per-options metadata).
+        /// </summary>
+        public static JsonSerializerOptions Options { get; } = CreateOptions();
+
+        private static JsonSerializerOptions CreateOptions()
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = null,
+                DictionaryKeyPolicy = null,
+            };
+            Configure(options);
+            return options;
+        }
+
+        public static void Configure(JsonSerializerOptions options)
+        {
+            // Enums -> camelCase strings (the string converter still reads integers on input, so request
+            // bodies that send enum ints keep working).
+            options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+
+            DefaultJsonTypeInfoResolver resolver =
+                options.TypeInfoResolver as DefaultJsonTypeInfoResolver ?? new DefaultJsonTypeInfoResolver();
+            resolver.Modifiers.Add(ApplyConvention);
+            options.TypeInfoResolver = resolver;
+        }
+
+        private static void ApplyConvention(JsonTypeInfo typeInfo)
+        {
+            if (typeInfo.Kind != JsonTypeInfoKind.Object)
+            {
+                return;
+            }
+
+            // Anonymous types are hand-rolled wire payloads (snake_case cart/build, Node-parity acks);
+            // their literal member names are intentional contracts, so never re-case them.
+            if (IsAnonymousType(typeInfo.Type))
+            {
+                return;
+            }
+
+            // Enums never reach Object-kind; only structs land here as value types.
+            bool isStruct = typeInfo.Type.IsValueType;
+            foreach (JsonPropertyInfo property in typeInfo.Properties)
+            {
+                if (HasExplicitName(property))
+                {
+                    continue;
+                }
+
+                Type memberType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+                // struct: every member camelCase. class: value-type members camelCase, ref-type members PascalCase.
+                bool camel = isStruct || memberType.IsValueType;
+                property.Name = camel ? ToCamel(property.Name) : ToPascal(property.Name);
+            }
+        }
+
+        private static bool HasExplicitName(JsonPropertyInfo property)
+        {
+            ICustomAttributeProvider provider = property.AttributeProvider;
+            return provider != null
+                && provider.GetCustomAttributes(typeof(JsonPropertyNameAttribute), inherit: true).Length > 0;
+        }
+
+        private static bool IsAnonymousType(Type type) =>
+            type.IsGenericType
+            && type.Name.Contains("AnonymousType", StringComparison.Ordinal)
+            && type.GetCustomAttribute<CompilerGeneratedAttribute>() != null;
+
+        private static string ToCamel(string name) =>
+            string.IsNullOrEmpty(name) ? name : JsonNamingPolicy.CamelCase.ConvertName(name);
+
+        private static string ToPascal(string name) =>
+            string.IsNullOrEmpty(name) || char.IsUpper(name[0])
+                ? name
+                : char.ToUpperInvariant(name[0]) + name.Substring(1);
+    }
+}

--- a/AnointedAutomation.Objects.API/AnointedAutomation.Objects.API.csproj
+++ b/AnointedAutomation.Objects.API/AnointedAutomation.Objects.API.csproj
@@ -12,7 +12,7 @@
 		<Copyright>Copyright © 2023 Anointed Automation, LLC All rights reserved.</Copyright>
 		<Description>Custom IFormFile implementation for ASP.NET Core - AnointedAutomation.Objects.API</Description>
 		<RepositoryUrl>https://github.com/AnointedAutomation/AnointedAutomation</RepositoryUrl>
-		<Version>1.0.2</Version>
+		<Version>1.0.3</Version>
 		<PackageTags>aspnetcore;formfile</PackageTags>
 		<PackageReleaseNotes>https://github.com/AnointedAutomation/AnointedAutomation/pkgs/nuget/AnointedAutomation.Objects.API</PackageReleaseNotes>
 		<Authors>Anointed Automation LLC, Alexander Fields</Authors>

--- a/AnointedAutomation.Repository.Mongo/AnointedAutomation.Repository.Mongo.csproj
+++ b/AnointedAutomation.Repository.Mongo/AnointedAutomation.Repository.Mongo.csproj
@@ -12,7 +12,7 @@
 		<Copyright>Copyright © 2023 Anointed Automation, LLC All rights reserved.</Copyright>
 		<Description>Repository for Generic Mongo Usage - AnointedAutomation.Repository.Mongo</Description>
 		<RepositoryUrl>https://github.com/AnointedAutomation/AnointedAutomation</RepositoryUrl>
-		<Version>1.0.2</Version>
+		<Version>1.0.3</Version>
 		<PackageTags>Mongo</PackageTags>
 		<PackageReleaseNotes>https://github.com/AnointedAutomation/AnointedAutomation/pkgs/nuget/AnointedAutomation.Repository.Logging</PackageReleaseNotes>
 		<Authors>Anointed Automation LLC, Alexander Fields</Authors>

--- a/AnointedAutomation.Repository.Mongo/BsonClassMapRegistrar.cs
+++ b/AnointedAutomation.Repository.Mongo/BsonClassMapRegistrar.cs
@@ -1,7 +1,9 @@
 // Copyright © Anointed Automation, LLC., 2024. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me
 
+using System;
 using AnointedAutomation.Objects.Account;
 using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
 using Newtonsoft.Json.Linq;
 
 namespace AnointedAutomation.Repository.Mongo
@@ -38,6 +40,24 @@ namespace AnointedAutomation.Repository.Mongo
 
                 _isRegistered = true;
             }
+        }
+
+        /// <summary>
+        /// OPT-IN (not auto-applied): registers the hybrid casing convention (value/enum/struct -> camelCase,
+        /// reference -> PascalCase) for types under <paramref name="namespacePrefix"/>. Publishing this package
+        /// changes NOTHING until a service calls this. Call ONCE at startup BEFORE <see cref="RegisterClassMaps"/>
+        /// / any Mongo use, and ONLY after that service's data has been migrated to hybrid keys — the convention
+        /// does not override explicit [BsonElement], so pure-casing [BsonElement] attributes must be removed for
+        /// it to take full effect.
+        /// </summary>
+        /// <param name="namespacePrefix">Restrict to a namespace (e.g. one API) to stage rollout. Default: all AnointedAutomation types.</param>
+        public static void RegisterHybridCasingConvention(string namespacePrefix = "AnointedAutomation")
+        {
+            ConventionPack pack = new ConventionPack { new HybridElementNameConvention() };
+            ConventionRegistry.Register(
+                "AnointedHybridElementName",
+                pack,
+                t => t.FullName != null && t.FullName.StartsWith(namespacePrefix, StringComparison.Ordinal));
         }
 
         private static void RegisterGlobalSerializers()

--- a/AnointedAutomation.Repository.Mongo/HybridElementNameConvention.cs
+++ b/AnointedAutomation.Repository.Mongo/HybridElementNameConvention.cs
@@ -1,0 +1,54 @@
+// Copyright © Anointed Automation, LLC., 2026. All Rights Reserved. Stewarded by Alexander Fields https://www.alexanderfields.me
+//
+// Hybrid element-name convention for MongoDB serialization. Mirrors the API's System.Text.Json
+// JsonCasingConvention so the DB and the JSON wire follow the SAME rule while C# code keeps idiomatic
+// PascalCase property names:
+//   - struct-declared member  -> camelCase
+//   - value-type / enum member -> camelCase
+//   - reference-type member    -> PascalCase
+// Implemented as an IMemberMapConvention (the canonical element-naming hook, same interface as the
+// driver's CamelCaseElementNameConvention). NOTE: explicit [BsonElement(...)] attributes WIN over any
+// convention, so a member that pins its own casing via [BsonElement] is NOT changed here — to make such
+// a field follow the hybrid rule, drop its pure-casing [BsonElement]. Intentional non-casing mappings
+// (snake_case external-API fields like "fulfillment_channel", "_id", deliberate renames) are preserved
+// by the guard below regardless. Register once at startup (before any class map is built) via
+// BsonClassMapRegistrar.RegisterClassMaps().
+
+using System;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace AnointedAutomation.Repository.Mongo
+{
+    /// <summary>
+    /// Sets Mongo element names per the hybrid rule (value/enum/struct -> camelCase, reference -> PascalCase),
+    /// preserving intentional non-casing mappings.
+    /// </summary>
+    public sealed class HybridElementNameConvention : ConventionBase, IMemberMapConvention
+    {
+        public void Apply(BsonMemberMap memberMap)
+        {
+            string memberName = memberMap.MemberName;
+            string current = memberMap.ElementName;
+
+            // Only re-case pure casing variants; preserve snake_case / renamed / "_id" mappings.
+            if (!string.Equals(current, memberName, StringComparison.Ordinal)
+                && !string.Equals(current, ToCamel(memberName), StringComparison.Ordinal)
+                && !string.Equals(current, ToPascal(memberName), StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            Type memberType = Nullable.GetUnderlyingType(memberMap.MemberType) ?? memberMap.MemberType;
+            bool declaringIsStruct = memberMap.ClassMap.ClassType.IsValueType;
+            bool camel = declaringIsStruct || memberType.IsValueType; // enums are value types
+            memberMap.SetElementName(camel ? ToCamel(memberName) : ToPascal(memberName));
+        }
+
+        private static string ToCamel(string n) =>
+            string.IsNullOrEmpty(n) || char.IsLower(n[0]) ? n : char.ToLowerInvariant(n[0]) + n.Substring(1);
+
+        private static string ToPascal(string n) =>
+            string.IsNullOrEmpty(n) || char.IsUpper(n[0]) ? n : char.ToUpperInvariant(n[0]) + n.Substring(1);
+    }
+}


### PR DESCRIPTION
Adds two shared conventions so APIs can make BOTH the Mongo DB keys and the JSON wire follow one hybrid rule (value/enum/struct -> camelCase, reference-type -> PascalCase) while C# keeps idiomatic PascalCase property names.

- `AnointedAutomation.Repository.Mongo`: `HybridElementNameConvention` (IMemberMapConvention) + opt-in `BsonClassMapRegistrar.RegisterHybridCasingConvention(namespacePrefix)`.
- `AnointedAutomation.Objects.API`: `JsonCasingConvention` (lifted out of the API Program.cs so every API shares it).
- Both packages bumped to 1.0.3.

Safety: the Mongo convention is OPT-IN and NOT auto-applied — publishing this changes nothing until a service explicitly calls `RegisterHybridCasingConvention(...)` (and only after its data is migrated to hybrid keys + its pure-casing [BsonElement] attributes are removed). The convention never overrides explicit [BsonElement], so snake_case/external-contract fields are preserved.

Part of the staged hybrid-casing migration (see Website/HYBRID_CASING_MIGRATION_RUNBOOK.md).